### PR TITLE
WIP: Add odometry message to local position plugin & coordinate frame review

### DIFF
--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -429,8 +429,8 @@ public:
 	/**
 	 * @brief Transform representation of attitude from 1 frame to another
 	 * (e.g. transfrom attitude from representing  from base_link -> NED
-	                 to representing base_link -> ENU)
-
+	 *               to representing base_link -> ENU)
+	 *
 	 * General function. Please use specialized enu-ned and ned-enu variants.
 	 */
 	static Eigen::Quaterniond transform_orientation(const Eigen::Quaterniond &q, const STATIC_TRANSFORM transform);
@@ -475,7 +475,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_orientation_ned_enu(const T &in) {
-		return transform_orientation(in,STATIC_TRANSFORM::NED_TO_ENU);
+		return transform_orientation(in, STATIC_TRANSFORM::NED_TO_ENU);
 	}
 
 	/**
@@ -484,7 +484,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_orientation_enu_ned(const T &in) {
-		return transform_orientation(in,STATIC_TRANSFORM::ENU_TO_NED);
+		return transform_orientation(in, STATIC_TRANSFORM::ENU_TO_NED);
 	}
 
 	/**
@@ -493,7 +493,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_orientation_aircraft_baselink(const T &in) {
-		return transform_orientation(in,STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
+		return transform_orientation(in, STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
 	}
 
 	/**
@@ -502,7 +502,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_orientation_baselink_aircraft(const T &in) {
-		return transform_orientation(in,STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
+		return transform_orientation(in, STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
 	}
 
 	/**
@@ -511,7 +511,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_ned_enu(const T &in) {
-		return transform_static_frame(in,STATIC_TRANSFORM::NED_TO_ENU);
+		return transform_static_frame(in, STATIC_TRANSFORM::NED_TO_ENU);
 	}
 
 	/**
@@ -520,7 +520,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_enu_ned(const T &in) {
-		return transform_static_frame(in,STATIC_TRANSFORM::ENU_TO_NED);
+		return transform_static_frame(in, STATIC_TRANSFORM::ENU_TO_NED);
 	}
 
 	/**
@@ -529,7 +529,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_aircraft_baselink(const T &in) {
-		return transform_static_frame(in,STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
+		return transform_static_frame(in, STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
 	}
 
 	/**
@@ -538,7 +538,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_baselink_aircraft(const T &in) {
-		return transform_static_frame(in,STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
+		return transform_static_frame(in, STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
 	}
 
 	/**
@@ -547,7 +547,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_aircraft_ned(const T &in,const Eigen::Quaterniond &q) {
-		return transform_frame(in,q);
+		return transform_frame(in, q);
 	}
 
 	/**
@@ -556,7 +556,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_ned_aircraft(const T &in,const Eigen::Quaterniond &q) {
-		return transform_frame(in,q);
+		return transform_frame(in, q);
 	}
 
 	/**
@@ -565,7 +565,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_aircraft_enu(const T &in,const Eigen::Quaterniond &q) {
-		return transform_frame(in,q);
+		return transform_frame(in, q);
 	}
 
 	/**
@@ -574,7 +574,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_enu_aircraft(const T &in,const Eigen::Quaterniond &q) {
-		return transform_frame(in,q);
+		return transform_frame(in, q);
 	}
 
 	/**
@@ -583,7 +583,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_enu_baselink(const T &in,const Eigen::Quaterniond &q) {
-		return transform_frame(in,q);
+		return transform_frame(in, q);
 	}
 
 	/**
@@ -592,7 +592,7 @@ public:
 	 */
 	template<class T>
 	static inline T transform_frame_baselink_enu(const T &in,const Eigen::Quaterniond &q) {
-		return transform_frame(in,q);
+		return transform_frame(in, q);
 	}
 
 	/**

--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -3,7 +3,7 @@
  * @file mavros_uas.h
  * @author Vladimir Ermakov <vooon341@gmail.com>
  * @author Eddy Scott <scott.edward@aurora.aero>
- * 
+ *
  * @addtogroup nodelib
  * @{
  */
@@ -419,17 +419,17 @@ public:
 	/**
 	 * @brief Orientation transform options when applying rotations to data
 	 */
-	enum class STATIC_TRANSFORM: uint8_t {
-		NED_TO_ENU, //! will change orinetation from being expressed WRT NED frame to WRT ENU frame
-		ENU_TO_NED,  //! change from expressed WRT ENU frame to WRT NED frame
-		AIRCRAFT_TO_BASELINK, //! change from expressed WRT aircraft frame to WRT to baselink frame
-		BASELINK_TO_AIRCRAFT //! change from expressed WRT baselnk to WRT aircraft
+	enum class STATIC_TRANSFORM : uint8_t {
+		NED_TO_ENU,	//!< will change orinetation from being expressed WRT NED frame to WRT ENU frame
+		ENU_TO_NED,	//!< change from expressed WRT ENU frame to WRT NED frame
+		AIRCRAFT_TO_BASELINK,	//!< change from expressed WRT aircraft frame to WRT to baselink frame
+		BASELINK_TO_AIRCRAFT	//!< change from expressed WRT baselnk to WRT aircraft
 	};
 
 	/**
 	 * @brief Transform representation of attitude from 1 frame to another
 	 * (e.g. transfrom attitude from representing  from base_link -> NED
-	 		 to representing base_link -> ENU)
+	                 to representing base_link -> ENU)
 
 	 * General function. Please use specialized enu-ned and ned-enu variants.
 	 */
@@ -458,7 +458,7 @@ public:
 	 * General function. Please use specialized enu-ned and ned-enu variants.
 	 */
 	static Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const STATIC_TRANSFORM transform);
-	
+
 	/**
 	 * @brief Transform convariance expressed in one frame to another
 	 *

--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -2,7 +2,8 @@
  * @brief MAVROS Plugin context
  * @file mavros_uas.h
  * @author Vladimir Ermakov <vooon341@gmail.com>
- *
+ * @author Eddy Scott <scott.edward@aurora.aero>
+ * 
  * @addtogroup nodelib
  * @{
  */
@@ -416,43 +417,182 @@ public:
 	}
 
 	/**
-	 * @brief Transform frame between ROS and FCU. (Vector3d)
-	 *
-	 * General function. Please use specialized enu-ned and ned-enu variants.
+	 * @brief Orientation transform options when applying rotations to data
 	 */
-	static Eigen::Vector3d transform_frame(const Eigen::Vector3d &vec);
+	enum class STATIC_TRANSFORM: uint8_t {
+		NED_TO_ENU, //! will change orinetation from being expressed WRT NED frame to WRT ENU frame
+		ENU_TO_NED,  //! change from expressed WRT ENU frame to WRT NED frame
+		AIRCRAFT_TO_BASELINK, //! change from expressed WRT aircraft frame to WRT to baselink frame
+		BASELINK_TO_AIRCRAFT //! change from expressed WRT baselnk to WRT aircraft
+	};
 
 	/**
-	 * @brief Transform frame between ROS and FCU. (Quaterniond)
-	 *
+	 * @brief Transform representation of attitude from 1 frame to another
+	 * (e.g. transfrom attitude from representing  from base_link -> NED
+	 		 to representing base_link -> ENU)
+
 	 * General function. Please use specialized enu-ned and ned-enu variants.
 	 */
-	static Eigen::Quaterniond transform_frame(const Eigen::Quaterniond &q);
+	static Eigen::Quaterniond transform_orientation(const Eigen::Quaterniond &q, const STATIC_TRANSFORM transform);
 
 	/**
-	 * @brief Transform frame between ROS and FCU. (Covariance3d)
+	 * @brief Transform data experessed in one frame to another frame.
 	 *
 	 * General function. Please use specialized enu-ned and ned-enu variants.
 	 */
-	static Covariance3d transform_frame(const Covariance3d &cov);
+	static Eigen::Vector3d transform_frame(const Eigen::Vector3d &vec, const Eigen::Quaterniond &q);
+
+	/**
+	 * @brief Transform convariance expressed in one frame to another
+	 *
+	 * General function. Please use specialized enu-ned and ned-enu variants.
+	 */
+	static Covariance3d transform_frame(const Covariance3d &cov, const Eigen::Quaterniond &q);
 
 	// XXX TODO implement that function
-	static Covariance6d transform_frame(const Covariance6d &cov);
+	static Covariance6d transform_frame(const Covariance6d &cov, const Eigen::Quaterniond &q);
 
 	/**
-	 * @brief Transform from FCU to ROS frame.
+	 * @brief Transform data experessed in one frame to another frame.
+	 *
+	 * General function. Please use specialized enu-ned and ned-enu variants.
+	 */
+	static Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const STATIC_TRANSFORM transform);
+	
+	/**
+	 * @brief Transform convariance expressed in one frame to another
+	 *
+	 * General function. Please use specialized enu-ned and ned-enu variants.
+	 */
+	static Covariance3d transform_static_frame(const Covariance3d &cov, const STATIC_TRANSFORM transform);
+
+	// XXX TODO implement that function
+	static Covariance6d transform_static_frame(const Covariance6d &cov, const STATIC_TRANSFORM transform);
+
+	/**
+	 * @brief Transform from attitude represented WRT NED frame to attitude
+	 *		  represented WRT ENU frame
 	 */
 	template<class T>
