### PR TITLE
Some changes in setpoint_attitude plugin

### DIFF
--- a/mavros/src/plugins/safety_area.cpp
+++ b/mavros/src/plugins/safety_area.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief SafetyArea plugin
  * @file safety_area.cpp
- * @author Nuno Marques
+ * @author Nuno Marques <n.marques21@hotmail.com>
  * @author Vladimir Ermakov <vooon341@gmail.com>
  *
  * @addtogroup plugin

--- a/mavros/src/plugins/setpoint_accel.cpp
+++ b/mavros/src/plugins/setpoint_accel.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief SetpointAcceleration plugin
  * @file setpoint_accel.cpp
- * @author Nuno Marques
+ * @author Nuno Marques <n.marques21@hotmail.com>
  * @author Vladimir Ermakov <vooon341@gmail.com>
  *
  * @addtogroup plugin
@@ -29,7 +29,7 @@
 #include <mavros/mavros_plugin.h>
 #include <pluginlib/class_list_macros.h>
 
-#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/Vector3Stamped.h>
 
 #include "setpoint_mixin.h"
 
@@ -84,7 +84,7 @@ private:
 	 *
 	 * Note: send only AFX AFY AFZ. ENU frame.
 	 */
-	void send_setpoint_acceleration(float afx, float afy, float afz) {
+    void send_setpoint_acceleration(const ros::Time &stamp, float afx, float afy, float afz) {
 
 		/* Documentation start from bit 1 instead 0,
 		 * but implementation PX4 Firmware #1151 starts from 0
@@ -95,7 +95,7 @@ private:
 			ignore_all_except_a_xyz |= (1<<9);
 
 		// ENU->NED. Issue #49.
-		set_position_target_local_ned(ros::Time::now().toNSec() / 1000000,
+        set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,
 				ignore_all_except_a_xyz,
 				0.0, 0.0, 0.0,
@@ -105,8 +105,11 @@ private:
 
 	/* -*- callbacks -*- */
 
-	void accel_cb(const geometry_msgs::Vector3::ConstPtr &req) {
-		send_setpoint_acceleration(req->x, req->y, req->z);
+    void accel_cb(const geometry_msgs::Vector3Stamped::ConstPtr &req) {
+        send_setpoint_acceleration(req->header.stamp,
+                                   req->vector.x,
+                                   req->vector.y,
+                                   req->vector.z);
 	}
 };
 

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -217,14 +217,14 @@ private:
 
 		if (reverse_throttle)
 			if ( throttle_normalized < -1.0 || throttle_normalized > 1.0 ) {
-				ROS_DEBUG_ONCE("Warning: Not normalized values of throttle! Values should be between -1.0 and 1.0");
+                ROS_ERROR_NAMED("attitude_throttle","Warning: Not normalized values of throttle! Values should be between -1.0 and 1.0");
 				return;
 			}
 			else
 				send_attitude_throttle(throttle_normalized);
 		else
 			if ( throttle_normalized < 0.0 || throttle_normalized > 1.0 ) {
-				ROS_DEBUG_ONCE("Warning: Not normalized values of throttle! Values should be between 0.0 and 1.0");
+                ROS_ERROR_NAMED("attitude_throttle","Warning: Not normalized values of throttle! Values should be between 0.0 and 1.0");
 				return;
 			}
 			else

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -96,10 +96,9 @@ private:
 
 	/**
 	 * Send transform to FCU position controller
-	 *
-	 * Note: send only XYZ,
-	 * velocity and af vector could be in Twist message
-	 * but it needs additional work.
+     *
+     * Note: send only XYZ
+     *
 	 */
 	void send_setpoint_transform(const tf::Transform &transform, const ros::Time &stamp) {
 		// ENU frame

--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief SetpointVelocity plugin
  * @file setpoint_velocity.cpp
- * @author Nuno Marques
+ * @author Nuno Marques <n.marques21@hotmail.com>
  * @author Vladimir Ermakov <vooon341@gmail.com>
  *
  * @addtogroup plugin
@@ -28,7 +28,7 @@
 #include <mavros/mavros_plugin.h>
 #include <pluginlib/class_list_macros.h>
 
-#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/TwistStamped.h>
 
 #include "setpoint_mixin.h"
 
@@ -79,7 +79,7 @@ private:
 	 *
 	 * Note: send only VX VY VZ. ENU frame.
 	 */
-	void send_setpoint_velocity(float vx, float vy, float vz) {
+    void send_setpoint_velocity(const ros::Time &stamp, float vx, float vy, float vz) {
 
 		/* Documentation start from bit 1 instead 0,
 		 * but implementation PX4 Firmware #1151 starts from 0
@@ -87,7 +87,7 @@ private:
 		uint16_t ignore_all_except_v_xyz = (7<<6)|(7<<0);
 
 		// ENU->NED. Issue #49.
-		set_position_target_local_ned(ros::Time::now().toNSec() / 1000000,
+        set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,
 				ignore_all_except_v_xyz,
 				0.0, 0.0, 0.0,
@@ -97,8 +97,11 @@ private:
 
 	/* -*- callbacks -*- */
 
-	void vel_cb(const geometry_msgs::Twist::ConstPtr &req) {
-		send_setpoint_velocity(req->linear.x, req->linear.y, req->linear.z);
+    void vel_cb(const geometry_msgs::TwistStamped::ConstPtr &req) {
+        send_setpoint_velocity(req->header.stamp,
+                               req->twist.linear.x,
+                               req->twist.linear.y,
+                               req->twist.linear.z);
 	}
 };
 


### PR DESCRIPTION
Namely:
- changed `Twist` to `TwistStamped`
- added `reverse_throttle` option for throttle control
- use `cmd_vel` as the same topic to control linear a angular velocities (it's commonly used by controllers)
- added normalization filter to thrust
