### PR TITLE
launch: change apm target component id

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -5,7 +5,7 @@
 	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
 	<arg name="gcs_url" default="" />
 	<arg name="tgt_system" default="1" />
-	<arg name="tgt_component" default="50" />
+	<arg name="tgt_component" default="1" />
 
 	<include file="$(find mavros)/launch/node.launch">
 		<arg name="blacklist_yaml" value="$(find mavros)/launch/apm_blacklist.yaml" />


### PR DESCRIPTION
APM uses 1/1 (sys/comp) by default.