### PR TITLE
Unittests to covariance

### DIFF
--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -306,9 +306,10 @@ public:
 
 	/**
 	 * @brief Function to convert general XYZ values from ENU to NED frames
-	 * @param _x: X coordinate value
-	 * @param _y: Y coordinate value
-	 * @param _z: Z coordinate value
+	 * @param _x: X coordinate/direction value
+	 * @param _y: Y coordinate/direction value
+	 * @param _z: Z coordinate/direction value
+	 * @return Translated XYZ values in NED frame
 	 */
 	static inline tf::Vector3 transform_frame_enu_ned_xyz(double _x, double _y, double _z){
 		return transform_frame_xyz(_x, _y, _z);
@@ -319,6 +320,7 @@ public:
 	 * @param _x: X coordinate value
 	 * @param _y: Y coordinate value
 	 * @param _z: Z coordinate value
+	 * @return Translated XYZ values in ENU frame
 	 */
 	static inline tf::Vector3 transform_frame_ned_enu_xyz(double _x, double _y, double _z){
 		return transform_frame_xyz(_x, _y, _z);
@@ -327,6 +329,7 @@ public:
 	/**
 	 * @brief Function to convert attitude quaternion values from ENU to NED frames
 	 * @param qo: tf::Quaternion format
+	 * @return Rotated Quaternion values in NED frame
 	 */
 	static inline tf::Quaternion transform_frame_enu_ned_attitude_q(tf::Quaternion qo){
 		return transform_frame_attitude_q(qo);
@@ -335,6 +338,7 @@ public:
 	/**
 	 * @brief Function to convert attitude quaternion values from NED to ENU frames
 	 * @param qo: tf::Quaternion format
+	 * @return Rotated Quaternion values in ENU frame
 	 */
 	static inline tf::Quaternion transform_frame_ned_enu_attitude_q(tf::Quaternion qo){
 		return transform_frame_attitude_q(qo);
@@ -345,6 +349,7 @@ public:
 	 * @param _roll: Roll value
 	 * @param _pitch: Pitch value
 	 * @param _yaw: Yaw value
+	 * @return Rotated RPY angles values in NED frame
 	 */
 	static inline tf::Vector3 transform_frame_enu_ned_attitude_rpy(double _roll, double _pitch, double _yaw){
 		return transform_frame_attitude_rpy(_roll, _pitch, _yaw);
@@ -355,6 +360,7 @@ public:
 	 * @param _roll: Roll value
 	 * @param _pitch: Pitch value
 	 * @param _yaw: Yaw value
+	 * @return Rotated RPY angles values in ENU frame
 	 */
 	static inline tf::Vector3 transform_frame_ned_enu_attitude_rpy(double _roll, double _pitch, double _yaw){
 		return transform_frame_attitude_rpy(_roll, _pitch, _yaw);
@@ -364,6 +370,7 @@ public:
 	 * @brief Function to convert full 6D pose covariance matrix values from ENU to NED frames
 	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw.
 	 * @param _covariance: 6x6 double precision covariance matrix
+	 * @return Propagated 6x6 covariance matrix in NED frame, if _covariance[0] != -1
 	 */
 	static inline Covariance6x6 transform_frame_enu_ned_covariance_pose6x6(Covariance6x6 _covariance){
 		return transform_frame_covariance_pose6x6(_covariance);
@@ -373,6 +380,7 @@ public:
 	 * @brief Function to convert full 6D pose covariance matrix values from NED to ENU frames
 	 * @details Full 6D pose covariance matrix format: a 3D position plus three attitude angles: roll, pitch and yaw.
 	 * @param _covariance: 6x6 double precision covariance matrix
+	 * @return Propagated 6x6 covariance matrix in ENU frame, if _covariance[0] != -1
 	 */
 	static inline Covariance6x6 transform_frame_ned_enu_covariance_pose6x6(Covariance6x6 _covariance){
 		return transform_frame_covariance_pose6x6(_covariance);
@@ -388,12 +396,12 @@ public:
 	 *              | cov_Yx cov_Yy cov_Yz cov_YZ var_Y  cov_YX |
 	 *              | cov_Xx cov_Xy cov_Xz cov_XZ cov_XY var_X  |
 	 *
-	 * Rot_matrix = | 1	 0	 0	 0	 0	 0 |
-	 *              | 0	-1       0	 0	 0	 0 |
-	 *              | 0	 0	-1	 0	 0	 0 |
-	 *              | 0	 0	 0	 1	 0	 0 |
-	 *              | 0	 0	 0	 0	-1	 0 |
-	 *              | 0	 0	 0	 0	 0	-1 |
+	 * Transf_matrix = | 1	 0	 0	 0	 0	 0 |
+	 *                 | 0	-1       0	 0	 0	 0 |
+	 *                 | 0	 0	-1	 0	 0	 0 |
+	 *                 | 0	 0	 0	 1	 0	 0 |
+	 *                 | 0	 0	 0	 0	-1	 0 |
+	 *                 | 0	 0	 0	 0	 0	-1 |
 	 *
 	 * Compute Covariance matrix in another frame: (according to the law of propagation of covariance)
 	 *
@@ -403,6 +411,7 @@ public:
 	/**
 	 * @brief Function to convert position, linear acceleration, angular velocity or attitude RPY covariance matrix values from ENU to NED frames
 	 * @param _covariance: 3x3 double precision covariance matrix
+	 * @return Propagated 3x3 covariance matrix in NED frame, if _covariance[0] != -1
 	 */
 	static inline Covariance3x3 transform_frame_covariance_enu_ned_general3x3(Covariance3x3 _covariance){
 		return transform_frame_covariance_general3x3(_covariance);
@@ -411,6 +420,7 @@ public:
 	/**
 	 * @brief Function to convert position, linear acceleration, angular velocity or attitude RPY covariance matrix values from NED to ENU frames
 	 * @param _covariance: 3x3 double precision covariance matrix
+	 * @return Propagated 3x3 covariance matrix in ENU frame, if _covariance[0] != -1
 	 */
 	static inline Covariance3x3 transform_frame_covariance_ned_enu_general3x3(Covariance3x3 _covariance){
 		return transform_frame_covariance_general3x3(_covariance);
@@ -431,7 +441,7 @@ public:
 	 *                      | cov_YZ var_Y  cov_YX |
 	 *                      | cov_XZ cov_XY var_X  |
 	 *
-	 * Note that for ROS<->ENU frame transformations, the rotation matrix is the same for position and attitude.
+	 * Note that for ROS<->ENU frame transformations, the transformation matrix is the same for position and attitude.
 	 *
 	 * Rot_matrix = | 1	 0	 0 |
 	 *              | 0	-1       0 |
@@ -439,7 +449,7 @@ public:
 	 *
 	 * Compute Covariance matrix in another frame: (according to the law of propagation of covariance)
 	 *
-	 *                      C' = R * C * R^T
+	 *                      C' = T * C * T^t
 	 */
 
 private:

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -65,7 +65,8 @@ UAS::Covariance6x6 UAS::transform_frame_covariance_pose6x6(UAS::Covariance6x6 &_
 	 * element 0 of the associated covariance matrix to is -1; So no transformation has be applied,
 	 * as the covariance is invalid/unknown; so, it returns the same cov matrix without transformation.
 	 */
-	if (rotation.at(0) != -1) {
+	if (_covariance.at(0) != -1) {
+		// XXX this doesn't multiply matrices correctly. We need Eigen on code!
 		std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
 		std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
 		return covariance;
@@ -95,6 +96,7 @@ UAS::Covariance3x3 UAS::transform_frame_covariance_general3x3(UAS::Covariance3x3
 	 * as the covariance is invalid/unknown; so, it returns the same cov matrix without transformation.
 	 */
 	if (_covariance.at(0) != -1) {
+		// XXX this doesn't multiply matrices correctly. We need Eigen on code!
 		std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
 		std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
 		return covariance;

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -56,14 +56,24 @@ UAS::Covariance6x6 UAS::transform_frame_covariance_pose6x6(UAS::Covariance6x6 &_
 	};
 
 	UAS::Covariance6x6 covariance;
-	UAS::Covariance6x6 temp;		// temporary matrix = R * C
+	UAS::Covariance6x6 temp;		// temporary matrix = T * C
 
-	// The rotation matrix in this case is a diagonal matrix so R = R^T
+	// The transformation matrix in this case is a orthogonal matrix so T = T^t
 
-	std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
-	std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
-
-	return covariance;
+	/**
+	 * @note According to ROS convention, if one has no estimate for one of the data elements,
+	 * element 0 of the associated covariance matrix to is -1; So no transformation has be applied,
+	 * as the covariance is invalid/unknown; so, it returns the same cov matrix without transformation.
+	 */
+	if (rotation.at(0) != -1) {
+		std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
+		std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
+		return covariance;
+	}
+	else {
+		_covariance.at(0) = -1;
+		return _covariance;
+	}
 }
 
 UAS::Covariance3x3 UAS::transform_frame_covariance_general3x3(UAS::Covariance3x3 &_covariance)
@@ -75,12 +85,21 @@ UAS::Covariance3x3 UAS::transform_frame_covariance_general3x3(UAS::Covariance3x3
 	};
 
 	UAS::Covariance3x3 covariance;
-	UAS::Covariance3x3 temp;		// temporary matrix = R * C
+	UAS::Covariance3x3 temp;		// temporary matrix = T * C
 
-	// The rotation matrix in this case is a diagonal matrix so R = R^T
+	// The transformation matrix in this case is a orthogonal matrix so T = T^t
 
-	std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
-	std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
-
-	return covariance;
+	/**
+	 * @note According to ROS convention, if one has no estimate for one of the data elements,
+	 * element 0 of the associated covariance matrix to is -1; So no transformation has be applied,
+	 * as the covariance is invalid/unknown; so, it returns the same cov matrix without transformation.
+	 */
+	if (_covariance.at(0) != -1) {
+		std::transform(rotation.begin(), rotation.end(), _covariance.begin(), temp.begin(), std::multiplies<double>());
+		std::transform(temp.begin(), temp.end(), rotation.begin(), covariance.begin(), std::multiplies<double>());
+		return covariance;
+	}
+	else {
+		return _covariance;
+	}
 }

--- a/mavros/test/test_frame_conv.cpp
+++ b/mavros/test/test_frame_conv.cpp
@@ -64,7 +64,7 @@ TEST(VECTOR, transform_frame_xyz_111)
 TEST(VECTOR, transform_frame_attitude_rpy_pi00)
 {
 	tf::Vector3 input(M_PI, 0, 0);
-	tf::Vector3 expected_out(2*M_PI, 0, 0);
+	tf::Vector3 expected_out(2 * M_PI, 0, 0);
 
 	auto out = UAS::transform_frame_attitude_rpy(input.x(), input.y(), input.z());
 
@@ -94,13 +94,12 @@ TEST(VECTOR, transform_frame_attitude_rpy_00pi)
 	EXPECT_EQ(expected_out, out);
 }
 
-
 /* -*- test attitude quaternion transform -*- */
 
 TEST(QUATERNION,  transform_frame_attitude_q_pi00)
 {
 	auto input = tf::createQuaternionFromRPY(M_PI, 0, 0);
-	auto expected_out = tf::createQuaternionFromRPY(2*M_PI, 0, 0);
+	auto expected_out = tf::createQuaternionFromRPY(2 * M_PI, 0, 0);
 
 	auto out = UAS::transform_frame_attitude_q(input);
 

--- a/mavros/test/test_frame_conv.cpp
+++ b/mavros/test/test_frame_conv.cpp
@@ -24,6 +24,48 @@ static void log_quaternion(tf::Quaternion &in, tf::Quaternion &out, tf::Quaterni
 	ROS_INFO("Out:          %f %f %f %f", out.x(), out.y(), out.z(), out.w());
 }
 
+static std::string log_v(UAS::Covariance6x6 &cov, int n)
+{
+	std::stringstream cov_stream;
+	std::string cov_mtrx_ln;
+	for (int i=n-5; i<=n ; i++)
+	{
+		if (i == 35)
+			cov_stream << cov.at(i);
+		else
+			cov_stream << cov.at(i)<< "\t";
+	}
+	cov_mtrx_ln = cov_stream.str();
+	return cov_mtrx_ln;
+}
+
+static void log_covariance6x6(UAS::Covariance6x6 &in, UAS::Covariance6x6 &out, UAS::Covariance6x6 &expected)
+{
+	ROS_INFO("\n\tIn (6x6 Covariance Matrix):\n\t{%s\n\t %s\n\t %s\n\t %s\n\t %s\n\t %s}",
+						log_v(in,5).c_str(),
+						log_v(in,11).c_str(),
+						log_v(in,17).c_str(),
+						log_v(in,23).c_str(),
+						log_v(in,29).c_str(),
+						log_v(in,35).c_str());
+
+	ROS_INFO("\n\tExpected:\n\t{%s\n\t %s\n\t %s\n\t %s\n\t %s\n\t %s}",
+						log_v(expected,5).c_str(),
+						log_v(expected,11).c_str(),
+						log_v(expected,17).c_str(),
+						log_v(expected,23).c_str(),
+						log_v(expected,29).c_str(),
+						log_v(expected,35).c_str());
+
+	ROS_INFO("\n\tOut:\n\t{%s\n\t %s\n\t %s\n\t %s\n\t %s\n\t %s}",
+						log_v(out,5).c_str(),
+						log_v(out,11).c_str(),
+						log_v(out,17).c_str(),
+						log_v(out,23).c_str(),
+						log_v(out,29).c_str(),
+						log_v(out,35).c_str());
+}
+
 /* -*- test general Vector3 transform function -*- */
 
 TEST(VECTOR, transform_frame_xyz_100)
@@ -129,6 +171,36 @@ TEST(QUATERNION,  transform_frame_attitude_q_00pi)
 	EXPECT_EQ(expected_out, out);
 }
 
+/* -*- test covariance transform -*- */
+
+TEST(COVARIANCE6X6,  transform_frame_covariance_pose6x6_sample1)
+{
+	UAS::Covariance6x6 test = {
+		176.75,    1E-6,      1E-6,  1E-6,   4.14,  1E-6,
+		1E-6,    1748.8,      1E-6,   2.1,   1E-6,  1E-6,
+		1E-6,      1E-6,  11447.14,  1E-6,   4.17,  1E-6,
+		1E-6,       2.1,      1E-6, 10001,   1E-6,  1E-6,
+		4.14,      1E-6,      4.17,  1E-6,  14111,  1E-6,
+		1E-6,      1E-6,      1E-6,  1E-6,   1E-6,   101
+	};
+
+	UAS::Covariance6x6 exp_out = { // XXX Still have to confirm this output
+		176.75,    -1E-6,      -1E-6,  -1E-6,   -4.14,  -1E-6,
+		-1E-6,    1748.8,      -1E-6,   -2.1,   -1E-6,   1E-6,
+		-1E-6,     -1E-6,   11447.14,   1E-6,    4.17,   1E-6,
+		-1E-6,      -2.1,       1E-6,  10001,    1E-6,   1E-6,
+		-4.14,      1E-6,       4.17,   1E-6,   14111,   1E-6,
+		-1E-6,      1E-6,       1E-6,   1E-6,    1E-6,    101
+	};
+
+	auto input = test;
+	auto expected_out = exp_out;
+
+	auto out = UAS::transform_frame_covariance_pose6x6(input);
+
+	log_covariance6x6(input, out, expected_out);
+	EXPECT_EQ(expected_out, out);
+}
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
* Updates to covariance calculation description
**Conclusion from inspection:** we need **Eigen** on code cause `std::transform` doesn't do matrix calculation, it is just multiplying each array element by each other and add it to the new array.
* added uinttest for Covariance conversion test; have to confirm the output but can't have a proper one without eigen. 