### PR TITLE
plugin: global_position: fix nullptr crash

### DIFF
--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -118,11 +118,12 @@ private:
 		// fill GPS status fields using GPS_RAW data
 		auto raw_fix = uas->get_gps_fix();
 
-		gp_fix->status.service = raw_fix->status.service;
-		gp_fix->status.status = raw_fix->status.status;
-
-		gp_fix->position_covariance = raw_fix->position_covariance;
-		gp_fix->position_covariance_type = raw_fix->position_covariance_type;
+		if (raw_fix != nullptr) {
+			gp_fix->status.service = raw_fix->status.service;
+			gp_fix->status.status = raw_fix->status.status;
+			gp_fix->position_covariance = raw_fix->position_covariance;
+			gp_fix->position_covariance_type = raw_fix->position_covariance_type;
+		}
 
 		// Global position velocity
 		gp_vel->header = header;


### PR DESCRIPTION
This fixes a crash in cases where a GLOBAL_POSITION_INT message
is received before a GPS_RAW_INT message, causing the `gps_fix`
pointer member to be dereferenced before it has been set.

I ran into this problem while testing mavros with APM on a mavlink channel that did not include GPS_RAW_INT messages: it was only transmitting LOCAL_POSITION_NED and GLOBAL_POSITION_INT. This configuration exposed an implicit dependency between the `gps` and `global_position` plugins, namely that the `global_position` plugin expects that the `gps` plugin has already received and processed a GPS_RAW_INT message beforehand, because it uses the latest `gps_fix` to determine relative altitude, heading, and covariance.

Because of that dependency, I suspect this isn't the *correct* fix for the crash, but it did solve my immediate problem. I did, however, subsequently run into another issue ("TF to MSG: Quaternion Not Properly Normalized" warnings) that caused me to enable GPS_RAW_INT messages on the mavlink channel, rendering the original issue moot. So maybe we just need to make the dependencies explicit and document the minimum set of mavlink messages required to use mavros and/or each of its plugins.