### PR TITLE
configurable vehicle model

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   visualization_msgs
   urdf
+  tf
 )
 
 ## System dependencies are found with CMake's conventions

--- a/mavros_extras/package.xml
+++ b/mavros_extras/package.xml
@@ -29,6 +29,7 @@
   <depend>std_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>urdf</depend>
+  <depend>tf</depend>
 
   <export>
     <mavros plugin="${prefix}/mavros_plugins.xml" />

--- a/mavros_extras/src/copter_visualization.cpp
+++ b/mavros_extras/src/copter_visualization.cpp
@@ -65,14 +65,18 @@ static void create_vehicle_markers( int num_rotors, float arm_len, float body_wi
 {
     if ( num_rotors <= 0 ) num_rotors=2;
     
-	/** Hexacopter marker code adapted from libsfly_viz
-	 *  thanks to Markus Achtelik.
-	 */
-    
+    /** Create markers only once for efficiency 
+     *  TODO use visualization_msgs::MarkerArray?
+     */
+
     if ( !vehicle_markers.empty() )
         return;
         
     vehicle_markers.reserve( 2*num_rotors + 1 );
+    
+	/** Hexacopter marker code adapted from libsfly_viz
+	 *  thanks to Markus Achtelik.
+	 */
     
 	// rotor marker template
     visualization_msgs::Marker rotor;


### PR DESCRIPTION
changes to mavros_extras/copter_visualization to make vehicle model configurable:
*  number of rotors
*  arm length
*  body width/height

(package now depends on TF for tf::createQuaternionMsgFromYaw but this could be removed)