### PR TITLE
unittests: corrected outputs from conversion tests

### DIFF
--- a/mavros/test/test_frame_conv.cpp
+++ b/mavros/test/test_frame_conv.cpp
@@ -10,22 +10,43 @@
 using mavros::UAS;
 
 
-static void log_vectors(tf::Vector3 &in, tf::Vector3 &out, tf::Vector3 &expexted)
+static void log_vectors(tf::Vector3 &in, tf::Vector3 &out, tf::Vector3 &expected)
 {
 	ROS_INFO("In (x y z): %f %f %f", in.x(), in.y(), in.z());
-	ROS_INFO("Expected:   %f %f %f", expexted.x(), expexted.y(), expexted.z());
+	ROS_INFO("Expected:   %f %f %f", expected.x(), expected.y(), expected.z());
 	ROS_INFO("Out:        %f %f %f", out.x(), out.y(), out.z());
 }
 
-static void log_quaternion(tf::Quaternion &in, tf::Quaternion &out, tf::Quaternion &expexted)
+static void log_quaternion(tf::Quaternion &in, tf::Quaternion &out, tf::Quaternion &expected)
 {
 	ROS_INFO("In (x y z w): %f %f %f %f", in.x(), in.y(), in.z(), in.w());
-	ROS_INFO("Expected:     %f %f %f %f", expexted.x(), expexted.y(), expexted.z(), expexted.w());
+	ROS_INFO("Expected:     %f %f %f %f", expected.x(), expected.y(), expected.z(), expected.w());
 	ROS_INFO("Out:          %f %f %f %f", out.x(), out.y(), out.z(), out.w());
 }
 
-
 /* -*- test general Vector3 transform function -*- */
+
+TEST(VECTOR, transform_frame_xyz_100)
+{
+	tf::Vector3 input(1, 0, 0);
+	tf::Vector3 expected_out(1, 0, 0);
+
+	auto out = UAS::transform_frame_xyz(input.x(), input.y(), input.z());
+
+	log_vectors(input, out, expected_out);
+	EXPECT_EQ(expected_out, out);
+}
+
+TEST(VECTOR, transform_frame_xyz_110)
+{
+	tf::Vector3 input(1, 1, 0);
+	tf::Vector3 expected_out(1, -1, 0);
+
+	auto out = UAS::transform_frame_xyz(input.x(), input.y(), input.z());
+
+	log_vectors(input, out, expected_out);
+	EXPECT_EQ(expected_out, out);
+}
 
 TEST(VECTOR, transform_frame_xyz_111)
 {
@@ -38,57 +59,12 @@ TEST(VECTOR, transform_frame_xyz_111)
 	EXPECT_EQ(expected_out, out);
 }
 
-TEST(VECTOR, transform_frame_xyz_pi00)
-{
-	tf::Vector3 input(M_PI, 0, 0);
-	tf::Vector3 expected_out(M_PI, 0, 0);
-
-	auto out = UAS::transform_frame_xyz(input.x(), input.y(), input.z());
-
-	log_vectors(input, out, expected_out);
-	EXPECT_EQ(expected_out, out);
-}
-
-TEST(VECTOR, transform_frame_xyz_0pi0)
-{
-	tf::Vector3 input(0, M_PI, 0);
-	tf::Vector3 expected_out(0, -M_PI, 0);
-
-	auto out = UAS::transform_frame_xyz(input.x(), input.y(), input.z());
-
-	log_vectors(input, out, expected_out);
-	EXPECT_EQ(expected_out, out);
-}
-
-TEST(VECTOR, transform_frame_xyz_00pi)
-{
-	tf::Vector3 input(0, 0, M_PI);
-	tf::Vector3 expected_out(0, 0, -M_PI);
-
-	auto out = UAS::transform_frame_xyz(input.x(), input.y(), input.z());
-
-	log_vectors(input, out, expected_out);
-	EXPECT_EQ(expected_out, out);
-}
-
-
 /* -*- test attitude RPY transform -*- */
