### PR TITLE
Plugin for manual control using sensor_msgs::Joy messages

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(mavros_extras
   src/plugins/vision_speed_estimate.cpp
   src/plugins/vibration.cpp
   src/plugins/cam_imu_sync.cpp
+  src/plugins/joy_control.cpp
 )
 target_link_libraries(mavros_extras
   ${mavros_LIBRARIES}

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -23,4 +23,8 @@
         <class name="cam_imu_sync" type="mavplugin::CamIMUSyncPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish camera trigger data for synchronisation of IMU and camera frames</description>
 	</class>
+	</class>
+        <class name="joy_control" type="mavplugin::JoyControlPlugin" base_class_type="mavplugin::MavRosPlugin">
+		<description>Listen to sensor_msgs::Joy and convert into Mavlink manual control messages</description>
+	</class>
 </library>

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -20,7 +20,7 @@
 	<class name="vibration" type="mavplugin::VibrationPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish VIBRATION message data from FCU.</description>
 	</class>
-		<class name="cam_imu_sync" type="mavplugin::CamIMUSyncPlugin" base_class_type="mavplugin::MavRosPlugin">
+	<class name="cam_imu_sync" type="mavplugin::CamIMUSyncPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish camera trigger data for synchronisation of IMU and camera frames</description>
 	</class>
 	<class name="joy_control" type="mavplugin::JoyControlPlugin" base_class_type="mavplugin::MavRosPlugin">

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -23,8 +23,7 @@
         <class name="cam_imu_sync" type="mavplugin::CamIMUSyncPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish camera trigger data for synchronisation of IMU and camera frames</description>
 	</class>
-	</class>
-        <class name="joy_control" type="mavplugin::JoyControlPlugin" base_class_type="mavplugin::MavRosPlugin">
+    <class name="joy_control" type="mavplugin::JoyControlPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Listen to sensor_msgs::Joy and convert into Mavlink manual control messages</description>
 	</class>
 </library>

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -20,10 +20,10 @@
 	<class name="vibration" type="mavplugin::VibrationPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish VIBRATION message data from FCU.</description>
 	</class>
-        <class name="cam_imu_sync" type="mavplugin::CamIMUSyncPlugin" base_class_type="mavplugin::MavRosPlugin">
+		<class name="cam_imu_sync" type="mavplugin::CamIMUSyncPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish camera trigger data for synchronisation of IMU and camera frames</description>
 	</class>
-    <class name="joy_control" type="mavplugin::JoyControlPlugin" base_class_type="mavplugin::MavRosPlugin">
+	<class name="joy_control" type="mavplugin::JoyControlPlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Listen to sensor_msgs::Joy and convert into Mavlink manual control messages</description>
 	</class>
 </library>

--- a/mavros_extras/src/plugins/joy_control.cpp
+++ b/mavros_extras/src/plugins/joy_control.cpp
@@ -24,13 +24,14 @@
 #include <mavros_msgs/State.h>
 #include <mavros_msgs/SetMode.h>
 
-using namespace std;
-
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace mavplugin {
-struct Control
+/**
+ * @brief Properties for joystick control axis
+ */
+struct JoyControl
 {
 	int axis;
 	double scale;
@@ -42,6 +43,17 @@ struct Control
 		if ( axis < 0 || axis >= joy->axes.size() ) throw std::out_of_range("failed to map axis");
 		double val = joy->axes[axis] + offset;
 		return ( val > deadzone || val < -deadzone ? val * scale : 0.0 );
+	}
+
+	void load_params( ros::NodeHandle &priv_nh, const std::string& name,
+			int def_axis = 0, double def_scale = 1, double def_offset = 0, double def_deadzone = 0 )
+	{
+		auto nh = ros::NodeHandle( priv_nh, name );
+
+		nh.param( "axis",		axis,		def_axis		);
+		nh.param( "scale",		scale,		def_scale		);
+		nh.param( "offset",		offset,		def_offset		);
+		nh.param( "deadzone",	deadzone,	def_deadzone	);
 	}
 };
 
@@ -55,16 +67,14 @@ class JoyControlPlugin : public MavRosPlugin
 {
 	ros::NodeHandle mavros_nh_, plugin_nh_;
 	UAS *uas_;
-	mavros_msgs::State state_;
-	mavlink_message_t ctrl_msg_;
+	mavros_msgs::State::ConstPtr curr_state_;
 
-	Control x_, y_, z_, r_;
+	JoyControl x_, y_, z_, r_;
 
 	int arm_button_;
-	vector<int> mode_mapping_;
-	vector<string> mode_names_;
+	std::vector<int> mode_mapping_;
+	std::vector<std::string> mode_names_;
 
-	ros::Timer send_msg_timer_;
 	ros::ServiceClient arming_srv_, set_mode_srv_;
 	ros::Subscriber joystick_sub_, state_sub_;
 
@@ -78,48 +88,29 @@ public:
 	{
 		uas_ = &uas;
 
-		int msg_rate;
-
-		plugin_nh_.param<int>("msg_rate", msg_rate, 10 );
-		plugin_nh_.param<int>("arm_button", arm_button_, 2 );
-
 		// Mode switches on remotes can be reported a single flag, or as a binary
 		// combination of several flags: eg. mode1=[0,0]=0, mode2=[1,0]=1, mode3=[0,1]=2
 		// mode_mapping={3,4} means a binary combination of the 4th and 5th values
-		// in the sensor_msgs::Joy buttons array
+		// in the sensor_msgs::Joy buttons array.
 
-		plugin_nh_.param< vector<int> >("mode_mapping", mode_mapping_, {3,4} );
-		plugin_nh_.param< vector<string> >("mode_names", mode_names_, {"MANUAL","ALTCTL","OFFBOARD"} );
+		// Note: param<> template type must be specified
+		// here for compatibility with older compilers.
 
-		plugin_nh_.param<int>      ("x_axis",       x_.axis,        1   );
-		plugin_nh_.param<double>   ("x_scale",      x_.scale,       1.0 );
-		plugin_nh_.param<double>   ("x_offset",     x_.offset,      0.0 );
-		plugin_nh_.param<double>   ("x_deadzone",   x_.deadzone,    0.2 );
+		plugin_nh_.param< std::vector<int>			>("mode_mapping", mode_mapping_, {3,4} );
+		plugin_nh_.param< std::vector<std::string>  >("mode_names", mode_names_, {"MANUAL","ALTCTL","OFFBOARD"} );
 
-		plugin_nh_.param<int>      ("y_axis",       y_.axis,        0   );
-		plugin_nh_.param<double>   ("y_scale",      y_.scale,       1.0 );
-		plugin_nh_.param<double>   ("y_offset",     y_.offset,      0.0 );
-		plugin_nh_.param<double>   ("y_deadzone",   y_.deadzone,    0.2 );
+		plugin_nh_.param("arm_button", arm_button_, 2 );
 
-		plugin_nh_.param<int>      ("z_axis",       z_.axis,        2   );
-		plugin_nh_.param<double>   ("z_scale",      z_.scale,       1.0 );
-		plugin_nh_.param<double>   ("z_offset",     z_.offset,      0.0 );
-		plugin_nh_.param<double>   ("z_deadzone",   z_.deadzone,    0.0 );
-
-		plugin_nh_.param<int>      ("r_axis",       r_.axis,        4   );
-		plugin_nh_.param<double>   ("r_scale",      r_.scale,       1.0 );
-		plugin_nh_.param<double>   ("r_offset",     r_.offset,      0.0 );
-		plugin_nh_.param<double>   ("r_deadzone",   r_.deadzone,    0.2 );
+		x_.load_params( plugin_nh_, "x", 1, 1.0, 0.0, 0.2 );
+		y_.load_params( plugin_nh_, "y", 0, 1.0, 0.0, 0.2 );
+		z_.load_params( plugin_nh_, "z", 2, 1.0, 0.0, 0.0 );
+		r_.load_params( plugin_nh_, "r", 4, 1.0, 0.0, 0.2 );
 
 		arming_srv_ = mavros_nh_.serviceClient<mavros_msgs::CommandBool>("cmd/arming");
 		set_mode_srv_ = mavros_nh_.serviceClient<mavros_msgs::SetMode>("set_mode");
 
-		arming_srv_.waitForExistence();
-		//set_mode_srv_.waitForExistence();
-
 		joystick_sub_ = mavros_nh_.subscribe("joy_topic", 10, &JoyControlPlugin::handle_joystick, this );
 		state_sub_ = mavros_nh_.subscribe("state", 10, &JoyControlPlugin::handle_state, this );
-		send_msg_timer_ = mavros_nh_.createTimer( ros::Rate(msg_rate), &JoyControlPlugin::send_message, this );
 	}
 
 	const message_map get_rx_handlers() {
@@ -131,7 +122,7 @@ private:
 	////////////////////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////
 
-	uint16_t array_to_bitset( const vector<int32_t>& array )
+	uint16_t array_to_bitset( const std::vector<int32_t>& array )
 	{
 		uint16_t bits = 0;
 
@@ -148,20 +139,24 @@ private:
 	{
 		try
 		{
+			handle_arming( joy );
+			handle_mode( joy );
+
 			// PX4 seems to ignore the buttons field when processing manual
 			// control messages so we need to handle button input ourselves
 			// @see MavlinkReceiver::handle_message_manual_control()
-
-			handle_arming   ( joy );// toggle arm/disarm based on /mavros/state
-			handle_mode     ( joy );
 
 			float x = x_.map_axis( joy );
 			float y = y_.map_axis( joy );
 			float z = z_.map_axis( joy );
 			float r = r_.map_axis( joy );
 
-			mavlink_msg_manual_control_pack_chan( UAS_PACK_CHAN(uas_), &ctrl_msg_,
+			mavlink_message_t ctrl_msg;
+
+			mavlink_msg_manual_control_pack_chan( UAS_PACK_CHAN(uas_), &ctrl_msg,
 					(uas_)->get_tgt_system(), x, y, z, r, array_to_bitset(joy->buttons) );
+
+			UAS_FCU(uas_)->send_message(&ctrl_msg);
 		}
 		catch ( const std::out_of_range& e )
 		{
@@ -172,32 +167,25 @@ private:
 	////////////////////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////
 
-	void send_message( const ros::TimerEvent& ) {
-		UAS_FCU(uas_)->send_message(&ctrl_msg_);
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////////
-
 	void handle_arming( const sensor_msgs::Joy::ConstPtr& joy )
 	{
+		if ( !curr_state_ )
+		{
+			ROS_WARN_THROTTLE( 1, "need message on state topic to arm/disarm" );
+			return;
+		}
+
 		if ( arm_button_ < 0 || arm_button_ > joy->buttons.size() )
 			throw std::out_of_range("arm button index is invalid");
 
 		bool arm_button_on = joy->buttons[arm_button_];
+		if ( !arm_button_on ) return;	// nothing to do
 
-		if ( arm_button_on && !state_.armed )
-		{
-			mavros_msgs::CommandBool arming;
-			arming.request.value = true;
-			arming_srv_.call(arming);
-		}
-		else if ( arm_button_on && state_.armed )
-		{
-			mavros_msgs::CommandBool arming;
-			arming.request.value = false;
-			arming_srv_.call(arming);
-		}
+		mavros_msgs::CommandBool arming;
+		arming.request.value = !curr_state_->armed;
+
+		if ( !arming_srv_.call(arming) || !arming.response.success )
+			ROS_WARN("call to arm/disarm service failed with result=%d", arming.response.result );
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -205,6 +193,12 @@ private:
 
 	void handle_mode( const sensor_msgs::Joy::ConstPtr& joy )
 	{
+		if ( !curr_state_ )
+		{
+			ROS_WARN_THROTTLE( 1, "need message on state topic to change mode" );
+			return;
+		}
+
 		int mode_idx = 0;
 
 		// find the mode index as a binary combination of the multiple flags
@@ -213,22 +207,24 @@ private:
 		for ( int i = 0; i < mode_mapping_.size(); ++i )
 			mode_idx += pow(2,i) * joy->buttons.at( mode_mapping_[i] );
 
-		static mavros_msgs::SetMode set_mode;
+		mavros_msgs::SetMode set_mode;
 		set_mode.request.custom_mode = mode_names_.at(mode_idx);
 
-		if ( set_mode.request.custom_mode != state_.mode )
-		{
-			ROS_INFO_STREAM("setting custom mode=" << set_mode.request.custom_mode);
-			set_mode_srv_.call( set_mode );
-		}
+		if ( set_mode.request.custom_mode == curr_state_->mode )
+			return;	// already in requested mode
+
+		ROS_INFO_STREAM( "setting custom mode=" << set_mode.request.custom_mode );
+
+		if ( !set_mode_srv_.call(set_mode) || !set_mode.response.success )
+			ROS_WARN_STREAM("failed to set custom mode");
 	}
 
 	////////////////////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////
 
-	void handle_state( const mavros_msgs::State::ConstPtr& msg )
+	void handle_state( const mavros_msgs::State::ConstPtr& state )
 	{
-		state_ = *msg;
+		curr_state_ = state;
 	}
 };
 };	// namespace mavplugin

--- a/mavros_extras/src/plugins/joy_control.cpp
+++ b/mavros_extras/src/plugins/joy_control.cpp
@@ -7,6 +7,8 @@
  * @{
  */
 /*
+ * Copyright 2016 Francois Chataigner.
+ *
  * This file is part of the mavros package and subject to the license terms
  * in the top-level LICENSE file of the mavros repository.
  * https://github.com/mavlink/mavros/tree/master/LICENSE.md
@@ -22,50 +24,39 @@
 #include <mavros_msgs/State.h>
 #include <mavros_msgs/SetMode.h>
 
-#include <thread>
-#include <mutex>
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename Service>
-bool call_service( const string& service_name, const typename Service::Request& req )
-{
-	if ( !ros::service::exists( service_name, true ) )
-		return false;
-
-	Service cmd;
-	cmd.request = req;
-
-	bool success = ros::service::call( service_name, cmd ) && cmd.response.success;
-	ROS_DEBUG_STREAM( "calling service=" << service_name << " success=" << success );
-	return success;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-
 namespace mavplugin {
+struct Control
+{
+	int axis;
+	double scale;
+	double offset;
+	double deadzone;
+
+	double map_axis( const sensor_msgs::Joy::ConstPtr& joy ) const
+	{
+		if ( axis < 0 || axis >= joy->axes.size() ) throw std::out_of_range("failed to map axis");
+		double val = joy->axes[axis] + offset;
+		return ( val > deadzone || val < -deadzone ? val * scale : 0.0 );
+	}
+};
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
 /**
  * @brief Joystick Control plugin
  */
 class JoyControlPlugin : public MavRosPlugin
 {
-	struct Control
-	{
-		int axis;
-		double scale;
-		double offset;
-		double deadzone;
-
-		double map_axis( const sensor_msgs::Joy::ConstPtr& joy ) const
-		{
-			if ( axis < 0 || axis >= joy->axes.size() ) throw std::out_of_range("failed to map axis");
-			double val = joy->axes[axis] + offset;
-			return ( val > deadzone || val < -deadzone ? val * scale : 0.0 );
-		}
-	};
+	ros::NodeHandle mavros_nh_, plugin_nh_;
+	UAS *uas_;
+	mavros_msgs::State state_;
+	mavlink_message_t ctrl_msg_;
 
 	Control x_, y_, z_, r_;
 
@@ -73,59 +64,62 @@ class JoyControlPlugin : public MavRosPlugin
 	vector<int> mode_mapping_;
 	vector<string> mode_names_;
 
-	string arming_service_;
-	string mode_service_;
+	ros::Timer send_msg_timer_;
+	ros::ServiceClient arming_srv_, set_mode_srv_;
+	ros::Subscriber joystick_sub_, state_sub_;
 
 public:
-	JoyControlPlugin() :
-		nh_("~joy_control"),
-		uas_(nullptr) {}
+	JoyControlPlugin()
+		: mavros_nh_("~")
+		, plugin_nh_("~joy_control")
+		, uas_(nullptr) {}
 
 	void initialize(UAS &uas )
 	{
 		uas_ = &uas;
 
-		int rc_rate_hz;
+		int msg_rate;
 
-		nh_.param("rc_rate_hz",     rc_rate_hz,      10 );
-
-		nh_.param("arming_service", arming_service_, string("/mavros/cmd/arming") );
-		nh_.param("mode_service",   mode_service_,   string("/mavros/set_mode") );
+		plugin_nh_.param<int>("msg_rate", msg_rate, 10 );
+		plugin_nh_.param<int>("arm_button", arm_button_, 2 );
 
 		// Mode switches on remotes can be reported a single flag, or as a binary
 		// combination of several flags: eg. mode1=[0,0]=0, mode2=[1,0]=1, mode3=[0,1]=2
 		// mode_mapping={3,4} means a binary combination of the 4th and 5th values
 		// in the sensor_msgs::Joy buttons array
 
-		nh_.param("mode_mapping",   mode_mapping_,  {3,4} );
-		nh_.param("mode_names",     mode_names_,    {"MANUAL","ALTCTL","OFFBOARD"} );
+		plugin_nh_.param< vector<int> >("mode_mapping", mode_mapping_, {3,4} );
+		plugin_nh_.param< vector<string> >("mode_names", mode_names_, {"MANUAL","ALTCTL","OFFBOARD"} );
 
-		nh_.param("arm_button",     arm_button_,    2   );
+		plugin_nh_.param<int>      ("x_axis",       x_.axis,        1   );
+		plugin_nh_.param<double>   ("x_scale",      x_.scale,       1.0 );
+		plugin_nh_.param<double>   ("x_offset",     x_.offset,      0.0 );
+		plugin_nh_.param<double>   ("x_deadzone",   x_.deadzone,    0.2 );
 
-		nh_.param("x_axis",         x_.axis,        1   );
-		nh_.param("x_scale",        x_.scale,       1.0 );
-		nh_.param("x_offset",       x_.offset,      0.0 );
-		nh_.param("x_deadzone",     x_.deadzone,    0.2 );
+		plugin_nh_.param<int>      ("y_axis",       y_.axis,        0   );
+		plugin_nh_.param<double>   ("y_scale",      y_.scale,       1.0 );
+		plugin_nh_.param<double>   ("y_offset",     y_.offset,      0.0 );
+		plugin_nh_.param<double>   ("y_deadzone",   y_.deadzone,    0.2 );
 
-		nh_.param("y_axis",         y_.axis,        0   );
-		nh_.param("y_scale",        y_.scale,       1.0 );
-		nh_.param("y_offset",       y_.offset,      0.0 );
-		nh_.param("y_deadzone",     y_.deadzone,    0.2 );
+		plugin_nh_.param<int>      ("z_axis",       z_.axis,        2   );
+		plugin_nh_.param<double>   ("z_scale",      z_.scale,       1.0 );
+		plugin_nh_.param<double>   ("z_offset",     z_.offset,      0.0 );
+		plugin_nh_.param<double>   ("z_deadzone",   z_.deadzone,    0.0 );
 
-		nh_.param("z_axis",         z_.axis,        2   );
-		nh_.param("z_scale",        z_.scale,       1.0 );
-		nh_.param("z_offset",       z_.offset,      0.0 );
-		nh_.param("z_deadzone",     z_.deadzone,    0.0 );
+		plugin_nh_.param<int>      ("r_axis",       r_.axis,        4   );
+		plugin_nh_.param<double>   ("r_scale",      r_.scale,       1.0 );
+		plugin_nh_.param<double>   ("r_offset",     r_.offset,      0.0 );
+		plugin_nh_.param<double>   ("r_deadzone",   r_.deadzone,    0.2 );
 
-		nh_.param("r_axis",         r_.axis,        4   );
-		nh_.param("r_scale",        r_.scale,       1.0 );
-		nh_.param("r_offset",       r_.offset,      0.0 );
-		nh_.param("r_deadzone",     r_.deadzone,    0.2 );
+		arming_srv_ = mavros_nh_.serviceClient<mavros_msgs::CommandBool>("cmd/arming");
+		set_mode_srv_ = mavros_nh_.serviceClient<mavros_msgs::SetMode>("set_mode");
 
-		joystick_sub_ = nh_.subscribe("/joy", 10, &JoyControlPlugin::handle_joystick, this );
-		state_sub_ = nh_.subscribe("/mavros/state", 10, &JoyControlPlugin::handle_state, this );
+		arming_srv_.waitForExistence();
+		//set_mode_srv_.waitForExistence();
 
-		thread_.reset( new std::thread( &JoyControlPlugin::thread_call, this, rc_rate_hz ) );
+		joystick_sub_ = mavros_nh_.subscribe("joy_topic", 10, &JoyControlPlugin::handle_joystick, this );
+		state_sub_ = mavros_nh_.subscribe("state", 10, &JoyControlPlugin::handle_state, this );
+		send_msg_timer_ = mavros_nh_.createTimer( ros::Rate(msg_rate), &JoyControlPlugin::send_message, this );
 	}
 
 	const message_map get_rx_handlers() {
@@ -133,34 +127,6 @@ public:
 	}
 
 private:
-	ros::NodeHandle nh_;
-	UAS *uas_;
-	ros::Subscriber joystick_sub_, state_sub_;
-	mavros_msgs::State state_;
-
-	std::mutex msg_mutex_;
-	shared_ptr<std::thread> thread_;
-	mavlink_message_t ctrl_msg_;
-
-	////////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////////
-
-	void thread_call( float rate_hz )
-	{
-		ros::Rate rate(rate_hz);
-
-		// We need to keep sending messages at a fixed
-		// rate or PX4 will trigger RC timeouts
-
-		while (1)
-		{
-			msg_mutex_.lock();
-			UAS_FCU(uas_)->send_message(&ctrl_msg_);
-			msg_mutex_.unlock();
-
-			rate.sleep();
-		}
-	}
 
 	////////////////////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////
@@ -194,15 +160,20 @@ private:
 			float z = z_.map_axis( joy );
 			float r = r_.map_axis( joy );
 
-			std::lock_guard<std::mutex> lock(msg_mutex_);
-
 			mavlink_msg_manual_control_pack_chan( UAS_PACK_CHAN(uas_), &ctrl_msg_,
 					(uas_)->get_tgt_system(), x, y, z, r, array_to_bitset(joy->buttons) );
 		}
 		catch ( const std::out_of_range& e )
 		{
-			ROS_WARN( "failed to process joystick input: %s", e.what() );
+			ROS_ERROR( "failed to process joystick input: %s", e.what() );
 		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	void send_message( const ros::TimerEvent& ) {
+		UAS_FCU(uas_)->send_message(&ctrl_msg_);
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -217,15 +188,15 @@ private:
 
 		if ( arm_button_on && !state_.armed )
 		{
-			mavros_msgs::CommandBool::Request req;
-			req.value = true;
-			call_service<mavros_msgs::CommandBool>( arming_service_, req );
+			mavros_msgs::CommandBool arming;
+			arming.request.value = true;
+			arming_srv_.call(arming);
 		}
 		else if ( arm_button_on && state_.armed )
 		{
-			mavros_msgs::CommandBool::Request req;
-			req.value = false;
-			call_service<mavros_msgs::CommandBool>( arming_service_, req );
+			mavros_msgs::CommandBool arming;
+			arming.request.value = false;
+			arming_srv_.call(arming);
 		}
 	}
 
@@ -242,13 +213,13 @@ private:
 		for ( int i = 0; i < mode_mapping_.size(); ++i )
 			mode_idx += pow(2,i) * joy->buttons.at( mode_mapping_[i] );
 
-		static mavros_msgs::SetMode::Request req;
-		req.custom_mode = mode_names_.at(mode_idx);
+		static mavros_msgs::SetMode set_mode;
+		set_mode.request.custom_mode = mode_names_.at(mode_idx);
 
-		if ( req.custom_mode != state_.mode )
+		if ( set_mode.request.custom_mode != state_.mode )
 		{
-			ROS_INFO_STREAM("setting mode=" << req.custom_mode);
-			call_service<mavros_msgs::SetMode>( mode_service_, req );
+			ROS_INFO_STREAM("setting custom mode=" << set_mode.request.custom_mode);
+			set_mode_srv_.call( set_mode );
 		}
 	}
 

--- a/mavros_extras/src/plugins/joy_control.cpp
+++ b/mavros_extras/src/plugins/joy_control.cpp
@@ -1,0 +1,266 @@
+/**
+ * @brief JoyControl plugin
+ * @file joy_control.cpp
+ * @author Francois Chataigner <chataign@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <pluginlib/class_list_macros.h>
+
+#include <sensor_msgs/Joy.h>
+
+#include <mavros_msgs/SetMode.h>
+#include <mavros_msgs/CommandBool.h>
+#include <mavros_msgs/State.h>
+#include <mavros_msgs/SetMode.h>
+
+#include <thread>
+#include <mutex>
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+template<typename Service>
+bool call_service( const string& service_name, const typename Service::Request& req )
+{
+	if ( !ros::service::exists( service_name, true ) )
+		return false;
+
+	Service cmd;
+	cmd.request = req;
+
+	bool success = ros::service::call( service_name, cmd ) && cmd.response.success;
+	ROS_DEBUG_STREAM( "calling service=" << service_name << " success=" << success );
+	return success;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+namespace mavplugin {
+/**
+ * @brief Joystick Control plugin
+ */
+class JoyControlPlugin : public MavRosPlugin
+{
+	struct Control
+	{
+		int axis;
+		double scale;
+		double offset;
+		double deadzone;
+
+		double map_axis( const sensor_msgs::Joy::ConstPtr& joy ) const
+		{
+			if ( axis < 0 || axis >= joy->axes.size() ) throw std::out_of_range("failed to map axis");
+			double val = joy->axes[axis] + offset;
+			return ( val > deadzone || val < -deadzone ? val * scale : 0.0 );
+		}
+	};
+
+	Control x_, y_, z_, r_;
+
+	int arm_button_;
+	vector<int> mode_mapping_;
+	vector<string> mode_names_;
+
+	string arming_service_;
+	string mode_service_;
+
+public:
+	JoyControlPlugin() :
+		nh_("~joy_control"),
+		uas_(nullptr) {}
+
+	void initialize(UAS &uas )
+	{
+		uas_ = &uas;
+
+		int rc_rate_hz;
+
+		nh_.param("rc_rate_hz",     rc_rate_hz,      10 );
+
+		nh_.param("arming_service", arming_service_, string("/mavros/cmd/arming") );
+		nh_.param("mode_service",   mode_service_,   string("/mavros/set_mode") );
+
+		// Mode switches on remotes can be reported a single flag, or as a binary
+		// combination of several flags: eg. mode1=[0,0]=0, mode2=[1,0]=1, mode3=[0,1]=2
+		// mode_mapping={3,4} means a binary combination of the 4th and 5th values
+		// in the sensor_msgs::Joy buttons array
+
+		nh_.param("mode_mapping",   mode_mapping_,  {3,4} );
+		nh_.param("mode_names",     mode_names_,    {"MANUAL","ALTCTL","OFFBOARD"} );
+
+		nh_.param("arm_button",     arm_button_,    2   );
+
+		nh_.param("x_axis",         x_.axis,        1   );
+		nh_.param("x_scale",        x_.scale,       1.0 );
+		nh_.param("x_offset",       x_.offset,      0.0 );
+		nh_.param("x_deadzone",     x_.deadzone,    0.2 );
+
+		nh_.param("y_axis",         y_.axis,        0   );
+		nh_.param("y_scale",        y_.scale,       1.0 );
+		nh_.param("y_offset",       y_.offset,      0.0 );
+		nh_.param("y_deadzone",     y_.deadzone,    0.2 );
+
+		nh_.param("z_axis",         z_.axis,        2   );
+		nh_.param("z_scale",        z_.scale,       1.0 );
+		nh_.param("z_offset",       z_.offset,      0.0 );
+		nh_.param("z_deadzone",     z_.deadzone,    0.0 );
+
+		nh_.param("r_axis",         r_.axis,        4   );
+		nh_.param("r_scale",        r_.scale,       1.0 );
+		nh_.param("r_offset",       r_.offset,      0.0 );
+		nh_.param("r_deadzone",     r_.deadzone,    0.2 );
+
+		joystick_sub_ = nh_.subscribe("/joy", 10, &JoyControlPlugin::handle_joystick, this );
+		state_sub_ = nh_.subscribe("/mavros/state", 10, &JoyControlPlugin::handle_state, this );
+
+		thread_.reset( new std::thread( &JoyControlPlugin::thread_call, this, rc_rate_hz ) );
+	}
+
+	const message_map get_rx_handlers() {
+		return { };
+	}
+
+private:
+	ros::NodeHandle nh_;
+	UAS *uas_;
+	ros::Subscriber joystick_sub_, state_sub_;
+	mavros_msgs::State state_;
+
+	std::mutex msg_mutex_;
+	shared_ptr<std::thread> thread_;
+	mavlink_message_t ctrl_msg_;
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	void thread_call( float rate_hz )
+	{
+		ros::Rate rate(rate_hz);
+
+		// We need to keep sending messages at a fixed
+		// rate or PX4 will trigger RC timeouts
+
+		while (1)
+		{
+			msg_mutex_.lock();
+			UAS_FCU(uas_)->send_message(&ctrl_msg_);
+			msg_mutex_.unlock();
+
+			rate.sleep();
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	uint16_t array_to_bitset( const vector<int32_t>& array )
+	{
+		uint16_t bits = 0;
+
+		for ( size_t i = 0; i < array.size(); ++i )
+			if ( array[i] > 0 ) bits |= ( 1 << i );
+
+		return bits;
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	void handle_joystick( const sensor_msgs::Joy::ConstPtr& joy )
+	{
+		try
+		{
+			// PX4 seems to ignore the buttons field when processing manual
+			// control messages so we need to handle button input ourselves
+			// @see MavlinkReceiver::handle_message_manual_control()
+
+			handle_arming   ( joy );// toggle arm/disarm based on /mavros/state
+			handle_mode     ( joy );
+
+			float x = x_.map_axis( joy );
+			float y = y_.map_axis( joy );
+			float z = z_.map_axis( joy );
+			float r = r_.map_axis( joy );
+
+			std::lock_guard<std::mutex> lock(msg_mutex_);
+
+			mavlink_msg_manual_control_pack_chan( UAS_PACK_CHAN(uas_), &ctrl_msg_,
+					(uas_)->get_tgt_system(), x, y, z, r, array_to_bitset(joy->buttons) );
+		}
+		catch ( const std::out_of_range& e )
+		{
+			ROS_WARN( "failed to process joystick input: %s", e.what() );
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	void handle_arming( const sensor_msgs::Joy::ConstPtr& joy )
+	{
+		if ( arm_button_ < 0 || arm_button_ > joy->buttons.size() )
+			throw std::out_of_range("arm button index is invalid");
+
+		bool arm_button_on = joy->buttons[arm_button_];
+
+		if ( arm_button_on && !state_.armed )
+		{
+			mavros_msgs::CommandBool::Request req;
+			req.value = true;
+			call_service<mavros_msgs::CommandBool>( arming_service_, req );
+		}
+		else if ( arm_button_on && state_.armed )
+		{
+			mavros_msgs::CommandBool::Request req;
+			req.value = false;
+			call_service<mavros_msgs::CommandBool>( arming_service_, req );
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	void handle_mode( const sensor_msgs::Joy::ConstPtr& joy )
+	{
+		int mode_idx = 0;
+
+		// find the mode index as a binary combination of the multiple flags
+		// eg. [0,1] <-> index=2, [1,1] <-> index=3
+
+		for ( int i = 0; i < mode_mapping_.size(); ++i )
+			mode_idx += pow(2,i) * joy->buttons.at( mode_mapping_[i] );
+
+		static mavros_msgs::SetMode::Request req;
+		req.custom_mode = mode_names_.at(mode_idx);
+
+		if ( req.custom_mode != state_.mode )
+		{
+			ROS_INFO_STREAM("setting mode=" << req.custom_mode);
+			call_service<mavros_msgs::SetMode>( mode_service_, req );
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////
+
+	void handle_state( const mavros_msgs::State::ConstPtr& msg )
+	{
+		state_ = *msg;
+	}
+};
+};	// namespace mavplugin
+
+PLUGINLIB_EXPORT_CLASS(mavplugin::JoyControlPlugin, mavplugin::MavRosPlugin)
+


### PR DESCRIPTION
I created a plugin to generate Mavlink manual_control messages from sensor_msgs::Joy input. It is based on the ROS node in px4/src/platforms/ros/nodes/manual_input

Mappings between buttons and the corresponding modes can be configured, as well as the button used to arm/disarm. The plugin has to handle modes & arming because PX4 seems to ignore the buttons flags in the manual_control message (see MavlinkReceiver::handle_message_manual_control) Ideally we would simply forward the button flags via Mavlink and let PX4 handle them.

Maybe this code is too specific, and not generic enough to make sense as a plugin, in which case it shouldn't be merged into master