### PR TITLE
Frame conversions

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -158,6 +158,7 @@ add_library(mavros
   src/lib/uas_stringify.cpp
   src/lib/uas_timesync.cpp
   src/lib/uas_sensor_orientation.cpp
+  src/lib/uas_frame_conversions.cpp
   src/lib/mavros.cpp
   src/lib/mavlink_diag.cpp
   src/lib/rosconsole_bridge.cpp

--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <array>
 #include <mutex>
 #include <atomic>
 #include <tf/transform_datatypes.h>
@@ -325,6 +326,30 @@ public:
 	 * @brief Function to convert attitude euler angles values from ENU to NED frames and vice-versa
 	 */
 	static tf::Vector3 convert_attitude_rpy(float _roll, float _pitch, float _yaw);
+
+	/**
+	 * @brief Function to convert full 6D pose covariance matrix values from ENU to NED frames and vice-versa
+	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw
+	 *
+	 * Cov_matrix =	|var_x  cov_xy cov_xz cov_xZ cov_xY cov_xX |
+	 * 		|cov_yx var_y  cov_yz cov_yZ cov_yY cov_yX |
+	 * 		|cov_zx cov_zy var_z  cov_zZ cov_zY cov_zX |
+	 * 		|cov_Zx cov_Zy cov_Zz var_Z  cov_ZY cov_ZX |
+	 * 		|cov_Yx cov_Yy cov_Yz cov_YZ var_Y  cov_YX |
+	 * 		|cov_Xx cov_Xy cov_Xz cov_XZ cov_XY var_X  |
+	 *
+	 * Rot_matrix = | 1	 0	 0	 0	 0	 0 |
+	 * 		| 0	-1 	 0	 0	 0	 0 |
+	 * 		| 0	 0	-1	 0	 0	 0 |
+	 * 		| 0	 0	 0	 1	 0	 0 |
+	 * 		| 0	 0	 0	 0	-1	 0 |
+	 * 		| 0	 0	 0	 0	 0	-1 |
+	 *
+	 * Compute Covariance matrix in another frame:
+	 *
+	 * 			C' = R * C * R^T
+	 */
+	static std::array<float, 36> convert_covariance_pose6x6(std::array<float, 36> _covariance);
 
 private:
 	std::recursive_mutex mutex;

--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -298,45 +298,30 @@ public:
 	static tf::Vector3 sensor_orientation_matching(MAV_SENSOR_ORIENTATION orientation);
 
 	/**
-	 * @brief Function to convert position values from ENU to NED frames and vice-versa
-	 */
-	static tf::Vector3 convert_position(float _x, float _y, float _z);
-
-	/**
-	 * @brief Function to convert velocity values from ENU to NED frames and vice-versa
-	 */
-	static tf::Vector3 convert_velocity(float _vx, float _vy, float _vz);
-
-	/**
-	 * @brief Function to convert acceleration values from ENU to NED frames and vice-versa
-	 */
-	static tf::Vector3 convert_accel(float _ax, float _ay, float _az);
-
-	/**
 	 * @brief Function to convert general XYZ values from ENU to NED frames and vice-versa
 	 */
-	static tf::Vector3 convert_general_xyz(float _x, float _y, float _z);
+	static tf::Vector3 transform_frame_general_xyz(float _x, float _y, float _z);
 
 	/**
 	 * @brief Function to convert attitude quaternion values from ENU to NED frames and vice-versa
 	 */
-	static tf::Quaternion convert_attitude_q(tf::Quaternion qo);
+	static tf::Quaternion transform_frame_attitude_q(tf::Quaternion qo);
 
 	/**
 	 * @brief Function to convert attitude euler angles values from ENU to NED frames and vice-versa
 	 */
-	static tf::Vector3 convert_attitude_rpy(float _roll, float _pitch, float _yaw);
+	static tf::Vector3 transform_frame_attitude_rpy(float _roll, float _pitch, float _yaw);
 
 	/**
 	 * @brief Function to convert full 6D pose covariance matrix values from ENU to NED frames and vice-versa
-	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw
+	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw.
 	 *
-	 * Cov_matrix =	|var_x  cov_xy cov_xz cov_xZ cov_xY cov_xX |
-	 * 		|cov_yx var_y  cov_yz cov_yZ cov_yY cov_yX |
-	 * 		|cov_zx cov_zy var_z  cov_zZ cov_zY cov_zX |
-	 * 		|cov_Zx cov_Zy cov_Zz var_Z  cov_ZY cov_ZX |
-	 * 		|cov_Yx cov_Yy cov_Yz cov_YZ var_Y  cov_YX |
-	 * 		|cov_Xx cov_Xy cov_Xz cov_XZ cov_XY var_X  |
+	 * Cov_matrix =	| var_x  cov_xy cov_xz cov_xZ cov_xY cov_xX |
+	 * 		| cov_yx var_y  cov_yz cov_yZ cov_yY cov_yX |
+	 * 		| cov_zx cov_zy var_z  cov_zZ cov_zY cov_zX |
+	 * 		| cov_Zx cov_Zy cov_Zz var_Z  cov_ZY cov_ZX |
+	 * 		| cov_Yx cov_Yy cov_Yz cov_YZ var_Y  cov_YX |
+	 * 		| cov_Xx cov_Xy cov_Xz cov_XZ cov_XY var_X  |
 	 *
 	 * Rot_matrix = | 1	 0	 0	 0	 0	 0 |
 	 * 		| 0	-1 	 0	 0	 0	 0 |
@@ -345,11 +330,41 @@ public:
 	 * 		| 0	 0	 0	 0	-1	 0 |
 	 * 		| 0	 0	 0	 0	 0	-1 |
 	 *
-	 * Compute Covariance matrix in another frame:
+	 * Compute Covariance matrix in another frame: (according to the law of propagation of covariance)
 	 *
 	 * 			C' = R * C * R^T
 	 */
-	static std::array<float, 36> convert_covariance_pose6x6(std::array<float, 36> _covariance);
+	static std::array<float, 36> transform_frame_covariance_pose6x6(std::array<float, 36> _covariance);
+
+	/**
+	 * @brief Function to convert position, linear acceleration, angular velocity or attitude RPY covariance matrix 
+	 * values from ENU to NED frames and vice-versa
+	 * 
+	 * Matrix formats:
+	 *
+	 * Pos_Cov_matrix =	| var_x  cov_xy cov_xz |
+	 * 			| cov_yx var_y  cov_yz |
+	 * 			| cov_zx cov_zy var_z  |
+	 *
+	 * Vel_Cov_matrix =	| var_vx  cov_vxvy cov_vxvz |
+	 * 			| cov_vyvx var_vy  cov_vyvz |
+	 * 			| cov_vzvx cov_vzvy var_vz  |
+	 *
+	 * Att_Cov_matrix =	| var_Z  cov_ZY cov_ZX |
+	 * 			| cov_YZ var_Y  cov_YX |
+	 * 			| cov_XZ cov_XY var_X  |
+	 *
+	 * Note that for ROS<->ENU frame transformations, the rotation matrix is the same for position and attitude.
+	 *
+	 * Rot_matrix = | 1	 0	 0 |
+	 * 		| 0	-1 	 0 |
+	 * 		| 0	 0	-1 |
+	 *
+	 * Compute Covariance matrix in another frame: (according to the law of propagation of covariance)
+	 *
+	 * 			C' = R * C * R^T
+	 */
+	static std::array<float, 9> transform_frame_covariance_general3x3(std::array<float, 9> _covariance);
 
 private:
 	std::recursive_mutex mutex;

--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -296,6 +296,36 @@ public:
 	 */
 	static tf::Vector3 sensor_orientation_matching(MAV_SENSOR_ORIENTATION orientation);
 
+	/**
+	 * @brief Function to convert position values from ENU to NED frames and vice-versa
+	 */
+	static tf::Vector3 convert_position(float _x, float _y, float _z);
+
+	/**
+	 * @brief Function to convert velocity values from ENU to NED frames and vice-versa
+	 */
+	static tf::Vector3 convert_velocity(float _vx, float _vy, float _vz);
+
+	/**
+	 * @brief Function to convert acceleration values from ENU to NED frames and vice-versa
+	 */
+	static tf::Vector3 convert_accel(float _ax, float _ay, float _az);
+
+	/**
+	 * @brief Function to convert general XYZ values from ENU to NED frames and vice-versa
+	 */
+	static tf::Vector3 convert_general_xyz(float _x, float _y, float _z);
+
+	/**
+	 * @brief Function to convert attitude quaternion values from ENU to NED frames and vice-versa
+	 */
+	static tf::Quaternion convert_attitude_q(tf::Quaternion qo);
+
+	/**
+	 * @brief Function to convert attitude euler angles values from ENU to NED frames and vice-versa
+	 */
+	static tf::Vector3 convert_attitude_rpy(float _roll, float _pitch, float _yaw);
+
 private:
 	std::recursive_mutex mutex;
 

--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -25,7 +25,6 @@
 
 #include <sensor_msgs/NavSatFix.h>
 
-
 namespace mavros {
 /**
  * @brief helper accessor to FCU link interface
@@ -77,6 +76,8 @@ class UAS {
 public:
 	typedef std::lock_guard<std::recursive_mutex> lock_guard;
 	typedef std::unique_lock<std::recursive_mutex> unique_lock;
+	typedef boost::array<double, 9> Covariance3x3;
+	typedef boost::array<double, 36> Covariance6x6;
 
 	UAS();
 	~UAS() {};
@@ -297,24 +298,88 @@ public:
 	 */
 	static tf::Vector3 sensor_orientation_matching(MAV_SENSOR_ORIENTATION orientation);
 
-	/**
-	 * @brief Function to convert general XYZ values from ENU to NED frames and vice-versa
-	 */
-	static tf::Vector3 transform_frame_general_xyz(float _x, float _y, float _z);
-
-	/**
-	 * @brief Function to convert attitude quaternion values from ENU to NED frames and vice-versa
-	 */
+	static tf::Vector3 transform_frame_xyz(double _x, double _y, double _z);
 	static tf::Quaternion transform_frame_attitude_q(tf::Quaternion qo);
+	static tf::Vector3 transform_frame_attitude_rpy(double _roll, double _pitch, double _yaw);
+	static Covariance6x6 transform_frame_covariance_pose6x6(Covariance6x6 &_covariance);
+	static Covariance3x3 transform_frame_covariance_general3x3(Covariance3x3 &_covariance);
 
 	/**
-	 * @brief Function to convert attitude euler angles values from ENU to NED frames and vice-versa
+	 * @brief Function to convert general XYZ values from ENU to NED frames
+	 * @param _x: X coordinate value
+ 	 * @param _y: Y coordinate value
+ 	 * @param _z: Z coordinate value
 	 */
-	static tf::Vector3 transform_frame_attitude_rpy(float _roll, float _pitch, float _yaw);
+	static inline tf::Vector3 transform_frame_enu_ned_xyz(double _x, double _y, double _z){
+		return transform_frame_xyz(_x, _y, _z);
+	}
 
 	/**
-	 * @brief Function to convert full 6D pose covariance matrix values from ENU to NED frames and vice-versa
+	 * @brief Function to convert general XYZ values from NED to ENU frames
+	 * @param _x: X coordinate value
+ 	 * @param _y: Y coordinate value
+ 	 * @param _z: Z coordinate value
+	 */
+	static inline tf::Vector3 transform_frame_ned_enu_xyz(double _x, double _y, double _z){
+		return transform_frame_xyz(_x, _y, _z);
+	}
+
+	/**
+	 * @brief Function to convert attitude quaternion values from ENU to NED frames
+	 * @param qo: tf::Quaternion format
+	 */
+	static inline tf::Quaternion transform_frame_enu_ned_attitude_q(tf::Quaternion qo){
+		return transform_frame_attitude_q(qo);
+	}
+
+	/**
+	 * @brief Function to convert attitude quaternion values from NED to ENU frames
+	 * @param qo: tf::Quaternion format
+	 */
+	static inline tf::Quaternion transform_frame_ned_enu_attitude_q(tf::Quaternion qo){
+		return transform_frame_attitude_q(qo);
+	}
+
+	/**
+	 * @brief Function to convert attitude euler angle values from ENU to NED frames
+	 * @param _roll: Roll value
+ 	 * @param _pitch: Pitch value
+	 * @param _yaw: Yaw value
+	 */
+	static inline tf::Vector3 transform_frame_enu_ned_attitude_rpy(double _roll, double _pitch, double _yaw){
+		return transform_frame_attitude_rpy(_roll, _pitch, _yaw);
+	}
+
+	/**
+	 * @brief Function to convert attitude euler angle values from NED to ENU frames
+	 * @param _roll: Roll value
+ 	 * @param _pitch: Pitch value
+	 * @param _yaw: Yaw value
+	 */
+	static inline tf::Vector3 transform_frame_ned_enu_attitude_rpy(double _roll, double _pitch, double _yaw){
+		return transform_frame_attitude_rpy(_roll, _pitch, _yaw);
+	}
+
+	/**
+	 * @brief Function to convert full 6D pose covariance matrix values from ENU to NED frames
 	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw.
+	 * @param _covariance: 6x6 double precision covariance matrix
+	 */
+	static inline Covariance6x6 transform_frame_enu_ned_covariance_pose6x6(Covariance6x6 _covariance){
+		return transform_frame_covariance_pose6x6(_covariance);
+	}
+
+	/**
+	 * @brief Function to convert full 6D pose covariance matrix values from NED to ENU frames
+	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw.
+	 * @param _covariance: 6x6 double precision covariance matrix
+	 */
+	static inline Covariance6x6 transform_frame_ned_enu_covariance_pose6x6(Covariance6x6 _covariance){
+		return transform_frame_covariance_pose6x6(_covariance);
+	}
+
+	/**
+	 * Matrix formats for the above funtions:
 	 *
 	 * Cov_matrix =	| var_x  cov_xy cov_xz cov_xZ cov_xY cov_xX |
 	 * 		| cov_yx var_y  cov_yz cov_yZ cov_yY cov_yX |
@@ -334,13 +399,25 @@ public:
 	 *
 	 * 			C' = R * C * R^T
 	 */
-	static std::array<float, 36> transform_frame_covariance_pose6x6(std::array<float, 36> _covariance);
 
 	/**
-	 * @brief Function to convert position, linear acceleration, angular velocity or attitude RPY covariance matrix 
-	 * values from ENU to NED frames and vice-versa
-	 * 
-	 * Matrix formats:
+	 * @brief Function to convert position, linear acceleration, angular velocity or attitude RPY covariance matrix values from ENU to NED frames
+	 * @param _covariance: 3x3 double precision covariance matrix
+	 */
+	static inline Covariance3x3 transform_frame_covariance_enu_ned_general3x3(Covariance3x3 _covariance){
+		return transform_frame_covariance_general3x3(_covariance);
+	}
+
+	/**
+	 * @brief Function to convert position, linear acceleration, angular velocity or attitude RPY covariance matrix values from NED to ENU frames
+	 * @param _covariance: 3x3 double precision covariance matrix
+	 */
+	static inline Covariance3x3 transform_frame_covariance_ned_enu_general3x3(Covariance3x3 _covariance){
+		return transform_frame_covariance_general3x3(_covariance);
+	}
+
+	/**
+	 * Matrix formats for the above funtions:
 	 *
 	 * Pos_Cov_matrix =	| var_x  cov_xy cov_xz |
 	 * 			| cov_yx var_y  cov_yz |
@@ -364,7 +441,6 @@ public:
 	 *
 	 * 			C' = R * C * R^T
 	 */
-	static std::array<float, 9> transform_frame_covariance_general3x3(std::array<float, 9> _covariance);
 
 private:
 	std::recursive_mutex mutex;

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -21,49 +21,28 @@ const double PI = boost::math::constants::pi<double>();
 
 using namespace mavros;
 
-static tf::Vector3 convert_position(float _x, float _y, float _z){
+static tf::Vector3 transform_frame_general_xyz(float _x, float _y, float _z){
 	float x =  _x;
 	float y = -_y;
 	float z = -_z;
 	return tf::Vector3(x, y, z);
 };
 
-static tf::Vector3 convert_velocity(float _vx, float _vy, float _vz){
-	float vx =  _vx;
-	float vy = -_vy;
-	float vz = -_vz;
-	return tf::Vector3(vx, vy, vz);
-};
-
-static tf::Vector3 convert_accel(float _ax, float _ay, float _az){
-	float ax =  _ax;
-	float ay = -_ay;
-	float az = -_az;
-	return tf::Vector3(ax, ay, az);
-};
-
-static tf::Vector3 convert_general_xyz(float _x, float _y, float _z){
-	float x =  _x;
-	float y = -_y;
-	float z = -_z;
-	return tf::Vector3(x, y, z);
-};
-
-static tf::Quaternion convert_attitude_q(tf::Quaternion qo){
+static tf::Quaternion transform_frame_attitude_q(tf::Quaternion qo){
 	double roll = PI, pitch = 0.0 , yaw = 0.0f; 
 	tf::Quaternion qr = tf::createQuaternionFromRPY(roll, pitch, yaw);
 	tf::Quaternion qt = qo * qr; 
 	return qt;
 };
 
-static tf::Vector3 convert_attitude_rpy(float _roll, float _pitch, float _yaw){
+static tf::Vector3 transform_frame_attitude_rpy(float _roll, float _pitch, float _yaw){
 	float roll = _roll + PI;
 	float pitch = _pitch;
 	float yaw = _yaw;
 	return tf::Vector3(roll, pitch, yaw);
 };
 
-static std::array<float, 36> convert_covariance_pose6x6(std::array<float, 36> _covariance){
+static std::array<float, 36> transform_frame_covariance_pose6x6(std::array<float, 36> _covariance){
 
 	std::array<float, 36> rotation = {1 ,0,0,0,0,0,
     					  0,-1,0,0,0,0,
@@ -74,6 +53,23 @@ static std::array<float, 36> convert_covariance_pose6x6(std::array<float, 36> _c
 
    	std::array<float, 36> covariance;							
 	std::array<float, 36> temp;		// temporary matrix = R * C
+
+	// The rotation matrix in this case is a diagonal matrix so R = R^T
+	
+	std::transform(rotation.begin()+1, rotation.end(), _covariance.begin()+1, temp.begin(), std::multiplies<float>());
+	std::transform(temp.begin()+1, temp.end(), rotation.begin()+1, covariance.begin(), std::multiplies<float>());
+
+	return covariance;
+};
+
+static std::array<float, 9> transform_frame_covariance_general3x3(std::array<float, 9> _covariance){
+
+	std::array<float, 9> rotation = {1 ,0,0,
+    					 0,-1,0,
+    					 0,0,-1};
+
+   	std::array<float, 9> covariance;							
+	std::array<float, 9> temp;		// temporary matrix = R * C
 
 	// The rotation matrix in this case is a diagonal matrix so R = R^T
 	

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -62,3 +62,23 @@ static tf::Vector3 convert_attitude_rpy(float _roll, float _pitch, float _yaw){
 	float yaw = _yaw;
 	return tf::Vector3(roll, pitch, yaw);
 };
+
+static std::array<float, 36> convert_covariance_pose6x6(std::array<float, 36> _covariance){
+
+	std::array<float, 36> rotation = {1 ,0,0,0,0,0,
+    					  0,-1,0,0,0,0,
+    					  0,0,-1,0,0,0,
+    					  0,0,0, 1,0,0,
+    					  0,0,0,0,-1,0,
+    					  0,0,0,0,0,-1};
+
+   	std::array<float, 36> covariance;							
+	std::array<float, 36> temp;		// temporary matrix = R * C
+
+	// The rotation matrix in this case is a diagonal matrix so R = R^T
+	
+	std::transform(rotation.begin()+1, rotation.end(), _covariance.begin()+1, temp.begin(), std::multiplies<float>());
+	std::transform(temp.begin()+1, temp.end(), rotation.begin()+1, covariance.begin(), std::multiplies<float>());
+
+	return covariance;
+};

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -21,60 +21,60 @@ const double PI = boost::math::constants::pi<double>();
 
 using namespace mavros;
 
-static tf::Vector3 transform_frame_general_xyz(float _x, float _y, float _z){
-	float x =  _x;
-	float y = -_y;
-	float z = -_z;
+tf::Vector3 UAS::transform_frame_xyz(double _x, double _y, double _z){
+	double x =  _x;
+	double y = -_y;
+	double z = -_z;
 	return tf::Vector3(x, y, z);
 };
 
-static tf::Quaternion transform_frame_attitude_q(tf::Quaternion qo){
+tf::Quaternion UAS::transform_frame_attitude_q(tf::Quaternion qo){
 	double roll = PI, pitch = 0.0 , yaw = 0.0f; 
 	tf::Quaternion qr = tf::createQuaternionFromRPY(roll, pitch, yaw);
 	tf::Quaternion qt = qo * qr; 
 	return qt;
 };
 
-static tf::Vector3 transform_frame_attitude_rpy(float _roll, float _pitch, float _yaw){
-	float roll = _roll + PI;
-	float pitch = _pitch;
-	float yaw = _yaw;
+tf::Vector3 UAS::transform_frame_attitude_rpy(double _roll, double _pitch, double _yaw){
+	double roll = _roll + PI;
+	double pitch = _pitch;
+	double yaw = _yaw;
 	return tf::Vector3(roll, pitch, yaw);
 };
 
-static std::array<float, 36> transform_frame_covariance_pose6x6(std::array<float, 36> _covariance){
+UAS::Covariance6x6 UAS::transform_frame_covariance_pose6x6(UAS::Covariance6x6 &_covariance){
 
-	std::array<float, 36> rotation = {1 ,0,0,0,0,0,
-    					  0,-1,0,0,0,0,
-    					  0,0,-1,0,0,0,
-    					  0,0,0, 1,0,0,
-    					  0,0,0,0,-1,0,
-    					  0,0,0,0,0,-1};
+	UAS::Covariance6x6 rotation = { 1 ,0,0,0,0,0,
+    					0,-1,0,0,0,0,
+    					0,0,-1,0,0,0,
+    					0,0,0, 1,0,0,
+    					0,0,0,0,-1,0,
+    					0,0,0,0,0,-1};
 
-   	std::array<float, 36> covariance;							
-	std::array<float, 36> temp;		// temporary matrix = R * C
+   	UAS::Covariance6x6 covariance;							
+	UAS::Covariance6x6 temp;		// temporary matrix = R * C
 
 	// The rotation matrix in this case is a diagonal matrix so R = R^T
 	
-	std::transform(rotation.begin()+1, rotation.end(), _covariance.begin()+1, temp.begin(), std::multiplies<float>());
-	std::transform(temp.begin()+1, temp.end(), rotation.begin()+1, covariance.begin(), std::multiplies<float>());
+	std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
+	std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
 
 	return covariance;
 };
 
-static std::array<float, 9> transform_frame_covariance_general3x3(std::array<float, 9> _covariance){
+UAS::Covariance3x3 UAS::transform_frame_covariance_general3x3(UAS::Covariance3x3 &_covariance){
 
-	std::array<float, 9> rotation = {1 ,0,0,
-    					 0,-1,0,
-    					 0,0,-1};
+	UAS::Covariance3x3 rotation = { 1 ,0,0,
+    					0,-1,0,
+    					0,0,-1};
 
-   	std::array<float, 9> covariance;							
-	std::array<float, 9> temp;		// temporary matrix = R * C
+   	UAS::Covariance3x3 covariance;							
+	UAS::Covariance3x3 temp;		// temporary matrix = R * C
 
 	// The rotation matrix in this case is a diagonal matrix so R = R^T
 	
-	std::transform(rotation.begin()+1, rotation.end(), _covariance.begin()+1, temp.begin(), std::multiplies<float>());
-	std::transform(temp.begin()+1, temp.end(), rotation.begin()+1, covariance.begin(), std::multiplies<float>());
+	std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
+	std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
 
 	return covariance;
 };

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -1,0 +1,64 @@
+/**
+ * @brief Frame conversions helper functions
+ * @file uas_frame_conversions.cpp
+ * @author Nuno Marques <n.marques21@hotmail.com>
+ *
+ * @addtogroup nodelib
+ * @{
+ */
+/*
+ * Copyright 2015 Nuno Marques.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+#include <array>
+#include <mavros/mavros_uas.h>
+#include <boost/math/constants/constants.hpp>
+
+const double PI = boost::math::constants::pi<double>();
+
+using namespace mavros;
+
+static tf::Vector3 convert_position(float _x, float _y, float _z){
+	float x =  _x;
+	float y = -_y;
+	float z = -_z;
+	return tf::Vector3(x, y, z);
+};
+
+static tf::Vector3 convert_velocity(float _vx, float _vy, float _vz){
+	float vx =  _vx;
+	float vy = -_vy;
+	float vz = -_vz;
+	return tf::Vector3(vx, vy, vz);
+};
+
+static tf::Vector3 convert_accel(float _ax, float _ay, float _az){
+	float ax =  _ax;
+	float ay = -_ay;
+	float az = -_az;
+	return tf::Vector3(ax, ay, az);
+};
+
+static tf::Vector3 convert_general_xyz(float _x, float _y, float _z){
+	float x =  _x;
+	float y = -_y;
+	float z = -_z;
+	return tf::Vector3(x, y, z);
+};
+
+static tf::Quaternion convert_attitude_q(tf::Quaternion qo){
+	double roll = PI, pitch = 0.0 , yaw = 0.0f; 
+	tf::Quaternion qr = tf::createQuaternionFromRPY(roll, pitch, yaw);
+	tf::Quaternion qt = qo * qr; 
+	return qt;
+};
+
+static tf::Vector3 convert_attitude_rpy(float _roll, float _pitch, float _yaw){
+	float roll = _roll + PI;
+	float pitch = _pitch;
+	float yaw = _yaw;
+	return tf::Vector3(roll, pitch, yaw);
+};

--- a/mavros/src/lib/uas_sensor_orientation.cpp
+++ b/mavros/src/lib/uas_sensor_orientation.cpp
@@ -1,6 +1,6 @@
 /**
  * @brief Sensor orientation helper function
- * @file sensor_orientation.cpp
+ * @file uas_sensor_orientation.cpp
  * @author Nuno Marques <n.marques21@hotmail.com>
  *
  * @addtogroup nodelib

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -146,7 +146,7 @@ private:
 		double northing, easting;
 		std::string zone;
 
-		/** @note Adapted from gps_umd ROS package @a http://wiki.ros.org/gps_umd
+		/** @note Adapted from gps_umd ROS package @http://wiki.ros.org/gps_umd
 		 *  Author: Ken Tossell <ken AT tossell DOT net>
 		 */
 		UTM::LLtoUTM(gp_fix->latitude, gp_fix->longitude, northing, easting, zone);

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -85,9 +85,7 @@ private:
 	bool send_tf;
 	double rot_cov;
 
-	/**
-	 * @todo Handler for GLOBAL_POSITION_INT_COV
-	 */
+	/** @todo Handler for GLOBAL_POSITION_INT_COV */
 
 	void handle_global_position_int(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
 		mavlink_global_position_int_t gp_pos;
@@ -148,7 +146,7 @@ private:
 		double northing, easting;
 		std::string zone;
 
-		/** Adapted from gps_umd ROS package @a http://wiki.ros.org/gps_umd
+		/** @note Adapted from gps_umd ROS package @a http://wiki.ros.org/gps_umd
 		 *  Author: Ken Tossell <ken AT tossell DOT net>
 		 */
 		UTM::LLtoUTM(gp_fix->latitude, gp_fix->longitude, northing, easting, zone);
@@ -189,7 +187,9 @@ private:
 
 		if (send_tf) {
 			tf::Transform transform;
-			auto position = UAS::convert_position(pose_cov->pose.pose.position.x,
+
+			/** ENU->NED frame conversion */
+			auto position = UAS::transform_frame_general_xyz(pose_cov->pose.pose.position.x,
 						pose_cov->pose.pose.position.y,
 						pose_cov->pose.pose.position.z);
 

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -158,7 +158,6 @@ private:
 		pose_cov->pose.pose.position.y = northing;
 		pose_cov->pose.pose.position.z = relative_alt->data;
 
-		// XXX Check #193
 		tf::quaternionTFToMsg(uas->get_attitude_orientation(), pose_cov->pose.pose.orientation);
 
 		// Use ENU covariance to build XYZRPY covariance
@@ -190,10 +189,11 @@ private:
 
 		if (send_tf) {
 			tf::Transform transform;
-			// XXX: we realy need change frame?
-			transform.setOrigin(tf::Vector3(pose_cov->pose.pose.position.y,
-						pose_cov->pose.pose.position.x,
-						-pose_cov->pose.pose.position.z));
+			auto position = UAS::convert_position(pose_cov->pose.pose.position.x,
+						pose_cov->pose.pose.position.y,
+						pose_cov->pose.pose.position.z);
+
+			transform.setOrigin(position);
 
 			transform.setRotation(uas->get_attitude_orientation());
 

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -188,8 +188,7 @@ private:
 		if (send_tf) {
 			tf::Transform transform;
 
-			/** ENU->NED frame conversion */
-			auto position = UAS::transform_frame_general_xyz(pose_cov->pose.pose.position.x,
+			auto position = UAS::transform_frame_enu_ned_xyz(pose_cov->pose.pose.position.x,
 						pose_cov->pose.pose.position.y,
 						pose_cov->pose.pose.position.z);
 

--- a/mavros/src/plugins/imu_pub.cpp
+++ b/mavros/src/plugins/imu_pub.cpp
@@ -254,9 +254,9 @@ private:
 
 			auto mag_field = UAS::transform_frame_ned_enu_xyz(imu_hr.xmag, imu_hr.ymag, imu_hr.zmag);
 
-			magn_msg->magnetic_field.x = mag_field.x() * MILLIT_TO_TESLA;
-			magn_msg->magnetic_field.y = mag_field.y() * MILLIT_TO_TESLA;
-			magn_msg->magnetic_field.z = mag_field.z() * MILLIT_TO_TESLA;
+			magn_msg->magnetic_field.x = mag_field.x() * GAUSS_TO_TESLA;
+			magn_msg->magnetic_field.y = mag_field.y() * GAUSS_TO_TESLA;
+			magn_msg->magnetic_field.z = mag_field.z() * GAUSS_TO_TESLA;
 
 			magn_msg->magnetic_field_covariance = magnetic_cov; // already in ENU frame
 

--- a/mavros/src/plugins/imu_pub.cpp
+++ b/mavros/src/plugins/imu_pub.cpp
@@ -178,12 +178,12 @@ private:
 
 		auto imu_msg = boost::make_shared<sensor_msgs::Imu>();
 
-		// NED -> ENU (body-fixed)
-		tf::Vector3 attitude = UAS::convert_attitude_rpy(att.roll, att.pitch, att.yaw);
+		/** NED->ENU frame conversion */
+		tf::Vector3 attitude = UAS::transform_frame_attitude_rpy(att.roll, att.pitch, att.yaw);
 		tf::Quaternion orientation = tf::createQuaternionFromRPY(
 				attitude.x(), attitude.y(), attitude.z());
 
-		tf::Vector3 attitude_s = UAS::convert_attitude_rpy(att.rollspeed, att.pitchspeed, att.yawspeed);
+		tf::Vector3 attitude_s = UAS::transform_frame_attitude_rpy(att.rollspeed, att.pitchspeed, att.yawspeed);
 		fill_imu_msg_attitude(imu_msg, orientation,
 				attitude_s.x(), attitude_s.y(), attitude_s.z());
 
@@ -207,11 +207,11 @@ private:
 
 		auto imu_msg = boost::make_shared<sensor_msgs::Imu>();
 
-		// PX4 NED -> ROS ENU (body-fixed)
+		/** NED->ENU frame conversion */
 		tf::Quaternion orientation(att_q.q1, att_q.q2, att_q.q3, att_q.q4);
-		tf::Quaternion qo = UAS::convert_attitude_q(orientation);
+		tf::Quaternion qo = UAS::transform_frame_attitude_q(orientation);
 
-		tf::Vector3 attitude_s = UAS::convert_attitude_rpy(att_q.rollspeed, att_q.pitchspeed, att_q.yawspeed);
+		tf::Vector3 attitude_s = UAS::transform_frame_attitude_rpy(att_q.rollspeed, att_q.pitchspeed, att_q.yawspeed);
 		fill_imu_msg_attitude(imu_msg, orientation,
 				attitude_s.x(), attitude_s.y(), attitude_s.z());
 
@@ -240,8 +240,9 @@ private:
 		if (imu_hr.fields_updated & ((7 << 3) | (7 << 0))) {
 			auto imu_msg = boost::make_shared<sensor_msgs::Imu>();
 
-			auto hr_imu_gyro = UAS::convert_general_xyz(imu_hr.xgyro, imu_hr.ygyro, imu_hr.zgyro);
-			auto hr_imu_acc = UAS::convert_general_xyz(imu_hr.xacc, imu_hr.yacc, imu_hr.zacc);
+			/** NED->ENU frame conversion */
+			auto hr_imu_gyro = UAS::transform_frame_general_xyz(imu_hr.xgyro, imu_hr.ygyro, imu_hr.zgyro);
+			auto hr_imu_acc = UAS::transform_frame_general_xyz(imu_hr.xacc, imu_hr.yacc, imu_hr.zacc);
 
 			fill_imu_msg_raw(imu_msg,
 					hr_imu_gyro.x(), hr_imu_gyro.y(), hr_imu_gyro.z(),
@@ -254,8 +255,8 @@ private:
 		if (imu_hr.fields_updated & (7 << 6)) {
 			auto magn_msg = boost::make_shared<sensor_msgs::MagneticField>();
 
-			// Convert from local NED plane to ENU
-			auto mag_field = UAS::convert_general_xyz(imu_hr.xmag, imu_hr.ymag, imu_hr.zmag);
+			/** NED->ENU frame conversion */
+			auto mag_field = UAS::transform_frame_general_xyz(imu_hr.xmag, imu_hr.ymag, imu_hr.zmag);
 
 			magn_msg->magnetic_field.x = mag_field.x() * MILLIT_TO_TESLA;
 			magn_msg->magnetic_field.y = mag_field.y() * MILLIT_TO_TESLA;
@@ -296,9 +297,11 @@ private:
 		header.stamp = uas->synchronise_stamp(imu_raw.time_usec);
 		header.frame_id = frame_id;
 
-		/* NOTE: APM send SCALED_IMU data as RAW_IMU */
-		auto raw_imu_gyro = UAS::convert_general_xyz(imu_raw.xgyro, imu_raw.ygyro, imu_raw.zgyro);
-		auto raw_imu_acc = UAS::convert_general_xyz(imu_raw.xacc, imu_raw.yacc, imu_raw.zacc);
+		/** @note APM send SCALED_IMU data as RAW_IMU */
+
+		/** NED->ENU frame conversion */
+		auto raw_imu_gyro = UAS::transform_frame_general_xyz(imu_raw.xgyro, imu_raw.ygyro, imu_raw.zgyro);
+		auto raw_imu_acc = UAS::transform_frame_general_xyz(imu_raw.xacc, imu_raw.yacc, imu_raw.zacc);
 
 		fill_imu_msg_raw(imu_msg,
 				raw_imu_gyro.x() * MILLIRS_TO_RADSEC,
@@ -321,9 +324,9 @@ private:
 		/* -*- magnetic vector -*- */
 		auto magn_msg = boost::make_shared<sensor_msgs::MagneticField>();
 
-		// Convert from local NED plane to ENU
-		auto mag_field = UAS::convert_general_xyz(imu_raw.xmag, imu_raw.ymag, imu_raw.zmag);
-		
+		/** NED->ENU frame conversion */
+		auto mag_field = UAS::transform_frame_general_xyz(imu_raw.xmag, imu_raw.ymag, imu_raw.zmag);
+
 		magn_msg->magnetic_field.x = mag_field.x() * MILLIT_TO_TESLA;
 		magn_msg->magnetic_field.y = mag_field.y() * MILLIT_TO_TESLA;
 		magn_msg->magnetic_field.z = mag_field.z() * MILLIT_TO_TESLA;
@@ -348,8 +351,9 @@ private:
 		std_msgs::Header header;
 		header.stamp = uas->synchronise_stamp(imu_raw.time_boot_ms);
 
-		auto raw_imu_gyro = UAS::convert_general_xyz(imu_raw.xgyro, imu_raw.ygyro, imu_raw.zgyro);
-		auto raw_imu_acc = UAS::convert_general_xyz(imu_raw.xacc, imu_raw.yacc, imu_raw.zacc);
+		/** NED->ENU frame conversion */
+		auto raw_imu_gyro = UAS::transform_frame_general_xyz(imu_raw.xgyro, imu_raw.ygyro, imu_raw.zgyro);
+		auto raw_imu_acc = UAS::transform_frame_general_xyz(imu_raw.xacc, imu_raw.yacc, imu_raw.zacc);
 
 		fill_imu_msg_raw(imu_msg,
 				raw_imu_gyro.x() * MILLIRS_TO_RADSEC,
@@ -365,8 +369,8 @@ private:
 		/* -*- magnetic vector -*- */
 		auto magn_msg = boost::make_shared<sensor_msgs::MagneticField>();
 
-		// Convert from local NED plane to ENU
-		auto mag_field = UAS::convert_general_xyz(imu_raw.xmag, imu_raw.ymag, imu_raw.zmag);
+		/** NED->ENU frame conversion */
+		auto mag_field = UAS::transform_frame_general_xyz(imu_raw.xmag, imu_raw.ymag, imu_raw.zmag);
 
 		magn_msg->magnetic_field.x = mag_field.x() * MILLIT_TO_TESLA;
 		magn_msg->magnetic_field.y = mag_field.y() * MILLIT_TO_TESLA;

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -72,15 +72,11 @@ private:
 				pos_ned.x, pos_ned.y, pos_ned.z,
 				pos_ned.vx, pos_ned.vy, pos_ned.vz);
 
-		/* TODO: check convertion to ENU
-		 * I think XZY is not body-fixed, but orientation does.
-		 * Perhaps this adds additional errorprone to us.
-		 * Need more tests. Issue #49.
-		 *
-		 * orientation in ENU, body-fixed
-		 */
 		tf::Transform transform;
-		transform.setOrigin(tf::Vector3(pos_ned.x, -pos_ned.y, -pos_ned.z));
+		// ENU->NED
+		auto position = UAS::convert_position(pos_ned.x, pos_ned.y, pos_ned.z);
+
+		transform.setOrigin(position);
 		transform.setRotation(uas->get_attitude_orientation());
 
 		auto pose = boost::make_shared<geometry_msgs::PoseStamped>();

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -74,8 +74,7 @@ private:
 
 		tf::Transform transform;
 
-		/** NED->ENU frame conversion */
-		auto position = UAS::transform_frame_general_xyz(pos_ned.x, pos_ned.y, pos_ned.z);
+		auto position = UAS::transform_frame_ned_enu_xyz(pos_ned.x, pos_ned.y, pos_ned.z);
 
 		transform.setOrigin(position);
 		transform.setRotation(uas->get_attitude_orientation());

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -24,7 +24,7 @@
 namespace mavplugin {
 /**
  * @brief Local position plugin.
- * Publish local position to TF and PositionStamped,
+ * Publish local position to TF and PositionStamped
  */
 class LocalPositionPlugin : public MavRosPlugin {
 public:
@@ -73,8 +73,9 @@ private:
 				pos_ned.vx, pos_ned.vy, pos_ned.vz);
 
 		tf::Transform transform;
-		// ENU->NED
-		auto position = UAS::convert_position(pos_ned.x, pos_ned.y, pos_ned.z);
+
+		/** NED->ENU frame conversion */
+		auto position = UAS::transform_frame_general_xyz(pos_ned.x, pos_ned.y, pos_ned.z);
 
 		transform.setOrigin(position);
 		transform.setRotation(uas->get_attitude_orientation());

--- a/mavros/src/plugins/safety_area.cpp
+++ b/mavros/src/plugins/safety_area.cpp
@@ -109,9 +109,8 @@ private:
 				p1x, p1y, p1z,
 				p2x, p2y, p2z);
 
-		/** ENU->NED frame conversion */
-		auto p1 = UAS::transform_frame_general_xyz(p1x, p1y, p1z);
-		auto p2 = UAS::transform_frame_general_xyz(p2x, p2y, p2z);
+		auto p1 = UAS::transform_frame_enu_ned_xyz(p1x, p1y, p1z);
+		auto p2 = UAS::transform_frame_enu_ned_xyz(p2x, p2y, p2z);
 
 		safety_set_allowed_area(
 				MAV_FRAME_LOCAL_NED, // TODO: use enum from lib

--- a/mavros/src/plugins/safety_area.cpp
+++ b/mavros/src/plugins/safety_area.cpp
@@ -110,10 +110,14 @@ private:
 				p1x, p1y, p1z,
 				p2x, p2y, p2z);
 
+		// ENU->NED
+		auto p1 = UAS::convert_position(p1x, p1y, p1z);
+		auto p2 = UAS::convert_position(p2x, p2y, p2z);
+
 		safety_set_allowed_area(
-				MAV_FRAME_LOCAL_NED,
-				p1y, p1x, -p1z,
-				p2y, p2x, -p2z);
+				MAV_FRAME_LOCAL_NED, // TODO: use enum from lib
+				p1.x(), p1.y(), p1.z(),
+				p2.x(), p2.y(), p2.z());
 	}
 
 	/* -*- callbacks -*- */

--- a/mavros/src/plugins/safety_area.cpp
+++ b/mavros/src/plugins/safety_area.cpp
@@ -70,9 +70,8 @@ public:
 
 	const message_map get_rx_handlers() {
 		return { /* Rx disabled */ };
-		/**
-		 * @todo Publish SAFETY_ALLOWED_AREA message
-		 */
+		
+		/** @todo Publish SAFETY_ALLOWED_AREA message */
 	}
 
 private:
@@ -99,7 +98,7 @@ private:
 	/* -*- mid-level helpers -*- */
 
 	/**
-	 * Send a safety zone (volume), which is defined by two corners of a cube,
+	 * @brief Send a safety zone (volume), which is defined by two corners of a cube,
 	 * to the FCU.
 	 *
 	 * @note ENU frame.
@@ -110,9 +109,9 @@ private:
 				p1x, p1y, p1z,
 				p2x, p2y, p2z);
 
-		// ENU->NED
-		auto p1 = UAS::convert_position(p1x, p1y, p1z);
-		auto p2 = UAS::convert_position(p2x, p2y, p2z);
+		/** ENU->NED frame conversion */
+		auto p1 = UAS::transform_frame_general_xyz(p1x, p1y, p1z);
+		auto p2 = UAS::transform_frame_general_xyz(p2x, p2y, p2z);
 
 		safety_set_allowed_area(
 				MAV_FRAME_LOCAL_NED, // TODO: use enum from lib

--- a/mavros/src/plugins/setpoint_accel.cpp
+++ b/mavros/src/plugins/setpoint_accel.cpp
@@ -62,12 +62,13 @@ private:
 	/* -*- mid-level helpers -*- */
 
 	/**
-	 * Send acceleration/force to FCU acceleration controller
+	 * @brief Send acceleration/force to FCU acceleration controller.
 	 *
-	 * Note: send only AFX AFY AFZ. ENU frame.
+	 * @warning Send only AFX AFY AFZ. ENU frame.
 	 */
 	void send_setpoint_acceleration(const ros::Time &stamp, float afx, float afy, float afz) {
-		/* Documentation start from bit 1 instead 0.
+		/**
+		 * Documentation start from bit 1 instead 0.
 		 * Ignore position and velocity vectors, yaw and yaw rate
 		 */
 		uint16_t ignore_all_except_a_xyz = (3 << 10) | (7 << 3) | (7 << 0);
@@ -75,8 +76,8 @@ private:
 		if (send_force)
 			ignore_all_except_a_xyz |= (1 << 9);
 
-		// ENU->NED
-		auto accel = UAS::convert_accel(afx, afy, afz);
+		/** ENU->NED frame conversion */
+		auto accel = UAS::transform_frame_general_xyz(afx, afy, afz);
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,	// TODO: use enum on lib

--- a/mavros/src/plugins/setpoint_accel.cpp
+++ b/mavros/src/plugins/setpoint_accel.cpp
@@ -66,7 +66,7 @@ private:
 	 *
 	 * @warning Send only AFX AFY AFZ. ENU frame.
 	 */
-	void send_setpoint_acceleration(const ros::Time &stamp, float afx, float afy, float afz) {
+	void send_setpoint_acceleration(const ros::Time &stamp, double afx, double afy, double afz) {
 		/**
 		 * Documentation start from bit 1 instead 0.
 		 * Ignore position and velocity vectors, yaw and yaw rate
@@ -76,8 +76,7 @@ private:
 		if (send_force)
 			ignore_all_except_a_xyz |= (1 << 9);
 
-		/** ENU->NED frame conversion */
-		auto accel = UAS::transform_frame_general_xyz(afx, afy, afz);
+		auto accel = UAS::transform_frame_enu_ned_xyz(afx, afy, afz);
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,	// TODO: use enum on lib

--- a/mavros/src/plugins/setpoint_accel.cpp
+++ b/mavros/src/plugins/setpoint_accel.cpp
@@ -75,13 +75,15 @@ private:
 		if (send_force)
 			ignore_all_except_a_xyz |= (1 << 9);
 
-		// ENU->NED. Issue #49.
+		// ENU->NED
+		auto accel = UAS::convert_accel(afx, afy, afz);
+
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
-				MAV_FRAME_LOCAL_NED,
+				MAV_FRAME_LOCAL_NED,	// TODO: use enum on lib
 				ignore_all_except_a_xyz,
 				0.0, 0.0, 0.0,
 				0.0, 0.0, 0.0,
-				afx, -afy, -afz,
+				accel.x(), accel.y(), accel.z(),
 				0.0, 0.0);
 	}
 

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -117,19 +117,21 @@ private:
 	/* -*- mid-level helpers -*- */
 
 	/**
-	 * Send attitude setpoint to FCU attitude controller
+	 * @brief Send attitude setpoint to FCU attitude controller
 	 *
-	 * ENU frame.
+	 * @note ENU frame.
 	 */
 	void send_attitude_transform(const tf::Transform &transform, const ros::Time &stamp) {
-		// Thrust + RPY, also bits noumbering started from 1 in docs
+		/**
+		* Thrust + RPY, also bits numbering started from 1 in docs
+		*/ 
 		const uint8_t ignore_all_except_q = (1 << 6) | (7 << 0);
 		float q[4];
 
 		tf::Quaternion tf_q = transform.getRotation();
-		
-		// ENU->NED
-		auto qt = UAS::convert_attitude_q(tf_q);
+
+		/** ENU->NED frame conversion */
+		auto qt = UAS::transform_frame_attitude_q(tf_q);
 
 		q[0] = qt.w();
 		q[1] = qt.x();
@@ -144,17 +146,19 @@ private:
 	}
 
 	/**
-	 * Send angular velocity setpoint to FCU attitude controller
+	 * @brief Send angular velocity setpoint to FCU attitude controller
 	 *
-	 * ENU frame.
+	 * @note ENU frame.
 	 */
 	void send_attitude_ang_velocity(const ros::Time &stamp, const float vx, const float vy, const float vz) {
-		// Q + Thrust, also bits noumbering started from 1 in docs
+		/**
+		 * Q + Thrust, also bits noumbering started from 1 in docs
+		 */
 		const uint8_t ignore_all_except_rpy = (1 << 7) | (1 << 6);
 		float q[4] = { 1.0, 0.0, 0.0, 0.0 };
 
-		// ENU->NED
-		auto vel = UAS::convert_velocity(vx, vy, vz);
+		/** ENU->NED frame conversion */
+		auto vel = UAS::transform_frame_general_xyz(vx, vy, vz);
 
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_rpy,
@@ -164,7 +168,7 @@ private:
 	}
 
 	/**
-	 * Send throttle to FCU attitude controller
+	 * @brief Send throttle to FCU attitude controller
 	 */
 	void send_attitude_throttle(const float throttle) {
 		// Q + RPY
@@ -216,7 +220,9 @@ private:
 	void throttle_cb(const std_msgs::Float64::ConstPtr &req) {
 		float throttle_normalized = req->data;
 
-		// note: && are lazy, is_normalized() should be called only if reverse_throttle are true.
+		/**
+		 * && are lazy, is_normalized() should be called only if reverse_throttle are true.
+		 */
 		if (reverse_throttle && !is_normalized(throttle_normalized, -1.0, 1.0))
 			return;
 		else if (!is_normalized(throttle_normalized, 0.0, 1.0))

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -126,12 +126,15 @@ private:
 		const uint8_t ignore_all_except_q = (1 << 6) | (7 << 0);
 		float q[4];
 
-		// ENU->NED, description in #49.
 		tf::Quaternion tf_q = transform.getRotation();
-		q[0] = tf_q.w();
-		q[1] = tf_q.y();
-		q[2] = tf_q.x();
-		q[3] = -tf_q.z();
+		
+		// ENU->NED
+		auto qt = UAS::convert_attitude_q(tf_q);
+
+		q[0] = qt.w();
+		q[1] = qt.x();
+		q[2] = qt.y();
+		q[3] = qt.z();
 
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_q,
@@ -150,10 +153,13 @@ private:
 		const uint8_t ignore_all_except_rpy = (1 << 7) | (1 << 6);
 		float q[4] = { 1.0, 0.0, 0.0, 0.0 };
 
+		// ENU->NED
+		auto vel = UAS::convert_velocity(vx, vy, vz);
+
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_rpy,
 				q,
-				vy, vx, -vz,
+				vel.x(), vel.y(), vel.z(),
 				0.0);
 	}
 

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -130,8 +130,7 @@ private:
 
 		tf::Quaternion tf_q = transform.getRotation();
 
-		/** ENU->NED frame conversion */
-		auto qt = UAS::transform_frame_attitude_q(tf_q);
+		auto qt = UAS::transform_frame_enu_ned_attitude_q(tf_q);
 
 		q[0] = qt.w();
 		q[1] = qt.x();
@@ -150,15 +149,14 @@ private:
 	 *
 	 * @note ENU frame.
 	 */
-	void send_attitude_ang_velocity(const ros::Time &stamp, const float vx, const float vy, const float vz) {
+	void send_attitude_ang_velocity(const ros::Time &stamp, const double vx, const double vy, const double vz) {
 		/**
 		 * Q + Thrust, also bits noumbering started from 1 in docs
 		 */
 		const uint8_t ignore_all_except_rpy = (1 << 7) | (1 << 6);
 		float q[4] = { 1.0, 0.0, 0.0, 0.0 };
 
-		/** ENU->NED frame conversion */
-		auto vel = UAS::transform_frame_general_xyz(vx, vy, vz);
+		auto vel = UAS::transform_frame_enu_ned_xyz(vx, vy, vz);
 
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_rpy,

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -102,9 +102,8 @@ private:
 			ignore_all_except_xyz_y = (1 << 11) | (7 << 6);
 		}
 
-		/** ENU->NED frame conversion */
-		auto position = UAS::transform_frame_general_xyz(origin.x(), origin.y(), origin.z());
-		auto qt = UAS::transform_frame_attitude_q(q);
+		auto position = UAS::transform_frame_enu_ned_xyz(origin.x(), origin.y(), origin.z());
+		auto qt = UAS::transform_frame_enu_ned_attitude_q(q);
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -77,33 +77,34 @@ private:
 	/* -*- mid-level helpers -*- */
 
 	/**
-	 * Send transform to FCU position controller
+	 * @brief Send transform to FCU position controller.
 	 *
-	 * Note: send only XYZ, Yaw
+	 * @warning Send only XYZ, Yaw. ENU frame.
 	 */
 	void send_setpoint_transform(const tf::Transform &transform, const ros::Time &stamp) {
 		// ENU frame
 		tf::Vector3 origin = transform.getOrigin();
 		tf::Quaternion q = transform.getRotation();
 
-		/* Documentation start from bit 1 instead 0,
-		 * Ignore velocity and accel vectors, yaw rate
+		/**
+		 * Documentation start from bit 1 instead 0;
+		 * Ignore velocity and accel vectors, yaw rate.
 		 */
 		uint16_t ignore_all_except_xyz_y = (1 << 11) | (7 << 6) | (7 << 3);
 
 		if (uas->is_px4()) {
 			/**
-			 * Current PX4 has bug: it cuts throttle if there no velocity sp
+			 * @bug Current PX4 has a bug: it cuts out throttle if there's no velocity SP
 			 * Issue #273.
 			 *
-			 * @todo Revesit this quirk later. Should be fixed in firmware.
+			 * @todo Revisit this quirk later. Should be fixed in firmware.
 			 */
 			ignore_all_except_xyz_y = (1 << 11) | (7 << 6);
 		}
 
-		// ENU->NED
-		auto position = UAS::convert_position(origin.x(), origin.y(), origin.z());
-		auto qt = UAS::convert_attitude_q(q);
+		/** ENU->NED frame conversion */
+		auto position = UAS::transform_frame_general_xyz(origin.x(), origin.y(), origin.z());
+		auto qt = UAS::transform_frame_attitude_q(q);
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -101,14 +101,17 @@ private:
 			ignore_all_except_xyz_y = (1 << 11) | (7 << 6);
 		}
 
-		// ENU->NED. Issue #49.
+		// ENU->NED
+		auto position = UAS::convert_position(origin.x(), origin.y(), origin.z());
+		auto qt = UAS::convert_attitude_q(q);
+
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,
 				ignore_all_except_xyz_y,
-				origin.x(), -origin.y(), -origin.z(),
+				position.x(), position.y(), position.z(),
 				0.0, 0.0, 0.0,
 				0.0, 0.0, 0.0,
-				tf::getYaw(q), 0.0);
+				tf::getYaw(qt), 0.0);
 	}
 
 	/* -*- callbacks -*- */

--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -57,19 +57,20 @@ private:
 	/* -*- mid-level helpers -*- */
 
 	/**
-	 * Send velocity to FCU velocity controller
+	 * @brief Send velocity to FCU velocity controller
 	 *
-	 * Note: send only VX VY VZ. ENU frame.
+	 * @warning Send only VX VY VZ. ENU frame.
 	 */
 	void send_setpoint_velocity(const ros::Time &stamp, float vx, float vy, float vz, float yaw_rate) {
-		/* Documentation start from bit 1 instead 0,
-		 * Ignore position and accel vectors, yaw
+		/**
+		 * Documentation start from bit 1 instead 0;
+		 * Ignore position and accel vectors, yaw.
 		 */
 		uint16_t ignore_all_except_v_xyz_yr = (1 << 10) | (7 << 6) | (7 << 0);
 
-		// ENU->NED
-		auto vel = UAS::convert_velocity(vx, vy, vz);
-		auto yr = UAS::convert_velocity(0.0, 0.0, yaw_rate);
+		/** ENU->NED frame conversion */
+		auto vel = UAS::transform_frame_general_xyz(vx, vy, vz);
+		auto yr = UAS::transform_frame_general_xyz(0.0, 0.0, yaw_rate);
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,

--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -61,16 +61,15 @@ private:
 	 *
 	 * @warning Send only VX VY VZ. ENU frame.
 	 */
-	void send_setpoint_velocity(const ros::Time &stamp, float vx, float vy, float vz, float yaw_rate) {
+	void send_setpoint_velocity(const ros::Time &stamp, double vx, double vy, double vz, double yaw_rate) {
 		/**
 		 * Documentation start from bit 1 instead 0;
 		 * Ignore position and accel vectors, yaw.
 		 */
 		uint16_t ignore_all_except_v_xyz_yr = (1 << 10) | (7 << 6) | (7 << 0);
 
-		/** ENU->NED frame conversion */
-		auto vel = UAS::transform_frame_general_xyz(vx, vy, vz);
-		auto yr = UAS::transform_frame_general_xyz(0.0, 0.0, yaw_rate);
+		auto vel = UAS::transform_frame_enu_ned_xyz(vx, vy, vz);
+		auto yr = UAS::transform_frame_enu_ned_xyz(0.0, 0.0, yaw_rate);
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,

--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -67,14 +67,17 @@ private:
 		 */
 		uint16_t ignore_all_except_v_xyz_yr = (1 << 10) | (7 << 6) | (7 << 0);
 
-		// ENU->NED. Issue #49.
+		// ENU->NED
+		auto vel = UAS::convert_velocity(vx, vy, vz);
+		auto yr = UAS::convert_velocity(0.0, 0.0, yaw_rate);
+
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,
 				ignore_all_except_v_xyz_yr,
 				0.0, 0.0, 0.0,
-				vx, -vy, -vz,
+				vel.x(), vel.y(), vel.z(),
 				0.0, 0.0, 0.0,
-				0.0, yaw_rate);
+				0.0, yr.z());
 	}
 
 	/* -*- callbacks -*- */

--- a/mavros_extras/src/plugins/mocap_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/mocap_pose_estimate.cpp
@@ -92,17 +92,16 @@ private:
 	{
 		float q[4];
 
-		/** ENU->NED frame conversion */
 		tf::Quaternion qo;
 		quaternionMsgToTF(pose->pose.orientation,qo);
-		auto qt = UAS::transform_frame_attitude_q(qo);
+		auto qt = UAS::transform_frame_enu_ned_attitude_q(qo);
 
 		q[0] = qt.w();
 		q[1] = qt.x();
 		q[2] = qt.y();
 		q[3] = qt.z();
 
-		auto position = UAS::transform_frame_general_xyz(
+		auto position = UAS::transform_frame_enu_ned_xyz(
 					pose->pose.position.x,
 					pose->pose.position.y,
 					pose->pose.position.z);
@@ -119,18 +118,17 @@ private:
 	{
 		float q[4];
 		
-		/** ENU->NED frame conversion */
 		tf::Transform tf;
 		transformMsgToTF(trans->transform,tf);
 		tf::Quaternion qo = tf.getRotation();
-		auto qt = UAS::transform_frame_attitude_q(qo);
+		auto qt = UAS::transform_frame_enu_ned_attitude_q(qo);
 
 		q[0] = qt.w();
 		q[1] = qt.x();
 		q[2] = qt.y();
 		q[3] = qt.z();
 
-		auto position = UAS::transform_frame_general_xyz(
+		auto position = UAS::transform_frame_enu_ned_xyz(
 					trans->transform.translation.x,
 					trans->transform.translation.y,
 					trans->transform.translation.z);

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -41,8 +41,8 @@ public:
 
 		flow_nh.param<std::string>("frame_id", frame_id, "px4flow");
 
-		//Default rangefinder is Maxbotix HRLV-EZ4
-		flow_nh.param("ranger_fov", ranger_fov, 0.0);	// TODO
+		/** Default rangefinder is Maxbotix HRLV-EZ4 */
+		flow_nh.param("ranger_fov", ranger_fov, 0.0);	/** @todo Check MAxbotix HRLV-EZ4 Field-of-View */
 		flow_nh.param("ranger_min_range", ranger_min_range, 0.3);
 		flow_nh.param("ranger_max_range", ranger_max_range, 5.0);
 
@@ -80,7 +80,9 @@ private:
 		header.stamp = ros::Time::now();
 		header.frame_id = frame_id;
 
-		/* Raw message with axes mapped to ROS conventions and temp in degrees celsius
+		/**
+		 * Raw message with axes mapped to ROS conventions and temp in degrees celsius.
+		 *
 		 * The optical flow camera is essentially an angular sensor, so conversion is like
 		 * gyroscope. (body-fixed NED -> ENU)
 		 */
@@ -91,14 +93,20 @@ private:
 
 		flow_rad_msg->integration_time_us = flow_rad.integration_time_us;
 
-		// NED->ENU
-		auto position = UAS::convert_position(flow_rad.integrated_x, flow_rad.integrated_y, 0.0);
+		/** ENU->NED frame conversion */
+		auto position = UAS::transform_frame_general_xyz(
+						flow_rad.integrated_x,
+						flow_rad.integrated_y,
+						0.0);
 
 		flow_rad_msg->integrated_x = position.x();
 		flow_rad_msg->integrated_y = position.y();
 
-		// NED->ENU
-		auto flow_gyro = UAS::convert_general_xyz(flow_rad.integrated_xgyro, flow_rad.integrated_ygyro, flow_rad.integrated_zgyro);
+		/** ENU->NED frame conversion */
+		auto flow_gyro = UAS::transform_frame_general_xyz(
+						flow_rad.integrated_xgyro,
+						flow_rad.integrated_ygyro,
+						flow_rad.integrated_zgyro);
 
 		flow_rad_msg->integrated_xgyro = flow_gyro.x();
 		flow_rad_msg->integrated_ygyro = flow_gyro.y();	
@@ -122,6 +130,14 @@ private:
 		temp_pub.publish(temp_msg);
 
 		// Rangefinder
+		/**
+		 * @todo: use distance_sensor plugin only to publish this data
+		 * (which receives DISTANCE_SENSOR msg with multiple rangefinder
+		 * sensors data)
+		 *
+		 * @todo: suggest modification on MAVLink OPTICAL_FLOW_RAD msg
+		 * which removes sonar data fields from it
+		 */
 		auto range_msg = boost::make_shared<sensor_msgs::Range>();
 
 		range_msg->header = header;

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -90,13 +90,24 @@ private:
 		flow_rad_msg->header = header;
 
 		flow_rad_msg->integration_time_us = flow_rad.integration_time_us;
-		flow_rad_msg->integrated_x = flow_rad.integrated_x;
-		flow_rad_msg->integrated_y = -flow_rad.integrated_y;	// NED -> ENU
-		flow_rad_msg->integrated_xgyro = flow_rad.integrated_xgyro;
-		flow_rad_msg->integrated_ygyro = -flow_rad.integrated_ygyro;	// NED -> ENU
-		flow_rad_msg->integrated_zgyro = -flow_rad.integrated_zgyro;	// NED -> ENU
+
+		// NED->ENU
+		auto position = UAS::convert_position(flow_rad.integrated_x, flow_rad.integrated_y, 0.0);
+
+		flow_rad_msg->integrated_x = position.x();
+		flow_rad_msg->integrated_y = position.y();
+
+		// NED->ENU
+		auto flow_gyro = UAS::convert_general_xyz(flow_rad.integrated_xgyro, flow_rad.integrated_ygyro, flow_rad.integrated_zgyro);
+
+		flow_rad_msg->integrated_xgyro = flow_gyro.x();
+		flow_rad_msg->integrated_ygyro = flow_gyro.y();	
+		flow_rad_msg->integrated_zgyro = flow_gyro.z();
+
 		flow_rad_msg->temperature = flow_rad.temperature / 100.0f;	// in degrees celsius
+
 		flow_rad_msg->time_delta_distance_us = flow_rad.time_delta_distance_us;
+
 		flow_rad_msg->distance = flow_rad.distance;
 
 		flow_rad_pub.publish(flow_rad_msg);

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -93,8 +93,7 @@ private:
 
 		flow_rad_msg->integration_time_us = flow_rad.integration_time_us;
 
-		/** ENU->NED frame conversion */
-		auto position = UAS::transform_frame_general_xyz(
+		auto position = UAS::transform_frame_enu_ned_xyz(
 						flow_rad.integrated_x,
 						flow_rad.integrated_y,
 						0.0);
@@ -102,8 +101,7 @@ private:
 		flow_rad_msg->integrated_x = position.x();
 		flow_rad_msg->integrated_y = position.y();
 
-		/** ENU->NED frame conversion */
-		auto flow_gyro = UAS::transform_frame_general_xyz(
+		auto flow_gyro = UAS::transform_frame_enu_ned_xyz(
 						flow_rad.integrated_xgyro,
 						flow_rad.integrated_ygyro,
 						flow_rad.integrated_zgyro);

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -107,7 +107,7 @@ private:
 	 */
 	void send_vision_transform(const tf::Transform &transform, const ros::Time &stamp) {
 		// origin and RPY in ENU frame
-		tf::Vector3 position = transform.getOrigin();
+		tf::Vector3 origin = transform.getOrigin();
 		double roll, pitch, yaw;
 		tf::Matrix3x3 orientation(transform.getBasis());
 		orientation.getRPY(roll, pitch, yaw);
@@ -121,10 +121,13 @@ private:
 		}
 		last_transform_stamp = stamp;
 
-		// TODO: check conversion. Issue #49.
+		// ENU->NED
+		auto position = UAS::convert_position(origin.x(), origin.y(), origin.z());
+		tf::Vector3 rpy = UAS::convert_attitude_rpy(roll, pitch, yaw);
+		
 		vision_position_estimate(stamp.toNSec() / 1000,
-				position.x(), -position.y(), -position.z(),
-				roll, -pitch, -yaw); // ??? please check!
+				position.x(), position.y(), position.z(),
+				rpy.x(), rpy.y(), rpy.z());
 	}
 
 	/* -*- callbacks -*- */

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -106,7 +106,6 @@ private:
 	 * @brief Send vision estimate transform to FCU position controller
 	 */
 	void send_vision_transform(const tf::Transform &transform, const ros::Time &stamp) {
-		/** ENU->NED frame conversion */
 		tf::Vector3 origin = transform.getOrigin();
 		double roll, pitch, yaw;
 		tf::Matrix3x3 orientation(transform.getBasis());
@@ -122,9 +121,8 @@ private:
 		}
 		last_transform_stamp = stamp;
 
-		/** ENU->NED frame conversion */
-		auto position = UAS::transform_frame_general_xyz(origin.x(), origin.y(), origin.z());
-		tf::Vector3 rpy = UAS::transform_frame_attitude_rpy(roll, pitch, yaw);
+		auto position = UAS::transform_frame_enu_ned_xyz(origin.x(), origin.y(), origin.z());
+		tf::Vector3 rpy = UAS::transform_frame_enu_ned_attitude_rpy(roll, pitch, yaw);
 		
 		vision_position_estimate(stamp.toNSec() / 1000,
 				position.x(), position.y(), position.z(),

--- a/mavros_extras/src/plugins/vision_speed_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_speed_estimate.cpp
@@ -25,8 +25,8 @@ namespace mavplugin {
 /**
  * @brief Vision speed estimate plugin
  *
- * Send speed estimation from various vision estimators
- * to FCU position controller.
+ * Send velocity estimation from various vision estimators
+ * to FCU position and attitude estimators.
  *
  */
 class VisionSpeedEstimatePlugin : public MavRosPlugin {
@@ -70,14 +70,19 @@ private:
 		UAS_FCU(uas)->send_message(&msg);
 	}
 
+	/**
+	 * @todo Suggest modification on PX4 firmware to MAVLINK VISION_SPEED_ESTIMATE
+	 * msg name, which should be called instead VISION_VELOCITY_ESTIMATE
+	 */
+
 	/* -*- mid-level helpers -*- */
 
 	/**
-	 * Send vision speed estimate to FCU velocity controller
+	 * @brief Send vision speed estimate to FCU velocity controller
 	 */
 	void send_vision_speed(float vx, float vy, float vz, const ros::Time &stamp) {
-		// ENU->NED
-		auto vel = UAS::convert_velocity(vx, vy, vz);
+		/** ENU->NED frame conversion */
+		auto vel = UAS::transform_frame_general_xyz(vx, vy, vz);
 
 		vision_speed_estimate(stamp.toNSec() / 1000,
 				vel.x(), vel.y(), vel.z());

--- a/mavros_extras/src/plugins/vision_speed_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_speed_estimate.cpp
@@ -81,8 +81,7 @@ private:
 	 * @brief Send vision speed estimate to FCU velocity controller
 	 */
 	void send_vision_speed(float vx, float vy, float vz, const ros::Time &stamp) {
-		/** ENU->NED frame conversion */
-		auto vel = UAS::transform_frame_general_xyz(vx, vy, vz);
+		auto vel = UAS::transform_frame_enu_ned_xyz(vx, vy, vz);
 
 		vision_speed_estimate(stamp.toNSec() / 1000,
 				vel.x(), vel.y(), vel.z());

--- a/mavros_extras/src/plugins/vision_speed_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_speed_estimate.cpp
@@ -76,9 +76,11 @@ private:
 	 * Send vision speed estimate to FCU velocity controller
 	 */
 	void send_vision_speed(float vx, float vy, float vz, const ros::Time &stamp) {
-		// TODO: check conversion. Issue #49.
+		// ENU->NED
+		auto vel = UAS::convert_velocity(vx, vy, vz);
+
 		vision_speed_estimate(stamp.toNSec() / 1000,
-				vy, vx, -vz);
+				vel.x(), vel.y(), vel.z());
 	}
 
 	/* -*- callbacks -*- */


### PR DESCRIPTION
Finally, after some tinkering with @blackcoder, we were able to get to the proper conversions to position and orientation between ROS ENU and PX4 NED frames.
So, as this is a common code for many plugins, I decided to create a specific lib file where all the functions for frame conversions are installed. This functions are called by the plugins to do the conversions online.
**ADD:** This PR also updates some comments and doxygen documentation on plugins.

Right now, I think I'm just missing:
- [x] Add covariance frame conversion to `uas_frame_conversions.cpp` (partially)

**Update:** Relative to covariance conversions, I'm still missing:
* Conversion to 7x7 full pose covariance matrix (attitude in quaternions instead of RPY)
* Conversion to quaternion covariance only (based on the previous)
- Note that `transform_frame_covariance_pose6x6()` can also be used to other covariances matrices, (p.e., lin_vel + RPY, ang_vel+RPY, and why not position+lin_vel since the conversion is the same - not very used)

**Update2:** I will leave the above covariances conversions to another PR.

This PR Fix #194, #148 (please continue list).