### PR TITLE
add MANUAL_CONTROL mavlink message publisher as a new plugin

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(mavros_plugins
   src/plugins/vfr_hud.cpp
   src/plugins/ftp.cpp
   src/plugins/actuator_control.cpp
+  src/plugins/manual_controls.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/launch/px4_pluginlists.yaml
+++ b/mavros/launch/px4_pluginlists.yaml
@@ -5,6 +5,10 @@ plugin_blacklist:
 - image_pub
 - vibration
 - distance_sensor
+#- setpoint_position
+- setpoint_accel
+- setpoint_velocity
+- actuator_control
 
 plugin_whitelist: []
 #- 'sys_*'

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -56,5 +56,8 @@
 	<class name="actuator_control" type="mavplugin::ActuatorControlPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Send direct controls values to the actuators</description>
 	</class>
+  <class name="manual_controls" type="mavplugin::ManualControlsPlugin" base_class_type="mavplugin::MavRosPlugin">
+    <description>Publish manual control values</description>
+  </class>
 </library>
 

--- a/mavros/scripts/mavparam
+++ b/mavros/scripts/mavparam
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim:set ts=4 sw=4 et:
 #
 # Copyright 2014 Vladimir Ermakov.

--- a/mavros/scripts/mavsafety
+++ b/mavros/scripts/mavsafety
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim:set ts=4 sw=4 et:
 #
 # Copyright 2014 Vladimir Ermakov.

--- a/mavros/scripts/mavsys
+++ b/mavros/scripts/mavsys
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim:set ts=4 sw=4 et:
 #
 # Copyright 2014 Vladimir Ermakov.

--- a/mavros/src/plugins/manual_controls.cpp
+++ b/mavros/src/plugins/manual_controls.cpp
@@ -1,0 +1,70 @@
+/**
+ * @brief ManualControls plugin
+ * @file manual_controls.cpp
+ * @author Matias Nitsche <mnitsche@dc.uba.ar>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <pluginlib/class_list_macros.h>
+
+#include <mavros_msgs/ManualControls.h>
+
+namespace mavplugin {
+/**
+ * @brief Manual Controls plugin
+ */
+class ManualControlsPlugin : public MavRosPlugin {
+public:
+  ManualControlsPlugin() :
+    rc_nh("~manual_controls"),
+    uas(nullptr)
+	{ };
+
+	void initialize(UAS &uas_)
+	{
+		uas = &uas_;
+
+    controls_pub = rc_nh.advertise<mavros_msgs::ManualControls>("controls", 10);
+    //uas->sig_connection_changed.connect(boost::bind(&RCIOPlugin::connection_cb, this, _1));
+	};
+
+	const message_map get_rx_handlers() {
+		return {
+             MESSAGE_HANDLER(MAVLINK_MSG_ID_MANUAL_CONTROL, &ManualControlsPlugin::handle_manual_control),
+		};
+	}
+
+private:
+	ros::NodeHandle rc_nh;
+	UAS *uas;
+
+  ros::Publisher controls_pub;
+
+	/* -*- rx handlers -*- */
+
+  void handle_manual_control(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
+    mavlink_manual_control_t manual_control;
+    mavlink_msg_manual_control_decode(msg, &manual_control);
+
+    mavros_msgs::ManualControls manual_controls_ros;
+    manual_controls_ros.header.stamp = ros::Time::now(); // correct?
+    manual_controls_ros.x = manual_control.x;
+    manual_controls_ros.y = manual_control.y;
+    manual_controls_ros.z = manual_control.z;
+    manual_controls_ros.r = manual_control.r;
+
+		controls_pub.publish(manual_controls_ros);
+	}
+};
+};	// namespace mavplugin
+
+PLUGINLIB_EXPORT_CLASS(mavplugin::ManualControlsPlugin, mavplugin::MavRosPlugin)
+

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim:set ts=4 sw=4 et:
 #
 # Copyright 2014 Vladimir Ermakov.

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_message_files(
   OpticalFlowRad.msg
   OverrideRCIn.msg
   ParamValue.msg
+  ManualControls.msg
   RCIn.msg
   RCOut.msg
   RadioStatus.msg

--- a/mavros_msgs/msg/ManualControls.msg
+++ b/mavros_msgs/msg/ManualControls.msg
@@ -1,0 +1,7 @@
+# Manual Control state, all values [-1000,1000]
+std_msgs/Header header
+int16 x
+int16 y
+int16 z
+int16 r
+# buttons is unused, pixhawk does not publish anything here


### PR DESCRIPTION
I've created a new plugin which simply publishes the MANUAL_CONTROL mavlink as a ROS message. This is a little easier to use than the raw RC input.

I would like to also receive switches states (such as AUX1, ...) but it appears the pixhawk does not publish these, AFAIK.