### PR TITLE
modified mavteleop to support RC modes

### DIFF
--- a/mavros_extras/launch/f710_joy.yaml
+++ b/mavros_extras/launch/f710_joy.yaml
@@ -14,3 +14,16 @@ button_map:
   takeoff: 0
   land: 1
   enable: 2
+rc_modes:
+  offboard:
+    rc_channel: 4
+    rc_value: 1000
+    joy_flags: [ [2,1] ]
+  auto:
+    rc_channel: 4
+    rc_value: 1500
+    joy_flags: [ [3,1] ]
+  manual:
+    rc_channel: 4
+    rc_value: 2000
+    joy_flags: [ [0,1] ]

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -99,8 +99,6 @@ rc_channels = {
     'throttle': RCChan('throttle', 2, 0.0)
 }
 
-rc = OverrideRCIn() # must be global to retain mode value
-
 def arm(args, state):
     try:
         command.arming(value=state)
@@ -134,11 +132,12 @@ def rc_override_control(args):
         v.load_param()
 
     rc_modes = RCMode.load_param()
+	rc = OverrideRCIn()
 
     override_pub = rospy.Publisher(mavros.get_topic("rc", "override"), OverrideRCIn, queue_size=10)
 
     def joy_cb(joy):
-        global rc
+        global rc # must be global to retain mode value
 
         # get axes normalized to -1.0..+1.0 RPY, 0.0..1.0 T
         roll = get_axis(joy, 'roll')

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -137,8 +137,6 @@ def rc_override_control(args):
     override_pub = rospy.Publisher(mavros.get_topic("rc", "override"), OverrideRCIn, queue_size=10)
 
     def joy_cb(joy):
-        global rc # must be global to retain mode value
-
         # get axes normalized to -1.0..+1.0 RPY, 0.0..1.0 T
         roll = get_axis(joy, 'roll')
         pitch = get_axis(joy, 'pitch')

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -44,6 +44,28 @@ class RCChan(object):
         # warn: limit check
         return arduino_map(pos, self.min_pos, 1.0, self.min, self.max)
 