-	static inline T transform_frame_ned_enu(const T &in) {
-		return transform_frame(in);
+	static inline T transform_orientation_ned_enu(const T &in) {
+		return transform_orientation(in,STATIC_TRANSFORM::NED_TO_ENU);
 	}
 
 	/**
-	 * @brief Transform from ROS to FCU frame.
+	 * @brief Transform from attitude represented WRT ENU frame to
+	 *		  attitude represented WRT NED frame
+	 */
+	template<class T>
+	static inline T transform_orientation_enu_ned(const T &in) {
+		return transform_orientation(in,STATIC_TRANSFORM::ENU_TO_NED);
+	}
+
+	/**
+	 * @brief Transform from attitude represented WRT aircraft frame to
+	 *		  attitude represented WRT base_link frame
+	 */
+	template<class T>
+	static inline T transform_orientation_aircraft_baselink(const T &in) {
+		return transform_orientation(in,STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
+	}
+
+	/**
+	 * @brief Transform from attitude represented WRT baselink frame to
+	 *		  attitude represented WRT body frame
+	 */
+	template<class T>
+	static inline T transform_orientation_baselink_aircraft(const T &in) {
+		return transform_orientation(in,STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
+	}
+
+	/**
+	 * @brief Transform data expressed in NED to ENU frame.
+	 *
+	 */
+	template<class T>
+	static inline T transform_frame_ned_enu(const T &in) {
+		return transform_static_frame(in,STATIC_TRANSFORM::NED_TO_ENU);
+	}
+
+	/**
+	 * @brief Transform data expressed in ENU to NED frame.
+	 *
 	 */
 	template<class T>
 	static inline T transform_frame_enu_ned(const T &in) {
-		return transform_frame(in);
+		return transform_static_frame(in,STATIC_TRANSFORM::ENU_TO_NED);
+	}
+
+	/**
+	 * @brief Transform data expressed in Aircraft frame to Baselink frame.
+	 *
+	 */
+	template<class T>
+	static inline T transform_frame_aircraft_baselink(const T &in) {
+		return transform_static_frame(in,STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
+	}
+
+	/**
+	 * @brief Transform data expressed in Baselink frame to Aircraft frame.
+	 *
+	 */
+	template<class T>
+	static inline T transform_frame_baselink_aircraft(const T &in) {
+		return transform_static_frame(in,STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
+	}
+
+	/**
+	 * @brief Transform data expressed in aircraft frame to NED frame.
+	 * Assumes quaternion represents rotation from aircraft frame to NED frame.
+	 */
+	template<class T>
+	static inline T transform_frame_aircraft_ned(const T &in,const Eigen::Quaterniond &q) {
+		return transform_frame(in,q);
+	}
+
+	/**
+	 * @brief Transform data expressed in NED to aircraft frame.
+	 * Assumes quaternion represents rotation from NED to aircraft frame.
+	 */
+	template<class T>
+	static inline T transform_frame_ned_aircraft(const T &in,const Eigen::Quaterniond &q) {
+		return transform_frame(in,q);
+	}
+
+	/**
+	 * @brief Transform data expressed in aircraft frame to ENU frame.
+	 * Assumes quaternion represents rotation from aircraft frame to ENU frame.
+	 */
+	template<class T>
+	static inline T transform_frame_aircraft_enu(const T &in,const Eigen::Quaterniond &q) {
+		return transform_frame(in,q);
+	}
+
+	/**
+	 * @brief Transform data expressed in ENU to aircraft frame.
+	 * Assumes quaternion represents rotation from ENU to aircraft frame.
+	 */
+	template<class T>
+	static inline T transform_frame_enu_aircraft(const T &in,const Eigen::Quaterniond &q) {
+		return transform_frame(in,q);
+	}
+
+	/**
+	 * @brief Transform data expressed in ENU to base_link frame.
+	 * Assumes quaternion represents rotation from ENU to base_link frame.
+	 */
+	template<class T>
+	static inline T transform_frame_enu_baselink(const T &in,const Eigen::Quaterniond &q) {
+		return transform_frame(in,q);
+	}
+
+	/**
+	 * @brief Transform data expressed in baselink to ENU frame.
+	 * Assumes quaternion represents rotation from basel_link to ENU frame.
+	 */
+	template<class T>
+	static inline T transform_frame_baselink_enu(const T &in,const Eigen::Quaterniond &q) {
+		return transform_frame(in,q);
 	}
 
 	/**

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -66,6 +66,7 @@ local_position:
     send: false
     frame_id: "local_origin"
     child_frame_id: "fcu"
+    send_fcu: false
 
 # param
 # None, used for FCU params

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -2,6 +2,7 @@
  * @brief Frame conversions helper functions
  * @file uas_frame_conversions.cpp
  * @author Nuno Marques <n.marques21@hotmail.com>
+ * @author Eddy Scott <scott.edward@aurora.aero>
  *
  * @addtogroup nodelib
  * @{
@@ -18,26 +19,132 @@
 
 using namespace mavros;
 
-// Eigen based functions
+// Static quaternion needed for rotating between ENU and NED frames
+// +PI rotation around X (North) axis follwed by +PI/2 rotation about Z (Down)
+// gives the ENU frame.  Similarly, a +PI rotation about X (East) followed by 
+// a +PI/2 roation about Z (Up) gives the NED frame.  
+static const Eigen::Quaterniond NED_ENU_Q = UAS::quaternion_from_rpy(M_PI, 0.0, M_PI_2);
 
-//! +PI rotation around X (Roll) axis give us ROS or FCU representation
-static const Eigen::Quaterniond FRAME_ROTATE_Q = UAS::quaternion_from_rpy(M_PI, 0.0, 0.0);
+// Static quaternion needed for rotating between aircraft and base_link frames
+// +PI rotation around X (Forward) axis transforms from Forward, Right, Down (aircraft) 
+// Fto Forward, Left, Up (base_link) frames.  
+static const Eigen::Quaterniond AIRCRAFT_BASELINK_Q = UAS::quaternion_from_rpy(M_PI, 0.0, 0.0);
+
 
 //! Transform for vector3
-static const Eigen::Transform<double, 3, Eigen::Affine> FRAME_TRANSFORM_VECTOR3(FRAME_ROTATE_Q);
+//static const Eigen::Transform<double, 3, Eigen::Affine> FRAME_TRANSFORM_VECTOR3(FRAME_ROTATE_Q);
 
 
-Eigen::Quaterniond UAS::transform_frame(const Eigen::Quaterniond &q)
+Eigen::Quaterniond UAS::transform_orientation(const Eigen::Quaterniond &q, const UAS::STATIC_TRANSFORM transform)
 {
-	return FRAME_ROTATE_Q * q * FRAME_ROTATE_Q.inverse();
+	//Transform the attitude representation from frame to frame.  The proof for this transform can 
+	//be seen http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/transforms/
+		switch(transform){
+		case STATIC_TRANSFORM::NED_TO_ENU:
+		case STATIC_TRANSFORM::ENU_TO_NED:{
+			return NED_ENU_Q * q;
+			break;
+		}
+		case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
+		case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT:{
+			return q * AIRCRAFT_BASELINK_Q;
+			break;
+		}
+		default:{
+			//We don't know how to express the attitude WRT an undefined
+			//frame.  Throw error and return given quaternion
+			ROS_ERROR("Requested Orientation Conversion Unkown");
+			return q;
+			break;
+		}
+	}
 }
 
-Eigen::Vector3d UAS::transform_frame(const Eigen::Vector3d &vec)
+Eigen::Vector3d UAS::transform_static_frame(const Eigen::Vector3d &vec, const UAS::STATIC_TRANSFORM transform)
 {
+	switch(transform){
+		case STATIC_TRANSFORM::NED_TO_ENU:
+		case STATIC_TRANSFORM::ENU_TO_NED:{
+			Eigen::Affine3d FRAME_TRANSFORM_VECTOR3(NED_ENU_Q);
+			return FRAME_TRANSFORM_VECTOR3 * vec;
+			break;
+		}
+		case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
+		case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT:{
+			Eigen::Affine3d FRAME_TRANSFORM_VECTOR3(AIRCRAFT_BASELINK_Q);
+			return FRAME_TRANSFORM_VECTOR3 * vec;
+			break;
+		}
+		default:{
+			//We don't know the transform between the static frames.
+			//throw error and return given vector
+			ROS_ERROR("Requested Static Frame Conversion Unkown");
+			return vec;
+			break;
+		}
+	}
+}
+
+UAS::Covariance3d UAS::transform_static_frame(const Covariance3d &cov, const UAS::STATIC_TRANSFORM transform)
+{
+	switch(transform){
+		case STATIC_TRANSFORM::NED_TO_ENU:
+		case STATIC_TRANSFORM::ENU_TO_NED:{
+			Covariance3d cov_out_;
+			EigenMapConstCovariance3d cov_in(cov.data());
+			EigenMapCovariance3d cov_out(cov_out_.data());
+
+			// code from imu_transformer tf2_sensor_msgs.h
+			//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
+			// from comments on github about tf2_sensor_msgs.h
+			cov_out = cov_in * NED_ENU_Q;
+			return cov_out_;
+			break;
+		}
+		case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
+		case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT:{
+			Covariance3d cov_out_;
+			EigenMapConstCovariance3d cov_in(cov.data());
+			EigenMapCovariance3d cov_out(cov_out_.data());
+
+			// code from imu_transformer tf2_sensor_msgs.h
+			//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
+			// from comments on github about tf2_sensor_msgs.h
+			cov_out = cov_in * AIRCRAFT_BASELINK_Q;
+			return cov_out_;
+			break;
+		}
+		default:{
+			//We don't know the transform between the static frames.
+			//throw error and return given covariance
+			ROS_ERROR("Requested Static Frame Conversion Unkown");
+			return cov;
+			break;
+		}
+	}
+}
+
+UAS::Covariance6d UAS::transform_static_frame(const Covariance6d &cov, const UAS::STATIC_TRANSFORM transform)
+{
+	//! @todo implement me!!!
+	switch(transform){
+		default:{
+			Covariance6d cov_out_;
+			EigenMapConstCovariance6d cov_in(cov.data());
+			EigenMapCovariance6d cov_out(cov_out_.data());
+			ROS_ASSERT(false);
+			return cov_out_;
+		}
+	}
+}
+
+Eigen::Vector3d UAS::transform_frame(const Eigen::Vector3d &vec, const Eigen::Quaterniond &q)
+{
+	Eigen::Affine3d FRAME_TRANSFORM_VECTOR3(q);
 	return FRAME_TRANSFORM_VECTOR3 * vec;
 }
 
-UAS::Covariance3d UAS::transform_frame(const Covariance3d &cov)
+UAS::Covariance3d UAS::transform_frame(const Covariance3d &cov, const Eigen::Quaterniond &q)
 {
 	Covariance3d cov_out_;
 	EigenMapConstCovariance3d cov_in(cov.data());
@@ -46,11 +153,11 @@ UAS::Covariance3d UAS::transform_frame(const Covariance3d &cov)
 	// code from imu_transformer tf2_sensor_msgs.h
 	//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
 	// from comments on github about tf2_sensor_msgs.h
-	cov_out = cov_in * FRAME_ROTATE_Q;
+	cov_out = cov_in * q;
 	return cov_out_;
 }
 
-UAS::Covariance6d UAS::transform_frame(const Covariance6d &cov)
+UAS::Covariance6d UAS::transform_frame(const Covariance6d &cov, const Eigen::Quaterniond &q)
 {
 	Covariance6d cov_out_;
 	EigenMapConstCovariance6d cov_in(cov.data());

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -47,7 +47,7 @@ static inline const Eigen::Affine3d &get_static_transform_affine(const UAS::STAT
 		break;
 	}
 	default: {
-		ROS_ASSERT(false);
+		ROS_BREAK(false);
 	}
 	}
 }
@@ -75,7 +75,7 @@ Eigen::Quaterniond UAS::transform_orientation(const Eigen::Quaterniond &q, const
 	default: {
 		//We don't know how to express the attitude WRT an undefined
 		//frame.
-		ROS_ASSERT(false);
+		ROS_BREAK(false);
 		return q;
 		break;
 	}
@@ -90,13 +90,12 @@ Eigen::Vector3d UAS::transform_static_frame(const Eigen::Vector3d &vec, const UA
 
 UAS::Covariance3d UAS::transform_static_frame(const Covariance3d &cov, const UAS::STATIC_TRANSFORM transform)
 {
+	Covariance3d cov_out_;
+	EigenMapConstCovariance3d cov_in(cov.data());
+	EigenMapCovariance3d cov_out(cov_out_.data());
 	switch (transform) {
 	case STATIC_TRANSFORM::NED_TO_ENU:
 	case STATIC_TRANSFORM::ENU_TO_NED: {
-		Covariance3d cov_out_;
-		EigenMapConstCovariance3d cov_in(cov.data());
-		EigenMapCovariance3d cov_out(cov_out_.data());
-
 		// code from imu_transformer tf2_sensor_msgs.h
 		//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
 		// from comments on github about tf2_sensor_msgs.h
@@ -106,10 +105,6 @@ UAS::Covariance3d UAS::transform_static_frame(const Covariance3d &cov, const UAS
 	}
 	case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
 	case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT: {
-		Covariance3d cov_out_;
-		EigenMapConstCovariance3d cov_in(cov.data());
-		EigenMapCovariance3d cov_out(cov_out_.data());
-
 		// code from imu_transformer tf2_sensor_msgs.h
 		//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
 		// from comments on github about tf2_sensor_msgs.h
@@ -135,7 +130,7 @@ UAS::Covariance6d UAS::transform_static_frame(const Covariance6d &cov, const UAS
 		Covariance6d cov_out_;
 		EigenMapConstCovariance6d cov_in(cov.data());
 		EigenMapCovariance6d cov_out(cov_out_.data());
-		ROS_ASSERT(false);
+		ROS_BREAK(false);
 		return cov_out_;
 	}
 	}
@@ -167,6 +162,6 @@ UAS::Covariance6d UAS::transform_frame(const Covariance6d &cov, const Eigen::Qua
 	EigenMapCovariance6d cov_out(cov_out_.data());
 
 	//! @todo implement me!!!
-	ROS_ASSERT(false);
+	ROS_BREAK(false);
 	return cov_out_;
 }

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -21,14 +21,36 @@ using namespace mavros;
 
 // Static quaternion needed for rotating between ENU and NED frames
 // +PI rotation around X (North) axis follwed by +PI/2 rotation about Z (Down)
-// gives the ENU frame.  Similarly, a +PI rotation about X (East) followed by 
-// a +PI/2 roation about Z (Up) gives the NED frame.  
+// gives the ENU frame.  Similarly, a +PI rotation about X (East) followed by
+// a +PI/2 roation about Z (Up) gives the NED frame.
 static const Eigen::Quaterniond NED_ENU_Q = UAS::quaternion_from_rpy(M_PI, 0.0, M_PI_2);
 
 // Static quaternion needed for rotating between aircraft and base_link frames
-// +PI rotation around X (Forward) axis transforms from Forward, Right, Down (aircraft) 
-// Fto Forward, Left, Up (base_link) frames.  
+// +PI rotation around X (Forward) axis transforms from Forward, Right, Down (aircraft)
+// Fto Forward, Left, Up (base_link) frames.
 static const Eigen::Quaterniond AIRCRAFT_BASELINK_Q = UAS::quaternion_from_rpy(M_PI, 0.0, 0.0);
+
+static const Eigen::Affine3d NED_ENU_AFFINE(NED_ENU_Q);
+static const Eigen::Affine3d AIRCRAFT_BASELINK_AFFINE(AIRCRAFT_BASELINK_Q);
+
+static inline const Eigen::Affine3d &get_static_transform_affine(const UAS::STATIC_TRANSFORM transform)
+{
+	switch (transform) {
+	case UAS::STATIC_TRANSFORM::NED_TO_ENU:
+	case UAS::STATIC_TRANSFORM::ENU_TO_NED: {
+		return NED_ENU_AFFINE;
+		break;
+	}
+	case UAS::STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
+	case UAS::STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT: {
+		return AIRCRAFT_BASELINK_AFFINE;
+		break;
+	}
+	default: {
+		ROS_ASSERT(false);
+	}
+	}
+}
 
 
 //! Transform for vector3
@@ -37,104 +59,85 @@ static const Eigen::Quaterniond AIRCRAFT_BASELINK_Q = UAS::quaternion_from_rpy(M
 
 Eigen::Quaterniond UAS::transform_orientation(const Eigen::Quaterniond &q, const UAS::STATIC_TRANSFORM transform)
 {
-	//Transform the attitude representation from frame to frame.  The proof for this transform can 
+	//Transform the attitude representation from frame to frame.  The proof for this transform can
 	//be seen http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/transforms/
-		switch(transform){
-		case STATIC_TRANSFORM::NED_TO_ENU:
-		case STATIC_TRANSFORM::ENU_TO_NED:{
-			return NED_ENU_Q * q;
-			break;
-		}
-		case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
-		case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT:{
-			return q * AIRCRAFT_BASELINK_Q;
-			break;
-		}
-		default:{
-			//We don't know how to express the attitude WRT an undefined
-			//frame.  Throw error and return given quaternion
-			ROS_ERROR("Requested Orientation Conversion Unkown");
-			return q;
-			break;
-		}
+	switch (transform) {
+	case STATIC_TRANSFORM::NED_TO_ENU:
+	case STATIC_TRANSFORM::ENU_TO_NED: {
+		return NED_ENU_Q * q;
+		break;
+	}
+	case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
+	case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT: {
+		return q * AIRCRAFT_BASELINK_Q;
+		break;
+	}
+	default: {
+		//We don't know how to express the attitude WRT an undefined
+		//frame.
+		ROS_ASSERT(false);
+		return q;
+		break;
+	}
 	}
 }
 
 Eigen::Vector3d UAS::transform_static_frame(const Eigen::Vector3d &vec, const UAS::STATIC_TRANSFORM transform)
 {
-	switch(transform){
-		case STATIC_TRANSFORM::NED_TO_ENU:
-		case STATIC_TRANSFORM::ENU_TO_NED:{
-			Eigen::Affine3d FRAME_TRANSFORM_VECTOR3(NED_ENU_Q);
-			return FRAME_TRANSFORM_VECTOR3 * vec;
-			break;
-		}
-		case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
-		case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT:{
-			Eigen::Affine3d FRAME_TRANSFORM_VECTOR3(AIRCRAFT_BASELINK_Q);
-			return FRAME_TRANSFORM_VECTOR3 * vec;
-			break;
-		}
-		default:{
-			//We don't know the transform between the static frames.
-			//throw error and return given vector
-			ROS_ERROR("Requested Static Frame Conversion Unkown");
-			return vec;
-			break;
-		}
-	}
+	auto affine_transform = get_static_transform_affine(transform);
+	return affine_transform * vec;
 }
 
 UAS::Covariance3d UAS::transform_static_frame(const Covariance3d &cov, const UAS::STATIC_TRANSFORM transform)
 {
-	switch(transform){
-		case STATIC_TRANSFORM::NED_TO_ENU:
-		case STATIC_TRANSFORM::ENU_TO_NED:{
-			Covariance3d cov_out_;
-			EigenMapConstCovariance3d cov_in(cov.data());
-			EigenMapCovariance3d cov_out(cov_out_.data());
+	switch (transform) {
+	case STATIC_TRANSFORM::NED_TO_ENU:
+	case STATIC_TRANSFORM::ENU_TO_NED: {
+		Covariance3d cov_out_;
+		EigenMapConstCovariance3d cov_in(cov.data());
+		EigenMapCovariance3d cov_out(cov_out_.data());
 
-			// code from imu_transformer tf2_sensor_msgs.h
-			//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
-			// from comments on github about tf2_sensor_msgs.h
-			cov_out = cov_in * NED_ENU_Q;
-			return cov_out_;
-			break;
-		}
-		case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
-		case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT:{
-			Covariance3d cov_out_;
-			EigenMapConstCovariance3d cov_in(cov.data());
-			EigenMapCovariance3d cov_out(cov_out_.data());
+		// code from imu_transformer tf2_sensor_msgs.h
+		//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
+		// from comments on github about tf2_sensor_msgs.h
+		cov_out = cov_in * NED_ENU_Q;
+		return cov_out_;
+		break;
+	}
+	case STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK:
+	case STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT: {
+		Covariance3d cov_out_;
+		EigenMapConstCovariance3d cov_in(cov.data());
+		EigenMapCovariance3d cov_out(cov_out_.data());
 
-			// code from imu_transformer tf2_sensor_msgs.h
-			//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
-			// from comments on github about tf2_sensor_msgs.h
-			cov_out = cov_in * AIRCRAFT_BASELINK_Q;
-			return cov_out_;
-			break;
-		}
-		default:{
-			//We don't know the transform between the static frames.
-			//throw error and return given covariance
-			ROS_ERROR("Requested Static Frame Conversion Unkown");
-			return cov;
-			break;
-		}
+		// code from imu_transformer tf2_sensor_msgs.h
+		//cov_out = FRAME_ROTATE_Q * cov_in * FRAME_ROTATE_Q.inverse();
+		// from comments on github about tf2_sensor_msgs.h
+		cov_out = cov_in * AIRCRAFT_BASELINK_Q;
+		return cov_out_;
+		break;
+	}
+	default: {
+		//We don't know the transform between the static frames.
+		//throw error and return given covariance
+		ROS_ERROR("Requested Static Frame Conversion Unkown");
+		return cov;
+		break;
+	}
 	}
 }
 
 UAS::Covariance6d UAS::transform_static_frame(const Covariance6d &cov, const UAS::STATIC_TRANSFORM transform)
 {
 	//! @todo implement me!!!
-	switch(transform){
-		default:{
-			Covariance6d cov_out_;
-			EigenMapConstCovariance6d cov_in(cov.data());
-			EigenMapCovariance6d cov_out(cov_out_.data());
-			ROS_ASSERT(false);
-			return cov_out_;
-		}
+	switch (transform) {
+	default: {
+		Covariance6d cov_out_;
+		EigenMapConstCovariance6d cov_in(cov.data());
+		EigenMapCovariance6d cov_out(cov_out_.data());
+		ROS_ASSERT(false);
+		return cov_out_;
+	}
 	}
 }
 

--- a/mavros/src/lib/uas_frame_conversions.cpp
+++ b/mavros/src/lib/uas_frame_conversions.cpp
@@ -47,7 +47,7 @@ static inline const Eigen::Affine3d &get_static_transform_affine(const UAS::STAT
 		break;
 	}
 	default: {
-		ROS_BREAK(false);
+		ROS_BREAK();
 	}
 	}
 }
@@ -75,7 +75,7 @@ Eigen::Quaterniond UAS::transform_orientation(const Eigen::Quaterniond &q, const
 	default: {
 		//We don't know how to express the attitude WRT an undefined
 		//frame.
-		ROS_BREAK(false);
+		ROS_BREAK();
 		return q;
 		break;
 	}
@@ -115,7 +115,7 @@ UAS::Covariance3d UAS::transform_static_frame(const Covariance3d &cov, const UAS
 	default: {
 		//We don't know the transform between the static frames.
 		//throw error and return given covariance
-		ROS_ERROR("Requested Static Frame Conversion Unkown");
+		ROS_BREAK();
 		return cov;
 		break;
 	}
@@ -130,7 +130,7 @@ UAS::Covariance6d UAS::transform_static_frame(const Covariance6d &cov, const UAS
 		Covariance6d cov_out_;
 		EigenMapConstCovariance6d cov_in(cov.data());
 		EigenMapCovariance6d cov_out(cov_out_.data());
-		ROS_BREAK(false);
+		ROS_BREAK();
 		return cov_out_;
 	}
 	}
@@ -162,6 +162,6 @@ UAS::Covariance6d UAS::transform_frame(const Covariance6d &cov, const Eigen::Qua
 	EigenMapCovariance6d cov_out(cov_out_.data());
 
 	//! @todo implement me!!!
-	ROS_BREAK(false);
+	ROS_BREAK();
 	return cov_out_;
 }

--- a/mavros/src/plugins/altitude.cpp
+++ b/mavros/src/plugins/altitude.cpp
@@ -36,7 +36,7 @@ public:
     void initialize(UAS &uas_)
     {
         uas = &uas_;
-        nh.param<std::string>("frame_id", frame_id, "fcu");
+        nh.param<std::string>("frame_id", frame_id, "map");
         altitude_pub = nh.advertise<mavros_msgs::Altitude>("altitude", 10);
     }
 

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -53,12 +53,12 @@ public:
 		uas = &uas_;
 
 		// general params
-		gp_nh.param<std::string>("frame_id", frame_id, "fcu");
+		gp_nh.param<std::string>("frame_id", frame_id, "map");
 		gp_nh.param("rot_covariance", rot_cov, 99999.0);
 		// tf subsection
 		gp_nh.param("tf/send", tf_send, true);
-		gp_nh.param<std::string>("tf/frame_id", tf_frame_id, "local_origin");
-		gp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "fcu_utm");
+		gp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
+		gp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "base_link");
 
 		UAS_DIAG(uas).add("GPS", this, &GlobalPositionPlugin::gps_diag_run);
 

--- a/mavros/src/plugins/imu_pub.cpp
+++ b/mavros/src/plugins/imu_pub.cpp
@@ -46,6 +46,9 @@ static constexpr double MILLIG_TO_MS2 = 9.80665 / 1000.0;
 //! millBar to Pascal coeff
 static constexpr double MILLIBAR_TO_PASCAL = 1.0e2;
 
+static constexpr double RAD_TO_DEG = 180.0/M_PI;
+
+
 
 /**
  * @brief IMU data publication plugin
@@ -66,7 +69,11 @@ public:
 
 		uas = &uas_;
 
-		imu_nh.param<std::string>("frame_id", frame_id, "fcu");
+		// we rotate the data from the aircraft-frame to the base_link frame.
+		// Additionally we report the orientation of the vehicle to describe the 
+		// transformation from the ENU frame to the base_link frame (ENU <-> base_link).  
+		// THIS ORIENTATION IS NOT THE SAME AS THAT REPORTED BY THE FCU (NED <-> aircraft)  
+		imu_nh.param<std::string>("frame_id", frame_id, "base_link"); 
 		imu_nh.param("linear_acceleration_stdev", linear_stdev, 0.0003);		// check default by MPU6000 spec
 		imu_nh.param("angular_velocity_stdev", angular_stdev, 0.02 * (M_PI / 180.0));	// check default by MPU6000 spec
 		imu_nh.param("orientation_stdev", orientation_stdev, 1.0);
@@ -203,12 +210,19 @@ private:
 		mavlink_attitude_t att;
 		mavlink_msg_attitude_decode(msg, &att);
 
-		auto orientation = UAS::transform_frame_ned_enu(
-				UAS::quaternion_from_rpy(att.roll, att.pitch, att.yaw));
-		auto gyro = UAS::transform_frame_ned_enu(
+		//Here we have rpy describing the rotation: aircraft->NED
+		//We need to change this to aircraft->ENU
+		//And finally change it to baselink->ENU
+		auto enu_baselink_orientation = UAS::transform_orientation_aircraft_baselink(
+				UAS::transform_orientation_ned_enu(
+				UAS::quaternion_from_rpy(att.roll, att.pitch, att.yaw)));
+
+		//Here we have the angular velocity expressed in the aircraft frame
+		//We need to apply the static rotation to get it into the base_link frame
+		auto gyro = UAS::transform_frame_aircraft_baselink(
 				Eigen::Vector3d(att.rollspeed, att.pitchspeed, att.yawspeed));
 
-		publish_imu_data(att.time_boot_ms, orientation, gyro);
+		publish_imu_data(att.time_boot_ms, enu_baselink_orientation, gyro);
 	}
 
 	// almost the same as handle_attitude(), but for ATTITUDE_QUATERNION
@@ -219,13 +233,19 @@ private:
 		ROS_INFO_COND_NAMED(!has_att_quat, "imu", "IMU: Attitude quaternion IMU detected!");
 		has_att_quat = true;
 
-		// MAVLink quaternion exactly match Eigen convention
-		auto orientation = UAS::transform_frame_ned_enu(
-				Eigen::Quaterniond(att_q.q1, att_q.q2, att_q.q3, att_q.q4));
-		auto gyro = UAS::transform_frame_ned_enu(
+		//MAVLink quaternion exactly matches Eigen convention
+		//Here we have rpy describing the rotation: aircraft->NED
+		//We need to change this to aircraft->ENU
+		//And finally change it to baselink->ENU
+		auto enu_baselink_orientation = UAS::transform_orientation_aircraft_baselink(
+							   UAS::transform_orientation_ned_enu(
+				Eigen::Quaterniond(att_q.q1, att_q.q2, att_q.q3, att_q.q4)));
+		//Here we have the angular velocity expressed in the aircraft frame
+		//We need to apply the static rotation to get it into the base_link frame
+		auto gyro = UAS::transform_frame_aircraft_baselink(
 				Eigen::Vector3d(att_q.rollspeed, att_q.pitchspeed, att_q.yawspeed));
 
-		publish_imu_data(att_q.time_boot_ms, orientation, gyro);
+		publish_imu_data(att_q.time_boot_ms, enu_baselink_orientation, gyro);
 	}
 
 	void handle_highres_imu(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
@@ -236,20 +256,20 @@ private:
 		has_hr_imu = true;
 
 		auto header = uas->synchronized_header(frame_id, imu_hr.time_usec);
-
 		//! @todo make more paranoic check of HIGHRES_IMU.fields_updated
 
 		// accelerometer + gyroscope data available
+		// Data is expressed in aircraft frame we need to rotate to base_link frame
 		if (imu_hr.fields_updated & ((7 << 3) | (7 << 0))) {
-			auto gyro = UAS::transform_frame_ned_enu(Eigen::Vector3d(imu_hr.xgyro, imu_hr.ygyro, imu_hr.zgyro));
-			auto accel = UAS::transform_frame_ned_enu(Eigen::Vector3d(imu_hr.xacc, imu_hr.yacc, imu_hr.zacc));
+			auto gyro = UAS::transform_frame_aircraft_baselink(Eigen::Vector3d(imu_hr.xgyro, imu_hr.ygyro, imu_hr.zgyro));
+			auto accel = UAS::transform_frame_aircraft_baselink(Eigen::Vector3d(imu_hr.xacc, imu_hr.yacc, imu_hr.zacc));
 
 			publish_imu_data_raw(header, gyro, accel);
 		}
 
 		// magnetometer data available
 		if (imu_hr.fields_updated & (7 << 6)) {
-			auto mag_field = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+			auto mag_field = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 					Eigen::Vector3d(imu_hr.xmag, imu_hr.ymag, imu_hr.zmag) * GAUSS_TO_TESLA);
 
 			publish_mag(header, mag_field);
@@ -286,10 +306,9 @@ private:
 		auto header = uas->synchronized_header(frame_id, imu_raw.time_usec);
 
 		//! @note APM send SCALED_IMU data as RAW_IMU
-
-		auto gyro = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+		auto gyro = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 				Eigen::Vector3d(imu_raw.xgyro, imu_raw.ygyro, imu_raw.zgyro) * MILLIRS_TO_RADSEC);
-		auto accel = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+		auto accel = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 				Eigen::Vector3d(imu_raw.xacc, imu_raw.yacc, imu_raw.zacc));
 
 		if (uas->is_ardupilotmega())
@@ -304,7 +323,7 @@ private:
 		}
 
 		/* -*- magnetic vector -*- */
-		auto mag_field = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+		auto mag_field = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 				Eigen::Vector3d(imu_raw.xmag, imu_raw.ymag, imu_raw.zmag) * MILLIT_TO_TESLA);
 
 		publish_mag(header, mag_field);
@@ -323,15 +342,15 @@ private:
 
 		auto header = uas->synchronized_header(frame_id, imu_raw.time_boot_ms);
 
-		auto gyro = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+		auto gyro = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 				Eigen::Vector3d(imu_raw.xgyro, imu_raw.ygyro, imu_raw.zgyro) * MILLIRS_TO_RADSEC);
-		auto accel = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+		auto accel = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 				Eigen::Vector3d(imu_raw.xacc, imu_raw.yacc, imu_raw.zacc) * MILLIG_TO_MS2);
 
 		publish_imu_data_raw(header, gyro, accel);
 
 		/* -*- magnetic vector -*- */
-		auto mag_field = UAS::transform_frame_ned_enu<Eigen::Vector3d>(
+		auto mag_field = UAS::transform_frame_aircraft_baselink<Eigen::Vector3d>(
 				Eigen::Vector3d(imu_raw.xmag, imu_raw.ymag, imu_raw.zmag) * MILLIT_TO_TESLA);
 
 		publish_mag(header, mag_field);

--- a/mavros/src/plugins/imu_pub.cpp
+++ b/mavros/src/plugins/imu_pub.cpp
@@ -26,7 +26,6 @@
 #include <geometry_msgs/Vector3.h>
 
 namespace mavplugin {
-
 /* Note: this coefficents before been inside plugin class,
  * but after #320 something broken and in resulting plugins.so
  * there no symbols for that constants.
@@ -46,8 +45,7 @@ static constexpr double MILLIG_TO_MS2 = 9.80665 / 1000.0;
 //! millBar to Pascal coeff
 static constexpr double MILLIBAR_TO_PASCAL = 1.0e2;
 
-static constexpr double RAD_TO_DEG = 180.0/M_PI;
-
+static constexpr double RAD_TO_DEG = 180.0 / M_PI;
 
 
 /**
@@ -70,10 +68,10 @@ public:
 		uas = &uas_;
 
 		// we rotate the data from the aircraft-frame to the base_link frame.
-		// Additionally we report the orientation of the vehicle to describe the 
-		// transformation from the ENU frame to the base_link frame (ENU <-> base_link).  
-		// THIS ORIENTATION IS NOT THE SAME AS THAT REPORTED BY THE FCU (NED <-> aircraft)  
-		imu_nh.param<std::string>("frame_id", frame_id, "base_link"); 
+		// Additionally we report the orientation of the vehicle to describe the
+		// transformation from the ENU frame to the base_link frame (ENU <-> base_link).
+		// THIS ORIENTATION IS NOT THE SAME AS THAT REPORTED BY THE FCU (NED <-> aircraft)
+		imu_nh.param<std::string>("frame_id", frame_id, "base_link");
 		imu_nh.param("linear_acceleration_stdev", linear_stdev, 0.0003);		// check default by MPU6000 spec
 		imu_nh.param("angular_velocity_stdev", angular_stdev, 0.02 * (M_PI / 180.0));	// check default by MPU6000 spec
 		imu_nh.param("orientation_stdev", orientation_stdev, 1.0);
@@ -215,7 +213,7 @@ private:
 		//And finally change it to baselink->ENU
 		auto enu_baselink_orientation = UAS::transform_orientation_aircraft_baselink(
 				UAS::transform_orientation_ned_enu(
-				UAS::quaternion_from_rpy(att.roll, att.pitch, att.yaw)));
+					UAS::quaternion_from_rpy(att.roll, att.pitch, att.yaw)));
 
 		//Here we have the angular velocity expressed in the aircraft frame
 		//We need to apply the static rotation to get it into the base_link frame
@@ -238,8 +236,8 @@ private:
 		//We need to change this to aircraft->ENU
 		//And finally change it to baselink->ENU
 		auto enu_baselink_orientation = UAS::transform_orientation_aircraft_baselink(
-							   UAS::transform_orientation_ned_enu(
-				Eigen::Quaterniond(att_q.q1, att_q.q2, att_q.q3, att_q.q4)));
+				UAS::transform_orientation_ned_enu(
+					Eigen::Quaterniond(att_q.q1, att_q.q2, att_q.q3, att_q.q4)));
 		//Here we have the angular velocity expressed in the aircraft frame
 		//We need to apply the static rotation to get it into the base_link frame
 		auto gyro = UAS::transform_frame_aircraft_baselink(

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -3,6 +3,7 @@
  * @file local_position.cpp
  * @author Vladimir Ermakov <vooon341@gmail.com>
  * @author Glenn Gregory
+ * @author Eddy Scott <scott.edward@aurora.aero>
  *
  * @addtogroup plugin
  * @{
@@ -23,10 +24,13 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/TransformStamped.h>
 
+#include <nav_msgs/Odometry.h>
+
 namespace mavplugin {
 /**
  * @brief Local position plugin.
- * Publish local position to TF and PositionStamped
+ * Publish local position to TF, PositionStamped, TwistStamped
+ * and Odometry
  */
 class LocalPositionPlugin : public MavRosPlugin {
 public:
@@ -40,15 +44,22 @@ public:
 	{
 		uas = &uas_;
 
-		// general params
-		lp_nh.param<std::string>("frame_id", frame_id, "fcu");
-		// tf subsection
+		// header frame_id.
+		// default to map (world-fixed,ENU as per REP-105).
+		lp_nh.param<std::string>("frame_id", frame_id, "map");
+		// Important tf subsection
+		// Report the transform from world to base_link here.  
 		lp_nh.param("tf/send", tf_send, true);
-		lp_nh.param<std::string>("tf/frame_id", tf_frame_id, "local_origin");
-		lp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "fcu");
+		lp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
+		lp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "base_link");
+		// Debug tf info
+		// broadcast the following transform: (can be expanded to more if desired)
+		// NED -> aircraft
+		lp_nh.param("tf/send_fcu",tf_send_fcu,false);
 
 		local_position = lp_nh.advertise<geometry_msgs::PoseStamped>("pose", 10);
 		local_velocity = lp_nh.advertise<geometry_msgs::TwistStamped>("velocity", 10);
+		local_odom = lp_nh.advertise<nav_msgs::Odometry>("odom",10);
 	}
 
 	const message_map get_rx_handlers() {
@@ -63,33 +74,53 @@ private:
 
 	ros::Publisher local_position;
 	ros::Publisher local_velocity;
+	ros::Publisher local_odom;
 
 	std::string frame_id;		//!< frame for Pose
 	std::string tf_frame_id;	//!< origin for TF
 	std::string tf_child_frame_id;	//!< frame for TF
 	bool tf_send;
+	bool tf_send_fcu; //!< report NED->aircraft in tf tree
 
 	void handle_local_position_ned(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
 		mavlink_local_position_ned_t pos_ned;
 		mavlink_msg_local_position_ned_decode(msg, &pos_ned);
 
-		auto position = UAS::transform_frame_ned_enu(Eigen::Vector3d(pos_ned.x, pos_ned.y, pos_ned.z));
-		auto velocity = UAS::transform_frame_ned_enu(Eigen::Vector3d(pos_ned.vx, pos_ned.vy, pos_ned.vz));
-		auto orientation = uas->get_attitude_orientation();
-		auto angular_velocity = uas->get_attitude_angular_velocity();
+		//--------------- Transform FCU position and Velocity Data ---------------//
+		auto enu_position = UAS::transform_frame_ned_enu(Eigen::Vector3d(pos_ned.x, pos_ned.y, pos_ned.z));
+		auto enu_velocity = UAS::transform_frame_ned_enu(Eigen::Vector3d(pos_ned.vx, pos_ned.vy, pos_ned.vz));
 
+		//--------------- Get Odom Information ---------------//
+		// Note this orientation describes baselink->ENU transform
+		auto enu_orientation_msg = uas->get_attitude_orientation();
+		auto baselink_angular_msg = uas->get_attitude_angular_velocity();
+		Eigen::Quaterniond enu_orientation;
+		tf::quaternionMsgToEigen(enu_orientation_msg,enu_orientation);
+		auto baselink_linear = UAS::transform_frame_enu_baselink(enu_velocity,enu_orientation.inverse());
+		
+		//--------------- Generate Message Pointers ---------------//
 		auto pose = boost::make_shared<geometry_msgs::PoseStamped>();
 		auto twist = boost::make_shared<geometry_msgs::TwistStamped>();
+		auto odom = boost::make_shared<nav_msgs::Odometry>();
 
 		pose->header = uas->synchronized_header(frame_id, pos_ned.time_boot_ms);
 		twist->header = pose->header;
 
-		tf::pointEigenToMsg(position, pose->pose.position);
-		pose->pose.orientation = orientation;
+		tf::pointEigenToMsg(enu_position, pose->pose.position);
+		pose->pose.orientation = enu_orientation_msg;
 
-		tf::vectorEigenToMsg(velocity,twist->twist.linear);
-		twist->twist.angular = angular_velocity;
-		
+		tf::vectorEigenToMsg(enu_velocity,twist->twist.linear);
+		twist->twist.angular = baselink_angular_msg;
+
+		odom->header.stamp = pose->header.stamp;
+		odom->header.frame_id = tf_frame_id;
+		odom->child_frame_id = tf_child_frame_id;
+		tf::vectorEigenToMsg(baselink_linear,odom->twist.twist.linear);
+		odom->twist.twist.angular = baselink_angular_msg;
+		odom->pose.pose = pose->pose;
+
+		//--------------- Publish Data ---------------//
+		local_odom.publish(odom);
 		local_position.publish(pose);
 		local_velocity.publish(twist);
 
@@ -100,10 +131,29 @@ private:
 			transform.header.frame_id = tf_frame_id;
 			transform.child_frame_id = tf_child_frame_id;
 
-			transform.transform.rotation = orientation;
-			tf::vectorEigenToMsg(position, transform.transform.translation);
+			transform.transform.rotation = enu_orientation_msg;
+			tf::vectorEigenToMsg(enu_position, transform.transform.translation);
 
 			uas->tf2_broadcaster.sendTransform(transform);
+		}
+		if (tf_send_fcu){
+			//--------------- Report NED->aircraft transform ---------------//
+			geometry_msgs::TransformStamped ned_aircraft_tf;
+
+			ned_aircraft_tf.header.stamp = pose->header.stamp;
+			ned_aircraft_tf.header.frame_id = "NED";
+			ned_aircraft_tf.child_frame_id = "aircraft";
+
+			//Don't just report the data from the mavlink message,
+			//actually perform rotations to see if anything is 
+			//wrong.
+			auto ned_position = UAS::transform_frame_enu_ned(enu_position);
+			tf::vectorEigenToMsg(ned_position, ned_aircraft_tf.transform.translation);
+
+			auto ned_orientation = UAS::transform_orientation_enu_ned(
+							UAS::transform_orientation_baselink_aircraft(enu_orientation));
+			tf::quaternionEigenToMsg(ned_orientation,ned_aircraft_tf.transform.rotation);
+			uas->tf2_broadcaster.sendTransform(ned_aircraft_tf);
 		}
 	}
 };

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -48,7 +48,7 @@ public:
 		// default to map (world-fixed,ENU as per REP-105).
 		lp_nh.param<std::string>("frame_id", frame_id, "map");
 		// Important tf subsection
-		// Report the transform from world to base_link here.  
+		// Report the transform from world to base_link here.
 		lp_nh.param("tf/send", tf_send, true);
 		lp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
 		lp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "base_link");
@@ -80,7 +80,7 @@ private:
 	std::string tf_frame_id;	//!< origin for TF
 	std::string tf_child_frame_id;	//!< frame for TF
 	bool tf_send;
-	bool tf_send_fcu; //!< report NED->aircraft in tf tree
+	bool tf_send_fcu;	//!< report NED->aircraft in tf tree
 
 	void handle_local_position_ned(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
 		mavlink_local_position_ned_t pos_ned;
@@ -97,7 +97,7 @@ private:
 		Eigen::Quaterniond enu_orientation;
 		tf::quaternionMsgToEigen(enu_orientation_msg,enu_orientation);
 		auto baselink_linear = UAS::transform_frame_enu_baselink(enu_velocity,enu_orientation.inverse());
-		
+
 		//--------------- Generate Message Pointers ---------------//
 		auto pose = boost::make_shared<geometry_msgs::PoseStamped>();
 		auto twist = boost::make_shared<geometry_msgs::TwistStamped>();
@@ -136,7 +136,7 @@ private:
 
 			uas->tf2_broadcaster.sendTransform(transform);
 		}
-		if (tf_send_fcu){
+		if (tf_send_fcu) {
 			//--------------- Report NED->aircraft transform ---------------//
 			geometry_msgs::TransformStamped ned_aircraft_tf;
 
@@ -145,13 +145,13 @@ private:
 			ned_aircraft_tf.child_frame_id = "aircraft";
 
 			//Don't just report the data from the mavlink message,
-			//actually perform rotations to see if anything is 
+			//actually perform rotations to see if anything is
 			//wrong.
 			auto ned_position = UAS::transform_frame_enu_ned(enu_position);
 			tf::vectorEigenToMsg(ned_position, ned_aircraft_tf.transform.translation);
 
 			auto ned_orientation = UAS::transform_orientation_enu_ned(
-							UAS::transform_orientation_baselink_aircraft(enu_orientation));
+					UAS::transform_orientation_baselink_aircraft(enu_orientation));
 			tf::quaternionEigenToMsg(ned_orientation,ned_aircraft_tf.transform.rotation);
 			uas->tf2_broadcaster.sendTransform(ned_aircraft_tf);
 		}

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -50,8 +50,8 @@ public:
 		sp_nh.param("reverse_throttle", reverse_throttle, false);
 		// tf params
 		sp_nh.param("tf/listen", tf_listen, false);
-		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "local_origin");
-		sp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "attitude");
+		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
+		sp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "aircraft");
 		sp_nh.param("tf/rate_limit", tf_rate, 10.0);
 
 		if (tf_listen) {
@@ -118,8 +118,8 @@ private:
 		float q[4];
 
 		UAS::quaternion_to_mavlink(
-				UAS::transform_frame_enu_ned(Eigen::Quaterniond(tr.rotation())),
-				q);
+				UAS::transform_orientation_enu_ned(
+					UAS::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation()))),q);
 
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_q,
@@ -139,7 +139,7 @@ private:
 		const uint8_t ignore_all_except_rpy = (1 << 7) | (1 << 6);
 		float q[4] = { 1.0, 0.0, 0.0, 0.0 };
 
