### PR TITLE
WIP: transform yaw and yaw rate from ENU to NED

### DIFF
--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -449,6 +449,20 @@ public:
 		return transform_frame(in);
 	}
 
+	/**
+	 * @brief Transform heading from ROS to FCU frame.
+	 */
+	static inline double transform_frame_yaw_enu_ned(double yaw) {
+		return transform_frame_yaw(yaw);
+	}
+
+	/**
+	 * @brief Transform heading from FCU to ROS frame.
+	 */
+	static inline double transform_frame_yaw_ned_enu(double yaw) {
+		return transform_frame_yaw(yaw);
+	}
+
 private:
 	std::recursive_mutex mutex;
 
@@ -473,5 +487,9 @@ private:
 
 	std::atomic<bool> fcu_caps_known;
 	std::atomic<uint64_t> fcu_capabilities;
+
+	static inline double transform_frame_yaw(double yaw) {
+		return -yaw;
+	}
 };
 };	// namespace mavros


### PR DESCRIPTION
@vooon My integration tests found a bug in `setpoint_raw`. In `setpoint_position` the orientation (quaternion) is handled by the transform methods. But we don't have a Q in `setpoint_raw`, we just copy yaw/yaw_rate. It needs to be inverted. I only changed it for `local_cb` to test and to show you, do you have a suggestion how to fix this properly? I'm a little lost on the transformation templates ;)
