### PR TITLE
[distance_sensor] fix orientation empty error

### DIFF
--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -334,7 +334,7 @@ DistanceSensorItem::Ptr DistanceSensorItem::create_item(DistanceSensorPlugin *ow
 	else {
 		// subscriber params
 		// orientation is required
-		if (!orientation_str.empty()) {
+		if (orientation_str.empty()) {
 			ROS_ERROR_NAMED("distance_sensor", "DS: %s: orientation not set!", topic_name.c_str());
 			p.reset(); return p;	// nullptr
 		}


### PR DESCRIPTION
Basically the distance_sensor plugin could never initialize with the subscribers defined in the config.