-
-TEST(VECTOR, transform_frame_attitude_rpy_111)
-{
-	tf::Vector3 input(1, 1, 1);
-	tf::Vector3 expected_out(0, -1, -1);
-
-	auto out = UAS::transform_frame_attitude_rpy(input.x(), input.y(), input.z());
-
-	log_vectors(input, out, expected_out);
-	EXPECT_EQ(expected_out, out);
-}
 
 TEST(VECTOR, transform_frame_attitude_rpy_pi00)
 {
 	tf::Vector3 input(M_PI, 0, 0);
-	tf::Vector3 expected_out(M_PI, 0, 0);
+	tf::Vector3 expected_out(2*M_PI, 0, 0);
 
 	auto out = UAS::transform_frame_attitude_rpy(input.x(), input.y(), input.z());
 
@@ -99,7 +75,7 @@ TEST(VECTOR, transform_frame_attitude_rpy_pi00)
 TEST(VECTOR, transform_frame_attitude_rpy_0pi0)
 {
 	tf::Vector3 input(0, M_PI, 0);
-	tf::Vector3 expected_out(0, -M_PI, 0);
+	tf::Vector3 expected_out(M_PI, M_PI, 0);
 
 	auto out = UAS::transform_frame_attitude_rpy(input.x(), input.y(), input.z());
 
@@ -110,7 +86,7 @@ TEST(VECTOR, transform_frame_attitude_rpy_0pi0)
 TEST(VECTOR, transform_frame_attitude_rpy_00pi)
 {
 	tf::Vector3 input(0, 0, M_PI);
-	tf::Vector3 expected_out(0, 0, -M_PI);
+	tf::Vector3 expected_out(M_PI, 0, M_PI);
 
 	auto out = UAS::transform_frame_attitude_rpy(input.x(), input.y(), input.z());
 
@@ -121,21 +97,10 @@ TEST(VECTOR, transform_frame_attitude_rpy_00pi)
 
 /* -*- test attitude quaternion transform -*- */
 
-TEST(QUATERNION,  transform_frame_attitude_q_111)
-{
-	auto input = tf::createQuaternionFromRPY(1, 1, 1);
-	auto expected_out = tf::createQuaternionFromRPY(1, -1, -1);
-
-	auto out = UAS::transform_frame_attitude_q(input);
-
-	log_quaternion(input, out, expected_out);
-	EXPECT_EQ(expected_out, out);
-}
-
 TEST(QUATERNION,  transform_frame_attitude_q_pi00)
 {
 	auto input = tf::createQuaternionFromRPY(M_PI, 0, 0);
-	auto expected_out = tf::createQuaternionFromRPY(M_PI, 0, 0);
+	auto expected_out = tf::createQuaternionFromRPY(2*M_PI, 0, 0);
 
 	auto out = UAS::transform_frame_attitude_q(input);
 
@@ -146,7 +111,7 @@ TEST(QUATERNION,  transform_frame_attitude_q_pi00)
 TEST(QUATERNION,  transform_frame_attitude_q_0pi0)
 {
 	auto input = tf::createQuaternionFromRPY(0, M_PI, 0);
-	auto expected_out = tf::createQuaternionFromRPY(0, -M_PI, 0);
+	auto expected_out = tf::createQuaternionFromRPY(M_PI, M_PI, 0);
 
 	auto out = UAS::transform_frame_attitude_q(input);
 
@@ -157,7 +122,7 @@ TEST(QUATERNION,  transform_frame_attitude_q_0pi0)
 TEST(QUATERNION,  transform_frame_attitude_q_00pi)
 {
 	auto input = tf::createQuaternionFromRPY(0, 0, M_PI);
-	auto expected_out = tf::createQuaternionFromRPY(0, 0, -M_PI);
+	auto expected_out = tf::createQuaternionFromRPY(M_PI, 0, M_PI);
 
 	auto out = UAS::transform_frame_attitude_q(input);
 


### PR DESCRIPTION
Full test run. Output positive:
```bash
Linking CXX shared library libgtest.so
[ 96%] Built target gtest
Scanning dependencies of target gtest_main
[ 96%] Building CXX object gtest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
Linking CXX shared library libgtest_main.so
[ 96%] Built target gtest_main
Scanning dependencies of target libmavros-frame-test
[100%] Building CXX object CMakeFiles/libmavros-frame-test.dir/test/test_frame_conv.cpp.o
Linking CXX executable /home/nuno/AIMAV_Project/devel/lib/mavros/libmavros-frame-test
[100%] Built target libmavros-frame-test
Scanning dependencies of target tests
[100%] Built target tests
Scanning dependencies of target _run_tests_mavros_gtest_libmavros-frame-test
-- run_tests.py: execute commands
  /home/nuno/AIMAV_Project/devel/lib/mavros/libmavros-frame-test --gtest_output=xml:/home/nuno/AIMAV_Project/build/mavros/test_results/mavros/gtest-libmavros-frame-test.xml
[==========] Running 9 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 6 tests from VECTOR
[ RUN      ] VECTOR.transform_frame_xyz_100
[ INFO] [1435605104.217576176]: In (x y z): 1.000000 0.000000 0.000000
[ INFO] [1435605104.217623970]: Expected:   1.000000 0.000000 0.000000
[ INFO] [1435605104.217640370]: Out:        1.000000 -0.000000 -0.000000
[       OK ] VECTOR.transform_frame_xyz_100 (0 ms)
[ RUN      ] VECTOR.transform_frame_xyz_110
[ INFO] [1435605104.217692461]: In (x y z): 1.000000 1.000000 0.000000
[ INFO] [1435605104.217707326]: Expected:   1.000000 -1.000000 0.000000
[ INFO] [1435605104.217720113]: Out:        1.000000 -1.000000 -0.000000
[       OK ] VECTOR.transform_frame_xyz_110 (0 ms)
[ RUN      ] VECTOR.transform_frame_xyz_111
[ INFO] [1435605104.217752577]: In (x y z): 1.000000 1.000000 1.000000
[ INFO] [1435605104.217765726]: Expected:   1.000000 -1.000000 -1.000000
[ INFO] [1435605104.217777696]: Out:        1.000000 -1.000000 -1.000000
[       OK ] VECTOR.transform_frame_xyz_111 (0 ms)
[ RUN      ] VECTOR.transform_frame_attitude_rpy_pi00
[ INFO] [1435605104.217809236]: In (x y z): 3.141593 0.000000 0.000000
[ INFO] [1435605104.217822098]: Expected:   6.283185 0.000000 0.000000
[ INFO] [1435605104.217834954]: Out:        6.283185 0.000000 0.000000
[       OK ] VECTOR.transform_frame_attitude_rpy_pi00 (0 ms)
[ RUN      ] VECTOR.transform_frame_attitude_rpy_0pi0
[ INFO] [1435605104.217865135]: In (x y z): 0.000000 3.141593 0.000000
[ INFO] [1435605104.217877634]: Expected:   3.141593 3.141593 0.000000
[ INFO] [1435605104.217890325]: Out:        3.141593 3.141593 0.000000
[       OK ] VECTOR.transform_frame_attitude_rpy_0pi0 (0 ms)
[ RUN      ] VECTOR.transform_frame_attitude_rpy_00pi
[ INFO] [1435605104.217919810]: In (x y z): 0.000000 0.000000 3.141593
[ INFO] [1435605104.217932535]: Expected:   3.141593 0.000000 3.141593
[ INFO] [1435605104.217944423]: Out:        3.141593 0.000000 3.141593
[       OK ] VECTOR.transform_frame_attitude_rpy_00pi (0 ms)
[----------] 6 tests from VECTOR (0 ms total)

[----------] 3 tests from QUATERNION
[ RUN      ] QUATERNION.transform_frame_attitude_q_pi00
[ INFO] [1435605104.218031323]: In (x y z w): 1.000000 0.000000 0.000000 0.000000
[ INFO] [1435605104.218051134]: Expected:     0.000000 0.000000 -0.000000 -1.000000
[ INFO] [1435605104.218066406]: Out:          0.000000 0.000000 0.000000 -1.000000
[       OK ] QUATERNION.transform_frame_attitude_q_pi00 (1 ms)
[ RUN      ] QUATERNION.transform_frame_attitude_q_0pi0
[ INFO] [1435605104.218105369]: In (x y z w): 0.000000 1.000000 0.000000 0.000000
[ INFO] [1435605104.218120279]: Expected:     0.000000 0.000000 -1.000000 0.000000
[ INFO] [1435605104.218133863]: Out:          0.000000 0.000000 -1.000000 0.000000
[       OK ] QUATERNION.transform_frame_attitude_q_0pi0 (0 ms)
[ RUN      ] QUATERNION.transform_frame_attitude_q_00pi
[ INFO] [1435605104.218168127]: In (x y z w): 0.000000 0.000000 1.000000 0.000000
[ INFO] [1435605104.218182441]: Expected:     0.000000 1.000000 0.000000 0.000000
[ INFO] [1435605104.218194887]: Out:          0.000000 1.000000 0.000000 0.000000
[       OK ] QUATERNION.transform_frame_attitude_q_00pi (0 ms)
[----------] 3 tests from QUATERNION (1 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 2 test cases ran. (1 ms total)
[  PASSED  ] 9 tests.
-- run_tests.py: verify result "/home/nuno/AIMAV_Project/build/mavros/test_results/mavros/gtest-libmavros-frame-test.xml"
[100%] Built target _run_tests_mavros_gtest_libmavros-frame-test
Scanning dependencies of target _run_tests_mavros_gtest
[100%] Built target _run_tests_mavros_gtest
Scanning dependencies of target _run_tests_mavros
[100%] Built target _run_tests_mavros
Scanning dependencies of target run_tests
[100%] Built target run_tests
```