-		auto av = UAS::transform_frame_enu_ned(ang_vel);
+		auto av = UAS::transform_frame_baselink_aircraft(ang_vel);
 
 		set_attitude_target(stamp.toNSec() / 1000000,
 				ignore_all_except_rpy,

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -45,8 +45,8 @@ public:
 
 		// tf params
 		sp_nh.param("tf/listen", tf_listen, false);
-		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "local_origin");
-		sp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "setpoint");
+		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
+		sp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "aircraft");
 		sp_nh.param("tf/rate_limit", tf_rate, 50.0);
 
 		if (tf_listen) {
@@ -92,7 +92,8 @@ private:
 		const uint16_t ignore_all_except_xyz_y = (1 << 11) | (7 << 6) | (7 << 3);
 
 		auto p = UAS::transform_frame_enu_ned(Eigen::Vector3d(tr.translation()));
-		auto q = UAS::transform_frame_enu_ned(Eigen::Quaterniond(tr.rotation()));
+		auto q = UAS::transform_orientation_enu_ned(
+				UAS::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation())));
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,

--- a/mavros/src/plugins/setpoint_raw.cpp
+++ b/mavros/src/plugins/setpoint_raw.cpp
@@ -73,7 +73,7 @@ private:
 		mavlink_position_target_local_ned_t tgt;
 		mavlink_msg_position_target_local_ned_decode(msg, &tgt);
 
