### PR TITLE
Vim modeline fix

### DIFF
--- a/libmavconn/CMakeLists.txt
+++ b/libmavconn/CMakeLists.txt
@@ -85,4 +85,4 @@ target_link_libraries(mavconn-test mavconn)
 
 endif()
 
-# vim: ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ft=cmake ff=unix sts=2 sw=2 ts=2 :

--- a/libmavconn/CMakeLists.txt
+++ b/libmavconn/CMakeLists.txt
@@ -85,4 +85,4 @@ target_link_libraries(mavconn-test mavconn)
 
 endif()
 
-# vim: set et fenc=utf-8 ft=cmake ff=unix sts=2 sw=2 ts=2 :
+# vim: set et fenc=utf-8 ft=cmake ff=unix:

--- a/libmavconn/cmake/Modules/EnableCXX11.cmake
+++ b/libmavconn/cmake/Modules/EnableCXX11.cmake
@@ -18,4 +18,4 @@ else ()
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif ()
 
-# vim: set ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ft=cmake ff=unix sts=2 sw=2 ts=2 :

--- a/libmavconn/cmake/Modules/MavrosMavlink.cmake
+++ b/libmavconn/cmake/Modules/MavrosMavlink.cmake
@@ -33,4 +33,4 @@ add_definitions(
   -DMAVLINK_DIALECT=${MAVLINK_DIALECT}
 )
 
