### PR TITLE
opencv 3.0/2.4 header compatibility

### DIFF
--- a/mavros_extras/src/gcs_image_bridge.cpp
+++ b/mavros_extras/src/gcs_image_bridge.cpp
@@ -23,8 +23,7 @@
 #include <sensor_msgs/image_encodings.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
 
 using namespace mavros;
 using namespace mavconn;

--- a/mavros_extras/src/plugins/image_pub.cpp
+++ b/mavros_extras/src/plugins/image_pub.cpp
@@ -20,8 +20,7 @@
 #include <sensor_msgs/image_encodings.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
 
 namespace mavplugin {
 namespace enc = sensor_msgs::image_encodings;


### PR DESCRIPTION
New stable release of opencv v3.0 includes some header changes. These changes, are retro-compatible with previous stable version 2.4, so they should be safe on both versions.