-		// Transform frame NED->ENU
+		// Transform desired position,velocities,and accels from ENU to NED frame
 		auto position = UAS::transform_frame_ned_enu(Eigen::Vector3d(tgt.x, tgt.y, tgt.z));
 		auto velocity = UAS::transform_frame_ned_enu(Eigen::Vector3d(tgt.vx, tgt.vy, tgt.vz));
 		auto af = UAS::transform_frame_ned_enu(Eigen::Vector3d(tgt.afx, tgt.afy, tgt.afz));
@@ -98,7 +98,7 @@ private:
 		mavlink_position_target_global_int_t tgt;
 		mavlink_msg_position_target_global_int_decode(msg, &tgt);
 
-		// Transform frame NED->ENU
+		// Transform desired velocities from ENU to NED frame
 		auto velocity = UAS::transform_frame_ned_enu(Eigen::Vector3d(tgt.vx, tgt.vy, tgt.vz));
 		auto af = UAS::transform_frame_ned_enu(Eigen::Vector3d(tgt.afx, tgt.afy, tgt.afz));
 		float yaw = UAS::transform_frame_yaw_ned_enu(tgt.yaw);
@@ -124,9 +124,12 @@ private:
 		mavlink_attitude_target_t tgt;
 		mavlink_msg_attitude_target_decode(msg, &tgt);
 
