### PR TITLE
MAVConnSerial: Stop io_service before closing serial device (Fixes #130)

### DIFF
--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -72,8 +72,8 @@ void MAVConnSerial::close() {
 	if (!is_open())
 		return;
 
-	serial_dev.close();
 	io_service.stop();
+	serial_dev.close();
 
 	// clear tx queue
 	for (auto &p : tx_q)


### PR DESCRIPTION
The serial device was closed before calling io_service.stop() so io_service::run() never returned, leading to hang on join in MAVConnSerial::close()

Backtrace when mavros_node gets SIGINT:
```
#0  0x00007f80217e966b in pthread_join (threadid=140188059690752, thread_return=0x0) at pthread_join.c:92
#1  0x00007f80215602d7 in std::thread::join() ()
#2  0x00007f8020ccc674 in mavconn::MAVConnSerial::close() ()
#3  0x00007f8020ccc6f5 in mavconn::MAVConnSerial::~MAVConnSerial() ()
#4  0x00007f8020cc7b2e in boost::detail::sp_counted_impl_pd<mavconn::MAVConnSerial*, boost::detail::sp_ms_deleter<mavconn::MAVConnSerial> >::dispose() ()
#5  0x000000000040ee0a in boost::detail::sp_counted_base::release() [clone .part.27] [clone .constprop.472] ()
#6  0x000000000041eb22 in mavros::MavRos::~MavRos() ()
#7  0x000000000040eb38 in main ()
```