### PR TITLE
Corrects vim mode lines.

### DIFF
--- a/mavros/launch/apm2.launch
+++ b/mavros/launch/apm2.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- example launch script for ArduPilotMega based FCU's -->
 
 	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=0 sw=2 ts=2 : -->

--- a/mavros/launch/apm2_radio.launch
+++ b/mavros/launch/apm2_radio.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- This file almost same as apm2.launch but defaults set for connections via 3DR Radio modem -->
 
 	<arg name="fcu_url" default="/dev/ttyUSB0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=0 sw=2 ts=2 : -->

--- a/mavros/launch/node.launch
+++ b/mavros/launch/node.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- base node launch file-->
 
 	<arg name="fcu_url" />
@@ -20,3 +19,5 @@
 		<rosparam command="load" file="$(arg config_yaml)" />
 	</node>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=0 sw=2 ts=2 : -->

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- example launch script for PX4 based FCU's -->
 
 	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=0 sw=2 ts=2 : -->

--- a/mavros/launch/px4_radio.launch
+++ b/mavros/launch/px4_radio.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- This file almost same as px4.launch but defaults set for connections via 3DR Radio modem -->
 
 	<arg name="fcu_url" default="/dev/ttyUSB0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=0 sw=2 ts=2 : -->


### PR DESCRIPTION
Ubuntu 14.04 was giving me warnings when opening the launch scripts with vim. Mainly due to a missing : in the mode line. I used modeliner to generate a mode line that doesn't create any warnings when using vim.