-		// Transform frame NED->ENU
-		auto orientation = UAS::transform_frame_ned_enu(Eigen::Quaterniond(tgt.q[0], tgt.q[1], tgt.q[2], tgt.q[3]));
-		auto body_rate = UAS::transform_frame_ned_enu(Eigen::Vector3d(tgt.body_roll_rate, tgt.body_pitch_rate, tgt.body_yaw_rate));
+		// Transform orientation from baselink -> ENU 
+		// to aircraft -> NED
+		auto orientation = UAS::transform_orientation_ned_enu(
+						   UAS::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tgt.q[0], tgt.q[1], tgt.q[2], tgt.q[3])));
+
+		auto body_rate = UAS::transform_frame_baselink_aircraft(Eigen::Vector3d(tgt.body_roll_rate, tgt.body_pitch_rate, tgt.body_yaw_rate));
 
 		auto target = boost::make_shared<mavros_msgs::AttitudeTarget>();
 
@@ -231,20 +234,25 @@ private:
 	}
 
 	void attitude_cb(const mavros_msgs::AttitudeTarget::ConstPtr &req) {
-		Eigen::Quaterniond orientation;
-		Eigen::Vector3d body_rate;
+		Eigen::Quaterniond desired_orientation;
+		Eigen::Vector3d baselink_angular_rate;
 
-		tf::quaternionMsgToEigen(req->orientation, orientation);
+
+		tf::quaternionMsgToEigen(req->orientation, desired_orientation);
+
+		// Transform desired orientation to represent aircraft->NED,
+		// MAVROS operates on orientation of base_link->ENU
+		auto ned_desired_orientation = UAS::transform_orientation_enu_ned(
+			UAS::transform_orientation_baselink_aircraft(desired_orientation));
+
+		auto body_rate = UAS::transform_frame_baselink_aircraft(baselink_angular_rate);
+
 		tf::vectorMsgToEigen(req->body_rate, body_rate);
-
-		// Transform frame ENU->NED
-		orientation = UAS::transform_frame_enu_ned(orientation);
-		body_rate = UAS::transform_frame_enu_ned(body_rate);
 
 		set_attitude_target(
 				req->header.stamp.toNSec() / 1000000,
 				req->type_mask,
-				orientation,
+				desired_orientation,
 				body_rate,
 				req->thrust);
 	}

