### PR TITLE
Added Optitrack Motive full compatibility to mocap position

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -120,6 +120,8 @@ mocap:
   # select mocap source
   use_tf: false   # ~mocap/tf
   use_pose: true  # ~mocap/pose
+  # select Optitrack Motive coordinates
+  use_motive_zxy: false # Set true if you use Motive
 
 # px4flow
 px4flow:

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -149,6 +149,8 @@ mocap:
   # select mocap source
   use_tf: false   # ~mocap/tf
   use_pose: true  # ~mocap/pose
+  # select Optitrack Motive coordinates
+  use_motive_zxy: false # Set true if you use Motive
 
 # px4flow
 px4flow:

--- a/mavros/src/plugins/altitude.cpp
+++ b/mavros/src/plugins/altitude.cpp
@@ -58,7 +58,7 @@ private:
         mavlink_msg_altitude_decode(msg, &altitude);
 
         auto ros_msg = boost::make_shared<mavros_msgs::Altitude>();
-        ros_msg->header = uas->synchronized_header(frame_id, altitude.time_usec);
+        ros_msg->header = uas->synchronized_header(frame_id, time_usec());
         
         ros_msg->monotonic = altitude.altitude_monotonic;
         ros_msg->amsl = altitude.altitude_amsl;

--- a/mavros/src/plugins/altitude.cpp
+++ b/mavros/src/plugins/altitude.cpp
@@ -58,7 +58,7 @@ private:
         mavlink_msg_altitude_decode(msg, &altitude);
 
         auto ros_msg = boost::make_shared<mavros_msgs::Altitude>();
-        ros_msg->header = uas->synchronized_header(frame_id, time_usec());
+        ros_msg->header = uas->synchronized_header(frame_id, altitude.time_usec);
         
         ros_msg->monotonic = altitude.altitude_monotonic;
         ros_msg->amsl = altitude.altitude_amsl;

--- a/mavros_extras/src/plugins/mocap_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/mocap_pose_estimate.cpp
@@ -98,8 +98,8 @@ private:
 	void mocap_pose_cb(const geometry_msgs::PoseStamped::ConstPtr &pose)
 	{
 		// Transformation matrix to convert Motive Optitrack to Mavlink supported coordinates (ENU as zxy to ENU as xyz)
-		Eigen::AngleAxis<double> tf1(-M_PI_2,Eigen::Vector3d(1.,0.,0.));
-		Eigen::AngleAxis<double> tf2(-M_PI_2,Eigen::Vector3d(0.,0.,1.));
+        Eigen::Transform3d tf(Eigen::Transform3d(Eigen::AngleAxisd(-M_PI_2,Eigen::Vector3d::UnitX()))
+                              *Eigen::Transform3d(Eigen::AngleAxisd(-M_PI_2,Eigen::Vector3d::UnitZ())));
 
 		Eigen::Quaterniond q_enu;
 		float q[4];
@@ -108,7 +108,8 @@ private:
 		
 		//Apply Motive Transform if needed
 		if(use_motive_zxy){
-			q_enu = (q_enu * tf1) * tf2 ;
+			q_enu = (q_enu * Eigen::AngleAxisd(-M_PI_2,Eigen::Vector3d::UnitX()))
+                        * Eigen::AngleAxisd(-M_PI_2,Eigen::Vector3d::UnitZ()) ;
 		}
 
 		UAS::quaternion_to_mavlink(
@@ -119,7 +120,7 @@ private:
 
 		//Apply Motive Transform if needed
 		if(use_motive_zxy){
-			position = (tf1.matrix() * tf2.matrix()) * position;
+			position = tf * position;
 		}
 
 		position = UAS::transform_frame_enu_ned(position);


### PR DESCRIPTION
Implemented Optitrack Motive coordinates uses (zxy)
   + Added /mavros/mocap/use_motive_zxy param (true use zxy ENU coordiates, false use xyz ENU coordinates)
   + Added auto transform from zxy to xyz (if use_motive_zxy set to true)