-# vim: set ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ft=cmake ff=unix sts=2 sw=2 ts=2 :

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -271,4 +271,4 @@ install(DIRECTORY launch/
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
 
-# vim: ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ft=cmake ff=unix sts=2 sw=2 ts=2 :

--- a/mavros/launch/apm2.launch
+++ b/mavros/launch/apm2.launch
@@ -17,4 +17,4 @@
 	</include>
 </launch>
 
-<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 : -->
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml : -->

--- a/mavros/launch/apm2.launch
+++ b/mavros/launch/apm2.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- example launch script for ArduPilotMega based FCU's -->
 
 	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 : -->

--- a/mavros/launch/apm2_blacklist.yaml
+++ b/mavros/launch/apm2_blacklist.yaml
@@ -10,3 +10,5 @@ plugin_blacklist:
 - 'mocap_*'
 - 'global_*'
 - 'ftp'
+
+# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :

--- a/mavros/launch/apm2_config.yaml
+++ b/mavros/launch/apm2_config.yaml
@@ -120,4 +120,4 @@ mission:
 #  use_tf: false   # ~mocap/tf
 #  use_pose: true  # ~mocap/pose
 
-# vim:ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :

--- a/mavros/launch/apm2_radio.launch
+++ b/mavros/launch/apm2_radio.launch
@@ -17,4 +17,4 @@
 	</include>
 </launch>
 
-<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 : -->
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml : -->

--- a/mavros/launch/apm2_radio.launch
+++ b/mavros/launch/apm2_radio.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- This file almost same as apm2.launch but defaults set for connections via 3DR Radio modem -->
 
 	<arg name="fcu_url" default="/dev/ttyUSB0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 : -->

--- a/mavros/launch/apm2_radio_blacklist.yaml
+++ b/mavros/launch/apm2_radio_blacklist.yaml
@@ -9,4 +9,4 @@ plugin_blacklist:
 - 'global_*'
 - 'ftp'
 
-# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :
+# vim: set noet fenc=utf-8 ff=unix ft=yaml :

--- a/mavros/launch/apm2_radio_blacklist.yaml
+++ b/mavros/launch/apm2_radio_blacklist.yaml
@@ -8,3 +8,5 @@ plugin_blacklist:
 - 'mocap_*'
 - 'global_*'
 - 'ftp'
+
+# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :

--- a/mavros/launch/node.launch
+++ b/mavros/launch/node.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- base node launch file-->
 
 	<arg name="fcu_url" />
@@ -20,3 +19,5 @@
 		<rosparam command="load" file="$(arg config_yaml)" />
 	</node>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=2 sw=2 ts=2 : -->

--- a/mavros/launch/node.launch
+++ b/mavros/launch/node.launch
@@ -20,4 +20,4 @@
 	</node>
 </launch>
 
-<!-- vim: set noet fenc= ff=unix ft=xml sts=2 sw=2 ts=2 : -->
+<!-- vim: set noet fenc= ff=unix ft=xml : -->

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -17,4 +17,4 @@
 	</include>
 </launch>
 
-<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 : -->
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml : -->

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- example launch script for PX4 based FCU's -->
 
 	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 : -->

--- a/mavros/launch/px4_blacklist.yaml
+++ b/mavros/launch/px4_blacklist.yaml
@@ -2,4 +2,4 @@ plugin_blacklist:
 - '3dr_radio'
 - 'image_pub'
 
-# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :
+# vim: set noet fenc=utf-8 ff=unix ft=yaml :

--- a/mavros/launch/px4_blacklist.yaml
+++ b/mavros/launch/px4_blacklist.yaml
@@ -1,3 +1,5 @@
 plugin_blacklist:
 - '3dr_radio'
 - 'image_pub'
+
+# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -124,4 +124,5 @@ mission:
 #  use_tf: false   # ~mocap/tf
 #  use_pose: true  # ~mocap/pose
 
-# vim:ts=2 sw=2 et:
+
+# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -125,4 +125,4 @@ mission:
 #  use_pose: true  # ~mocap/pose
 
 
-# vim: set et fenc=utf-8 ff=unix ft=yaml sts=2 sw=2 ts=2 :
+# vim: set noet fenc=utf-8 ff=unix ft=yaml :

--- a/mavros/launch/px4_radio.launch
+++ b/mavros/launch/px4_radio.launch
@@ -17,4 +17,4 @@
 	</include>
 </launch>
 
-<!-- vim: set noet fenc= ff=unix ft=xml sts=2 sw=2 ts=2 : -->
+<!-- vim: set noet fenc= ff=unix ft=xml : -->

--- a/mavros/launch/px4_radio.launch
+++ b/mavros/launch/px4_radio.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- This file almost same as px4.launch but defaults set for connections via 3DR Radio modem -->
 
 	<arg name="fcu_url" default="/dev/ttyUSB0:57600" />
@@ -17,3 +16,5 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 	</include>
 </launch>
+
+<!-- vim: set noet fenc= ff=unix ft=xml sts=2 sw=2 ts=2 : -->

--- a/mavros/scripts/mavcmd
+++ b/mavros/scripts/mavcmd
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/scripts/mavftp
+++ b/mavros/scripts/mavftp
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/scripts/mavparam
+++ b/mavros/scripts/mavparam
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/scripts/mavsafety
+++ b/mavros/scripts/mavsafety
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/scripts/mavsetp
+++ b/mavros/scripts/mavsetp
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Nuno Marques, Vladimir Ermakov.
 #

--- a/mavros/scripts/mavsys
+++ b/mavros/scripts/mavsys
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/scripts/mavwp
+++ b/mavros/scripts/mavwp
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/src/mavros/__init__.py
+++ b/mavros/src/mavros/__init__.py
@@ -1,2 +1,2 @@
 # -*- python -*-
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :

--- a/mavros/src/mavros/ftp.py
+++ b/mavros/src/mavros/ftp.py
@@ -1,5 +1,5 @@
 # -*- python -*-
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/src/mavros/mission.py
+++ b/mavros/src/mavros/mission.py
@@ -1,5 +1,5 @@
 # -*- python -*-
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/src/mavros/param.py
+++ b/mavros/src/mavros/param.py
@@ -1,5 +1,5 @@
 # -*- python -*-
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros/src/mavros/utils.py
+++ b/mavros/src/mavros/utils.py
@@ -1,5 +1,5 @@
 # -*- python -*-
-# vim:set ts=4 sw=4 et:
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4 :
 #
 # Copyright 2014 Vladimir Ermakov.
 #

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -181,4 +181,4 @@ install(DIRECTORY launch/
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
 
-# vim: ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ft=cmake ff=unix sts=0 sw=2 ts=2 :

--- a/mavros_extras/launch/px4_image.launch
+++ b/mavros_extras/launch/px4_image.launch
@@ -19,4 +19,4 @@
 	</node>
 </launch>
 
-<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 :
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml :

--- a/mavros_extras/launch/px4_image.launch
+++ b/mavros_extras/launch/px4_image.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- example launch script for PX4 based FCU's with gcs_image_bridge -->
 
 	<arg name="fcu_url" default="serial:///dev/ttyACM0:57600" />
@@ -19,3 +18,5 @@
 		<param name="gcs_url" value="$(arg gcs_url)" />
 	</node>
 </launch>
+
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 :

--- a/mavros_extras/launch/px4flow.launch
+++ b/mavros_extras/launch/px4flow.launch
@@ -23,4 +23,4 @@
 	</node>
 </launch>
 
-<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 :
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml :

--- a/mavros_extras/launch/px4flow.launch
+++ b/mavros_extras/launch/px4flow.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- Based on mavros/node.launch -->
 	<!-- Launch script for PX4Flow -->
 
@@ -23,3 +22,5 @@
 		<rosparam command="load" file="$(find mavros_extras)/launch/px4flow_config.yaml" />
 	</node>
 </launch>
+
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 :

--- a/mavros_extras/launch/px4flow_config.yaml
+++ b/mavros_extras/launch/px4flow_config.yaml
@@ -14,4 +14,4 @@ sys:
 # image_pub [extras]
 camera_frame_id: "pf4flow"
 
-# vim:set ts=2 sw=2 et:
+# vim: set et fenc=utf-8 ft=yaml ff=unix sts=2 sw=2 ts=2 :

--- a/mavros_extras/launch/teleop.launch
+++ b/mavros_extras/launch/teleop.launch
@@ -1,5 +1,4 @@
 <launch>
-	<!-- vim: ft=xml -->
 	<!-- mavteleop example launch script -->
 
 	<!-- <include file="$(find mavros)/launch/px4.launch" /> -->
@@ -14,3 +13,5 @@
 		<rosparam command="load" file="$(find mavros_extras)/launch/f710_joy.yaml" />
 	</node>
 </launch>
+
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 :

--- a/mavros_extras/launch/teleop.launch
+++ b/mavros_extras/launch/teleop.launch
@@ -14,4 +14,4 @@
 	</node>
 </launch>
 
-<!-- vim: set noet fenc=utf-8 ff=unix ft=xml sts=2 sw=2 ts=2 :
+<!-- vim: set noet fenc=utf-8 ff=unix ft=xml :

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# vim:set ts=4 sw=4 et:
 #
 # Copyright 2014 Vladimir Ermakov.
 #
@@ -296,3 +295,4 @@ def main():
 if __name__ == '__main__':
     main()
 
+# vim: set et fenc=utf-8 ff=unix sts=4 sw=4 ts=4 :


### PR DESCRIPTION
This makes the change that you requested. I think for mode et, it should still be there as you have in most of the python scripts.