--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -70,7 +70,7 @@ private:
 		uint16_t ignore_all_except_v_xyz_yr = (1 << 10) | (7 << 6) | (7 << 0);
 
 		auto vel = UAS::transform_frame_enu_ned(vel_enu);
-		auto yr = UAS::transform_frame_enu_ned(Eigen::Vector3d(0.0, 0.0, yaw_rate));
+		auto yr = UAS::transform_frame_baselink_aircraft(Eigen::Vector3d(0.0, 0.0, yaw_rate));
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 				MAV_FRAME_LOCAL_NED,

--- a/mavros/test/test_frame_conversions.cpp
+++ b/mavros/test/test_frame_conversions.cpp
@@ -22,24 +22,74 @@ static const double epsilon_f = 1e-6;
 
 /* -*- test general transform function -*- */
 
-TEST(UAS, transform_frame__vector3d_123)
+TEST(UAS, transform_static_frame__aircraft_to_baselink_123)
 {
 	Eigen::Vector3d input(1, 2, 3);
 	Eigen::Vector3d expected(1, -2, -3);
 
-	auto out = UAS::transform_frame(input);
+	auto out = UAS::transform_static_frame(input,UAS::STATIC_TRANSFORM::AIRCRAFT_TO_BASELINK);
 
 	EXPECT_NEAR(expected.x(), out.x(), epsilon);
 	EXPECT_NEAR(expected.y(), out.y(), epsilon);
 	EXPECT_NEAR(expected.z(), out.z(), epsilon);
 }
 
