### PR TITLE
Mavros library depends on mavros_msgs headers

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(mavros
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
 )
+add_dependencies(mavros mavros_msgs_generate_messages_cpp)
 
 add_library(mavros_plugins
   src/plugins/dummy.cpp


### PR DESCRIPTION
Adding this dependency makes sure that mavros_msgs message headers are generated before the mavros library is built, since it needs those headers.

Otherwise you get intermittent build errors when building using multiple catkin_make threads, such as:
```
[  4%] Building CXX object third_party/mavros/mavros/CMakeFiles/mavros.dir/src/lib/uas_data.cpp.o
In file included from /home/odroid/ros/src/third_party/mavros/mavros/include/mavros/utils.h:21:0,
                 from /home/odroid/ros/src/third_party/mavros/mavros/src/lib/uas_data.cpp:18:
/home/odroid/ros/src/third_party/mavros/mavros_msgs/include/mavros_msgs/mavlink_convert.h:17:33: fatal error: mavros_msgs/Mavlink.h: No such file or directory
 #include <mavros_msgs/Mavlink.h>
                                 ^
compilation terminated.
```