### PR TITLE
Fixed bug in send_attitude_target()

### DIFF
--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -119,10 +119,17 @@ private:
 		// Eigen use same convention as mavlink: w x y z
 		Eigen::Map<Eigen::Quaternionf> q_out(q);
 		q_out = UAS::transform_frame_enu_ned(Eigen::Quaterniond(tr.rotation())).cast<float>();
+		
+		float q_transformed[4];
+		
+		q_transformed[0] = q_out.w();
+		q_transformed[1] = q_out.x();
+		q_transformed[2] = q_out.y();
+		q_transformed[3] = q_out.z();
 
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_q,
-				q,
+				q_transformed,
 				0.0, 0.0, 0.0,
 				0.0);
 	}


### PR DESCRIPTION
The transformed quaternion wasn't being passed to set_attitude_target(), resulting in an incorrect attitude setpoint. I've now fixed this issue.