-TEST(UAS, transform_frame__quaterniond_123)
+TEST(UAS, transform_static_frame__baselink_to_aircraft_123)
+{
+	Eigen::Vector3d input(1, 2, 3);
+	Eigen::Vector3d expected(1, -2, -3);
+
+	auto out = UAS::transform_static_frame(input,UAS::STATIC_TRANSFORM::BASELINK_TO_AIRCRAFT);
+
+	EXPECT_NEAR(expected.x(), out.x(), epsilon);
+	EXPECT_NEAR(expected.y(), out.y(), epsilon);
+	EXPECT_NEAR(expected.z(), out.z(), epsilon);
+}
+
+TEST(UAS, transform_static_frame__enu_to_ned_123)
+{
+	Eigen::Vector3d input(1, 2, 3);
+	Eigen::Vector3d expected(2, 1, -3);
+
+	auto out = UAS::transform_static_frame(input,UAS::STATIC_TRANSFORM::ENU_TO_NED);
+
+	EXPECT_NEAR(expected.x(), out.x(), epsilon);
+	EXPECT_NEAR(expected.y(), out.y(), epsilon);
+	EXPECT_NEAR(expected.z(), out.z(), epsilon);
+}
+
+TEST(UAS, transform_static_frame__ned_to_enu_123)
+{
+	Eigen::Vector3d input(1, 2, 3);
+	Eigen::Vector3d expected(2, 1, -3);
+
+	auto out = UAS::transform_static_frame(input,UAS::STATIC_TRANSFORM::ENU_TO_NED);
+
+	EXPECT_NEAR(expected.x(), out.x(), epsilon);
+	EXPECT_NEAR(expected.y(), out.y(), epsilon);
+	EXPECT_NEAR(expected.z(), out.z(), epsilon);
+}
+
+TEST(UAS, quaternion_transforms__ned_to_ned_123)
+{
+	auto input_aircraft_ned_orient = UAS::quaternion_from_rpy(1.0, 2.0, 3.0);
+	auto aircraft_enu_orient = UAS::transform_orientation_ned_enu(input_aircraft_ned_orient);
+	auto baselink_enu_orient = UAS::transform_orientation_aircraft_baselink(aircraft_enu_orient);
+	aircraft_enu_orient = UAS::transform_orientation_baselink_aircraft(baselink_enu_orient);
+	auto output_aircraft_ned = UAS::transform_orientation_enu_ned(aircraft_enu_orient);
+
+	EXPECT_QUATERNION(input_aircraft_ned_orient, output_aircraft_ned, epsilon);
+}
+
+#if 0
+// not implemented
+TEST(UAS, transform_static_frame__quaterniond_123)
 {
 	auto input = UAS::quaternion_from_rpy(1.0, 2.0, 3.0);
 	auto expected = UAS::quaternion_from_rpy(1.0, -2.0, -3.0);
 
-	auto out = UAS::transform_frame(input);
+	UAS::TRANSFORM_TYPE enu_sensor = UAS::PLATFORM_TO_ENU;
+	auto out = UAS::transform_frame(input,enu_sensor);
 
 	EXPECT_QUATERNION(expected, out, epsilon);
 }
