### PR TITLE
Added velocity output of FCU's local position estimate to local_position plugin

### DIFF
--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -41,15 +41,14 @@ public:
 		uas = &uas_;
 
 		// general params
-		
 		lp_nh.param<std::string>("frame_id", frame_id, "fcu");
 		// tf subsection
 		lp_nh.param("tf/send", tf_send, true);
 		lp_nh.param<std::string>("tf/frame_id", tf_frame_id, "local_origin");
 		lp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "fcu");
 
-		local_position = lp_nh.advertise<geometry_msgs::PoseStamped>("local/position", 10);
-		local_velocity = lp_nh.advertise<geometry_msgs::TwistStamped>("local/velocity", 10);
+		local_position = lp_nh.advertise<geometry_msgs::PoseStamped>("pose", 10);
+		local_velocity = lp_nh.advertise<geometry_msgs::TwistStamped>("velocity", 10);
 	}
 
 	const message_map get_rx_handlers() {


### PR DESCRIPTION
This adds a TwistStamped velocity topic to the output of the local_position node.  The velocity messages contains a vector3 of linear velocities in the ENU frame and a vector3 of the angular velocitires in the ENU frame.  Note that the angular velocity is expressed in the ENU frame for consistency though I would venture to guess people will quite possibly confuse this.  I'd be happy to change it to the body frame if people think that is best.  

The published topics of the plugin are now:
local_position/local/position(geometry_msgs/PoseStamped)
local_position/local/velocity(geometry_msgs/TwistStamped)