### PR TITLE
launch: enable setpoint plugins for APM

### DIFF
--- a/mavros/launch/apm2_blacklist.yaml
+++ b/mavros/launch/apm2_blacklist.yaml
@@ -2,7 +2,6 @@ plugin_blacklist:
 - '3dr_radio'
 - '*_position'
 - 'safety_area'
-- 'setpoint_*'
 - 'px4flow'
 - 'image_pub'
 - 'vision_*'


### PR DESCRIPTION
As of ArduCopter 3.2, APM supports position and velocity setpoints via SET_POSITION_TARGET_LOCAL_NED.