@@ -63,16 +113,13 @@ TEST(UAS, transform_frame__covariance3x3)
 		7.0, -8.0, -9.0
 	}};
 
-	auto out = UAS::transform_frame(input);
+	auto out = UAS::transform_frame(input,enu_sensor);
 
 	for (size_t idx = 0; idx < expected.size(); idx++) {
 		SCOPED_TRACE(idx);
 		EXPECT_NEAR(expected[idx], out[idx], epsilon);
 	}
 }
-
-#if 0
-// not implemented
 TEST(UAS,  transform_frame__covariance6x6)
 {
 	UAS::Covariance6d input = {{

--- a/mavros_extras/src/plugins/mocap_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/mocap_pose_estimate.cpp
@@ -96,7 +96,8 @@ private:
 
 		tf::quaternionMsgToEigen(pose->pose.orientation, q_enu);
 		UAS::quaternion_to_mavlink(
-				UAS::transform_frame_enu_ned(q_enu),
+				UAS::transform_orientation_enu_ned(
+					UAS::transform_orientation_baselink_aircraft(q_enu)),
 				q);
 
 		auto position = UAS::transform_frame_enu_ned(
@@ -120,7 +121,8 @@ private:
 
 		tf::quaternionMsgToEigen(trans->transform.rotation, q_enu);
 		UAS::quaternion_to_mavlink(
-				UAS::transform_frame_enu_ned(q_enu),
+				UAS::transform_orientation_enu_ned(
+					UAS::transform_orientation_baselink_aircraft(q_enu)),
 				q);
 
 		auto position = UAS::transform_frame_enu_ned(

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -84,16 +84,14 @@ private:
 		 * Raw message with axes mapped to ROS conventions and temp in degrees celsius.
 		 *
 		 * The optical flow camera is essentially an angular sensor, so conversion is like
-		 * gyroscope. (body-fixed NED -> ENU)
+		 * gyroscope. (aircraft -> baselink)
 		 */
-
-
-		auto int_xy = UAS::transform_frame_enu_ned(
+		auto int_xy = UAS::transform_frame_aircraft_baselink(
 				Eigen::Vector3d(
 						flow_rad.integrated_x,
 						flow_rad.integrated_y,
 						0.0));
-		auto int_gyro = UAS::transform_frame_enu_ned(
+		auto int_gyro = UAS::transform_frame_aircraft_baselink(
 				Eigen::Vector3d(
 						flow_rad.integrated_xgyro,
 						flow_rad.integrated_ygyro,

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -48,7 +48,7 @@ public:
 
 		// tf params
 		sp_nh.param("tf/listen", tf_listen, false);
-		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "local_origin");
+		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
 		sp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "vision");
 		sp_nh.param("tf/rate_limit", tf_rate, 50.0);
 
@@ -115,7 +115,7 @@ private:
 
 		auto position = UAS::transform_frame_enu_ned(Eigen::Vector3d(tr.translation()));
 		auto rpy = UAS::quaternion_to_rpy(
-				UAS::transform_frame_ned_enu(Eigen::Quaterniond(tr.rotation())));
+				UAS::transform_orientation_enu_ned(Eigen::Quaterniond(tr.rotation())));
 
 		vision_position_estimate(stamp.toNSec() / 1000,
 				position.x(), position.y(), position.z(),

--- a/mavros_extras/src/plugins/vision_speed_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_speed_estimate.cpp
@@ -84,6 +84,7 @@ private:
 	void send_vision_speed(const geometry_msgs::Vector3 &vel_enu, const ros::Time &stamp) {
 		Eigen::Vector3d vel_;
 		tf::vectorMsgToEigen(vel_enu, vel_);
+		//Transform from ENU to NED frame
 		auto vel = UAS::transform_frame_enu_ned(vel_);
 
 		vision_speed_estimate(stamp.toNSec() / 1000,


### PR DESCRIPTION
This PR will add a nav_msgs/Odometry output to the local position plugin, solving #470 directly.  Additionally #438 will be addressed by this PR with an in-depth analysis of the current coordinate frames used, transformations between frames, and making these frames as [REP 105](http://www.ros.org/reps/rep-0105.html) and [REP 103](http://www.ros.org/reps/rep-0103.html) compliant with minimal impact on the current user base (e.g. with changing as few frame names as possible).

Coordinate Frame Examination
======
- [x] Review frames currently in use
    - [x] Determine if renaming frames to be REP 105 compliant is worth the disruption to current user base
    - [x] Review rotations between current frames in [uas_frame_conversions.cpp]
(https://github.com/mavlink/mavros/blob/master/mavros/src/lib/uas_frame_conversions.cpp)
    - [x] Update frame naming and rotation methods as necessary

Odometry Message Publication
======
- [x] Publish Odometry message 
    - [x] Determine proper frames to be placed in header and child frame within the message
    - [x] Calculate linear and angular velocities in the associated child frame
    - [x] Determine way in which to provide the pose and twist covariances from the local position message

Documentation
======
[Here](https://drive.google.com/open?id=1bDhaozrUu9F915T58WGzZeOM-McyU20dwxX-NRum1KA) is a discussion of the proposed changes and why they are being made.

To help facilitate ensuring frames are properly rotated I've [begun tabulating](https://docs.google.com/spreadsheets/d/1LnsWTblU92J5_SMinTvBvHJWx6sqvzFa8SKbn8TXlnU/edit?usp=sharing) each plugin's data and what frame it is represented in on the FCU.  Not being and Arducopter developer I will not be diving into  frame representations on that firmware stack but have included it anyway if someone wants to take the lead on it.