### PR TITLE
Add allow_udp_broadcast option

### DIFF
--- a/libmavconn/include/mavconn/interface.h
+++ b/libmavconn/include/mavconn/interface.h
@@ -173,7 +173,7 @@ public:
 	 *         or throw @a DeviceError if error occured.
 	 */
 	static Ptr open_url(std::string url,
-			uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE);
+                        uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE, bool allow_udp_broadcast = false);
 
 protected:
 	int channel;

--- a/libmavconn/include/mavconn/udp.h
+++ b/libmavconn/include/mavconn/udp.h
@@ -40,7 +40,7 @@ public:
 	 */
 	MAVConnUDP(uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
 			std::string bind_host = "localhost", unsigned short bind_port = 14555,
-			std::string remote_host = "", unsigned short remote_port = 14550);
+                        std::string remote_host = "", unsigned short remote_port = 14550, bool allow_broadcast = false);
 	~MAVConnUDP();
 
 	void close();

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -224,7 +224,7 @@ static MAVConnInterface::Ptr url_parse_serial(
 
 static MAVConnInterface::Ptr url_parse_udp(
 		std::string hosts, std::string query,
-		uint8_t system_id, uint8_t component_id)
+        uint8_t system_id, uint8_t component_id, bool allow_broadcast)
 {
 	std::string bind_pair, remote_pair;
 	std::string bind_host, remote_host;
@@ -246,7 +246,7 @@ static MAVConnInterface::Ptr url_parse_udp(
 
 	return boost::make_shared<MAVConnUDP>(system_id, component_id,
 			bind_host, bind_port,
-			remote_host, remote_port);
+            remote_host, remote_port, allow_broadcast);
 }
 
 static MAVConnInterface::Ptr url_parse_tcp_client(
@@ -280,7 +280,7 @@ static MAVConnInterface::Ptr url_parse_tcp_server(
 }
 
 MAVConnInterface::Ptr MAVConnInterface::open_url(std::string url,
-		uint8_t system_id, uint8_t component_id) {
+        uint8_t system_id, uint8_t component_id, bool allow_udp_broadcast) {
 
 	/* Based on code found here:
 	 * http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
@@ -326,7 +326,7 @@ MAVConnInterface::Ptr MAVConnInterface::open_url(std::string url,
 			path.c_str(), query.c_str());
 
 	if (proto == "udp")
-		return url_parse_udp(host, query, system_id, component_id);
+        return url_parse_udp(host, query, system_id, component_id, allow_udp_broadcast);
 	else if (proto == "tcp")
 		return url_parse_tcp_client(host, query, system_id, component_id);
 	else if (proto == "tcp-l")

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -82,11 +82,11 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 
 	try {
 		socket.open(udp::v4());
-        if(allow_broadcast)
-        {
-           boost::asio::socket_base::broadcast option(true);
-           socket.set_option(option);
-        }
+		if(allow_broadcast)
+		{
+			boost::asio::socket_base::broadcast option(true);
+			socket.set_option(option);
+		}
 		socket.bind(bind_ep);
 	}
 	catch (boost::system::system_error &err) {

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -58,7 +58,7 @@ static bool resolve_address_udp(io_service &io, int chan, std::string host, unsi
 
 MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 		std::string bind_host, unsigned short bind_port,
-		std::string remote_host, unsigned short remote_port) :
+        std::string remote_host, unsigned short remote_port, bool allow_broadcast) :
 	MAVConnInterface(system_id, component_id),
 	remote_exists(false),
 	tx_in_progress(false),
@@ -82,6 +82,11 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 
 	try {
 		socket.open(udp::v4());
+        if(allow_broadcast)
+        {
+           boost::asio::socket_base::broadcast option(true);
+           socket.set_option(option);
+        }
 		socket.bind(bind_ep);
 	}
 	catch (boost::system::system_error &err) {

--- a/mavros/src/gcs_bridge.cpp
+++ b/mavros/src/gcs_bridge.cpp
@@ -53,9 +53,11 @@ int main(int argc, char *argv[])
 
 	std::string gcs_url;
 	priv_nh.param<std::string>("gcs_url", gcs_url, "udp://@");
+    bool allow_udp_broadcast;
+    priv_nh.param("allow_udp_broadcast", allow_udp_broadcast, false);
 
 	try {
-		gcs_link = MAVConnInterface::open_url(gcs_url);
+        gcs_link = MAVConnInterface::open_url(gcs_url, 1, MAV_COMP_ID_UDP_BRIDGE, allow_udp_broadcast);
 		gcs_link_diag.set_mavconn(gcs_link);
 		gcs_link_diag.set_connection_status(true);
 	}

--- a/mavros/src/lib/mavros.cpp
+++ b/mavros/src/lib/mavros.cpp
@@ -126,7 +126,7 @@ MavRos::MavRos() :
 #define STR(x)	STR2(x)
 
 	ROS_INFO("Built-in SIMD instructions: %s", Eigen::SimdInstructionSetsInUse());
-	ROS_INFO("Built-in MAVLink package version: %s", MAVLINK_VERSION);
+    ROS_INFO("Built-in MAVLink package version: %d", MAVLINK_VERSION);
 	ROS_INFO("Built-in MAVLink dialect: %s", STR(MAVLINK_DIALECT));
 	ROS_INFO("MAVROS started. MY ID [%d, %d], TARGET ID [%d, %d]",
 		system_id, component_id,

--- a/mavros/src/lib/mavros.cpp
+++ b/mavros/src/lib/mavros.cpp
@@ -32,7 +32,7 @@ MavRos::MavRos() :
 	std::string fcu_url, gcs_url;
 	int system_id, component_id;
 	int tgt_system_id, tgt_component_id;
-	bool px4_usb_quirk;
+	bool px4_usb_quirk, allow_udp_broadcast;
 	ros::V_string plugin_blacklist{}, plugin_whitelist{};
 	MAVConnInterface::Ptr fcu_link;
 
@@ -47,6 +47,7 @@ MavRos::MavRos() :
 	nh.param("startup_px4_usb_quirk", px4_usb_quirk, false);
 	nh.getParam("plugin_blacklist", plugin_blacklist);
 	nh.getParam("plugin_whitelist", plugin_whitelist);
+	nh.param("allow_udp_broadcast", allow_udp_broadcast, false);
 
 	// Now we use FCU URL as a hardware Id
 	UAS_DIAG(&mav_uas).setHardwareID(fcu_url);
@@ -70,7 +71,7 @@ MavRos::MavRos() :
 	if (gcs_url != "") {
 		ROS_INFO_STREAM("GCS URL: " << gcs_url);
 		try {
-			gcs_link = MAVConnInterface::open_url(gcs_url, system_id, component_id);
+			gcs_link = MAVConnInterface::open_url(gcs_url, system_id, component_id, allow_udp_broadcast);
 
 			gcs_link_diag.set_mavconn(gcs_link);
 			UAS_DIAG(&mav_uas).add(gcs_link_diag);


### PR DESCRIPTION
This adds `allow_udp_broadcast` option to mavros. This feature required, for example, to use qgroundcontrol on any device, connected to companion computer by wifi, without any tuning. Also, this fixes format string bug on startup of `mavros_node`.