+class RCMode(object):
+	def __init__( self, name, joy_flags, rc_channel, rc_value ):
+		self.name = name
+		self.joy_flags = joy_flags
+		self.rc_channel = rc_channel
+		self.rc_value = rc_value
+		
+	@staticmethod
+	def load_param(ns='~rc_modes/'):
+		yaml = rospy.get_param(ns)
+		return [ RCMode( name, data['joy_flags'], data['rc_channel'], data['rc_value'] ) 
+			for name,data in yaml.iteritems() ]
+		
+	def is_toggled(self,joy):
+		for btn,flag in self.joy_flags:
+			if joy.buttons[btn] != flag:
+				return False
+		return True
+		
+	def apply_mode(self,joy,rc):
+		if self.is_toggled(joy):
+			rc.channels[self.rc_channel]=self.rc_value
 
 # Mode 2 on Logitech F710 gamepad
 axes_map = {
@@ -77,6 +99,8 @@ rc_channels = {
     'throttle': RCChan('throttle', 2, 0.0)
 }
 
+rc = OverrideRCIn() # must be global to retain mode value
+
 def arm(args, state):
     try:
         command.arming(value=state)
@@ -109,9 +133,13 @@ def rc_override_control(args):
     for k, v in rc_channels.iteritems():
         v.load_param()
 
+	rc_modes = RCMode.load_param()
+	
     override_pub = rospy.Publisher(mavros.get_topic("rc", "override"), OverrideRCIn, queue_size=10)
 
     def joy_cb(joy):
+    	global rc
+    	
         # get axes normalized to -1.0..+1.0 RPY, 0.0..1.0 T
         roll = get_axis(joy, 'roll')
         pitch = get_axis(joy, 'pitch')
@@ -120,22 +148,20 @@ def rc_override_control(args):
 
         rospy.logdebug("RPYT: %f, %f, %f, %f", roll, pitch, yaw, throttle)
 
-        rc = OverrideRCIn()
         def set_chan(n, v):
             ch = rc_channels[n]
             rc.channels[ch.chan] = ch.calc_us(v)
             rospy.logdebug("RC%d (%s): %d us", ch.chan, ch.name, ch.calc_us(v))
 
-        # XXX: buttons
-        if get_buttons(joy,'arm') == 1:
-            arm(args, True)
-        elif get_buttons(joy,'disarm') == 1:
-            arm(args, False)
 
         set_chan('roll', roll)
         set_chan('pitch', pitch)
         set_chan('yaw', yaw)
         set_chan('throttle', throttle)
+        
+        for m in rc_modes:
+            m.apply_mode(joy,rc)
+        
         override_pub.publish(rc)
 
 

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -45,27 +45,27 @@ class RCChan(object):
         return arduino_map(pos, self.min_pos, 1.0, self.min, self.max)
 
 class RCMode(object):
-	def __init__( self, name, joy_flags, rc_channel, rc_value ):
-		self.name = name
-		self.joy_flags = joy_flags
-		self.rc_channel = rc_channel
-		self.rc_value = rc_value
-		
-	@staticmethod
-	def load_param(ns='~rc_modes/'):
-		yaml = rospy.get_param(ns)
-		return [ RCMode( name, data['joy_flags'], data['rc_channel'], data['rc_value'] ) 
-			for name,data in yaml.iteritems() ]
-		
-	def is_toggled(self,joy):
-		for btn,flag in self.joy_flags:
-			if joy.buttons[btn] != flag:
-				return False
-		return True
-		
-	def apply_mode(self,joy,rc):
-		if self.is_toggled(joy):
-			rc.channels[self.rc_channel]=self.rc_value
+    def __init__( self, name, joy_flags, rc_channel, rc_value ):
+        self.name = name
+        self.joy_flags = joy_flags
+        self.rc_channel = rc_channel
+        self.rc_value = rc_value
+        
+    @staticmethod
+    def load_param(ns='~rc_modes/'):
+        yaml = rospy.get_param(ns)
+        return [ RCMode( name, data['joy_flags'], data['rc_channel'], data['rc_value'] ) 
+            for name,data in yaml.iteritems() ]
+        
+    def is_toggled(self,joy):
+        for btn,flag in self.joy_flags:
+            if joy.buttons[btn] != flag:
+                return False
+        return True
+        
+    def apply_mode(self,joy,rc):
+        if self.is_toggled(joy):
+            rc.channels[self.rc_channel]=self.rc_value
 
 # Mode 2 on Logitech F710 gamepad
 axes_map = {
@@ -133,13 +133,13 @@ def rc_override_control(args):
     for k, v in rc_channels.iteritems():
         v.load_param()
 
-	rc_modes = RCMode.load_param()
-	
+    rc_modes = RCMode.load_param()
+
     override_pub = rospy.Publisher(mavros.get_topic("rc", "override"), OverrideRCIn, queue_size=10)
 
     def joy_cb(joy):
-    	global rc
-    	
+        global rc
+
         # get axes normalized to -1.0..+1.0 RPY, 0.0..1.0 T
         roll = get_axis(joy, 'roll')
         pitch = get_axis(joy, 'pitch')

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -132,7 +132,7 @@ def rc_override_control(args):
         v.load_param()
 
     rc_modes = RCMode.load_param()
-	rc = OverrideRCIn()
+    rc = OverrideRCIn()
 
     override_pub = rospy.Publisher(mavros.get_topic("rc", "override"), OverrideRCIn, queue_size=10)
 


### PR DESCRIPTION
update to `mavteleop` to allow support modes in -rc mode
* modes are read from the `~rc_modes` in yaml format eg. with `<rosparam>` (see examples below)
* tested with [Futaba flight controller](http://www.realflight.com/products/gpmz4520.html) and [Logitech gamepad](http://gaming.logitech.com/en-roeu/product/f710-wireless-gamepad)
* removed support for arm/disarm in RC mode as it is already available over RC with stick in lower-right position