### PR TITLE
Use safe methods to get IMU data in local_position plugin

### DIFF
--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -207,6 +207,12 @@ public:
 	 */
 	geometry_msgs::Quaternion get_attitude_orientation();
 
+	/**
+	 * @brief Get angular velocity from IMU data
+	 * @return vector3
+	 */
+	geometry_msgs::Vector3 get_attitude_angular_velocity();
+
 
 	/* -*- GPS data -*- */
 

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -112,6 +112,19 @@ geometry_msgs::Quaternion UAS::get_attitude_orientation()
 	}
 }
 
+geometry_msgs::Vector3 UAS::get_attitude_angular_velocity()
+{
+	lock_guard lock(mutex);
+	if (imu_data)
+		return imu_data->angular_velocity;
+	else {
+		// fallback
+		geometry_msgs::Vector3 v;
+		v.x = v.y = v.z = 0.0;
+		return v;
+	}
+}
+
 
 /* -*- GPS data -*- */
 

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -75,7 +75,8 @@ private:
 
 		auto position = UAS::transform_frame_ned_enu(Eigen::Vector3d(pos_ned.x, pos_ned.y, pos_ned.z));
 		auto velocity = UAS::transform_frame_ned_enu(Eigen::Vector3d(pos_ned.vx, pos_ned.vy, pos_ned.vz));
-		auto imu_data = uas->get_attitude_imu();
+		auto orientation = uas->get_attitude_orientation();
+		auto angular_velocity = uas->get_attitude_angular_velocity();
 
 		auto pose = boost::make_shared<geometry_msgs::PoseStamped>();
 		auto twist = boost::make_shared<geometry_msgs::TwistStamped>();
@@ -84,10 +85,10 @@ private:
 		twist->header = pose->header;
 
 		tf::pointEigenToMsg(position, pose->pose.position);
-		pose->pose.orientation = imu_data->orientation;
+		pose->pose.orientation = orientation;
 
 		tf::vectorEigenToMsg(velocity,twist->twist.linear);
-		twist->twist.angular = imu_data->angular_velocity;
+		twist->twist.angular = angular_velocity;
 		
 		local_position.publish(pose);
 		local_velocity.publish(twist);
@@ -99,7 +100,7 @@ private:
 			transform.header.frame_id = tf_frame_id;
 			transform.child_frame_id = tf_child_frame_id;
 
-			transform.transform.rotation = imu_data->orientation;
+			transform.transform.rotation = orientation;
 			tf::vectorEigenToMsg(position, transform.transform.translation);
 
 			uas->tf2_broadcaster.sendTransform(transform);


### PR DESCRIPTION
Fixes #432
@scott-eddy : your latest change in the `local_position` plugin introduced a race condition that was previously handled by using "safe" methods to get the IMU data from `uas`.
@vooon: This PR adds another fallback method for velocity if that's your preferred solution. @scott-eddy it would probably be good if you give this a test.