### PR TITLE
Fix for Mac OSX build

### DIFF
--- a/libmavconn/include/mavconn/thread_utils.h
+++ b/libmavconn/include/mavconn/thread_utils.h
@@ -26,6 +26,41 @@
 
 namespace mavutils {
 
+ #ifdef __APPLE__
+
+/**
+ * @brief Set std::thread name with printf-like mode
+ * @param[in] thd std::thread
+ * @param[in] name name for thread
+ * @return true if success
+ *
+ * @note Only for Linux target
+ * @todo add for other posix system
+ */
+
+inline bool set_thread_name(const char *name, ...)
+{
+	va_list arg_list;
+	va_start(arg_list, name);
+
+	char new_name[256];
+	vsnprintf(new_name, sizeof(new_name), name, arg_list);
+	va_end(arg_list);
+	return pthread_setname_np(new_name) == 0;
+}
+
+
+/**
+ * @brief Set thread name (std::string variation)
+ */
+template <typename Thread>
+inline bool set_thread_name(std::string &name)
+{
+	return set_thread_name(name.c_str());
+};
+
+#else
+
 /**
  * @brief Set std::thread name with printf-like mode
  * @param[in] thd std::thread
@@ -47,6 +82,7 @@ inline bool set_thread_name(std::thread &thd, const char *name, ...)
 	return pthread_setname_np(pth, new_name) == 0;
 }
 
+
 /**
  * @brief Set thread name (std::string variation)
  */
@@ -55,6 +91,8 @@ inline bool set_thread_name(Thread &thd, std::string &name)
 {
 	return set_thread_name(thd, name.c_str());
 };
+
+#endif
 
 /**
  * @brief Convert to string objects with operator <<

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -59,7 +59,9 @@ MAVConnSerial::MAVConnSerial(uint8_t system_id, uint8_t component_id,
 
 	// run io_service for async io
 	std::thread t(boost::bind(&io_service::run, &this->io_service));
+#ifndef __APPLE__
 	mavutils::set_thread_name(t, "MAVConnSerial%d", channel);
+#endif
 	io_thread.swap(t);
 }
 
@@ -123,6 +125,9 @@ void MAVConnSerial::send_message(const mavlink_message_t *message, uint8_t sysid
 
 void MAVConnSerial::do_read(void)
 {
+#ifdef __APPLE__
+	mavutils::set_thread_name("MAVConnSerial%d", channel);
+#endif
 	serial_dev.async_read_some(
 			buffer(rx_buf, sizeof(rx_buf)),
 			boost::bind(&MAVConnSerial::async_read_end,

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -84,7 +84,9 @@ MAVConnTCPClient::MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 
 	// run io_service for async io
 	std::thread t(boost::bind(&io_service::run, &this->io_service));
+#ifndef __APPLE__
 	mavutils::set_thread_name(t, "MAVConnTCPc%d", channel);
+#endif
 	io_thread.swap(t);
 }
 
@@ -165,6 +167,9 @@ void MAVConnTCPClient::send_message(const mavlink_message_t *message, uint8_t sy
 
 void MAVConnTCPClient::do_recv()
 {
+#ifdef __APPLE__
+	mavutils::set_thread_name("MAVConnTCPc%d", channel);
+#endif
 	socket.async_receive(
 			buffer(rx_buf, sizeof(rx_buf)),
 			boost::bind(&MAVConnTCPClient::async_receive_end,
@@ -273,7 +278,9 @@ MAVConnTCPServer::MAVConnTCPServer(uint8_t system_id, uint8_t component_id,
 
 	// run io_service for async io
 	std::thread t(boost::bind(&io_service::run, &this->io_service));
+#ifndef __APPLE__
 	mavutils::set_thread_name(t, "MAVConnTCPs%d", channel);
+#endif
 	io_thread.swap(t);
 }
 
@@ -361,6 +368,9 @@ void MAVConnTCPServer::send_message(const mavlink_message_t *message, uint8_t sy
 
 void MAVConnTCPServer::do_accept()
 {
+#ifdef __APPLE__
+	mavutils::set_thread_name("MAVConnTCPs%d", channel);
+#endif
 	acceptor_client.reset();
 	acceptor_client = boost::make_shared<MAVConnTCPClient>(sys_id, comp_id, io_service);
 	acceptor.async_accept(

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -93,7 +93,9 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 
 	// run io_service for async io
 	std::thread t(boost::bind(&io_service::run, &this->io_service));
+#ifndef __APPLE__
 	mavutils::set_thread_name(t, "MAVConnUDP%d", channel);
+#endif
 	io_thread.swap(t);
 }
 
@@ -168,6 +170,9 @@ void MAVConnUDP::send_message(const mavlink_message_t *message, uint8_t sysid, u
 
 void MAVConnUDP::do_recvfrom()
 {
+#ifdef __APPLE__
+	mavutils::set_thread_name("MAVConnUDP%d", channel);
+#endif
 	socket.async_receive_from(
 			buffer(rx_buf, sizeof(rx_buf)),
 			remote_ep,


### PR DESCRIPTION
In Mac OSX, 'pthread_setname_np' doesn't allow to set the tread name outside of the thread.
( also has different argument convention. see [here](http://stackoverflow.com/questions/2369738/can-i-set-the-name-of-a-thread-in-pthreads-linux/7989973#7989973) )
So to build for Mac OSX, it requires to change to set name within the thread and change the argument convention!
With this change, it builds perfectly in Mac OSX-El Capitan!