### PR TITLE
Added a plugin that publishes HIL_CONTROLS as ROS messages

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(mavros_plugins
   src/plugins/actuator_control.cpp
   src/plugins/manual_control.cpp
   src/plugins/altitude.cpp
+  src/plugins/hil_controls.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -65,5 +65,8 @@
 	<class name="altitude" type="mavplugin::AltitudePlugin" base_class_type="mavplugin::MavRosPlugin">
 		<description>Publish altitude values</description>
 	</class>
+        <class name="hil_controls" type="mavplugin::HilControlsPlugin" base_class_type="mavplugin::MavRosPlugin">
+		<description>Publish HIL controls values</description>
+	</class>
 </library>
 

--- a/mavros/src/plugins/hil_controls.cpp
+++ b/mavros/src/plugins/hil_controls.cpp
@@ -25,52 +25,52 @@ namespace mavplugin {
  */
 class HilControlsPlugin : public MavRosPlugin {
 public:
-    HilControlsPlugin() :
-        hil_controls_nh("~hil_controls"),
-        uas(nullptr)
-    { };
+	HilControlsPlugin() :
+		hil_controls_nh("~hil_controls"),
+		uas(nullptr)
+	{ };
 
-    void initialize(UAS &uas_)
-    {
-        uas = &uas_;
+	void initialize(UAS &uas_)
+	{
+		uas = &uas_;
 
-        hil_controls_pub = hil_controls_nh.advertise<mavros_msgs::HilControls>("hil_controls", 10);
-    };
+		hil_controls_pub = hil_controls_nh.advertise<mavros_msgs::HilControls>("hil_controls", 10);
+	};
 
-    const message_map get_rx_handlers() {
-        return {
-                   MESSAGE_HANDLER(MAVLINK_MSG_ID_HIL_CONTROLS, &HilControlsPlugin::handle_hil_controls),
-        };
-    }
+	const message_map get_rx_handlers() {
+		return {
+			       MESSAGE_HANDLER(MAVLINK_MSG_ID_HIL_CONTROLS, &HilControlsPlugin::handle_hil_controls),
+		};
+	}
 
 private:
-    ros::NodeHandle hil_controls_nh;
-    UAS *uas;
+	ros::NodeHandle hil_controls_nh;
+	UAS *uas;
 
-    ros::Publisher hil_controls_pub;
+	ros::Publisher hil_controls_pub;
 
-    /* -*- rx handlers -*- */
+	/* -*- rx handlers -*- */
 
-    void handle_hil_controls(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
-        mavlink_hil_controls_t hil_controls;
-        mavlink_msg_hil_controls_decode(msg, &hil_controls);
+	void handle_hil_controls(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
+		mavlink_hil_controls_t hil_controls;
+		mavlink_msg_hil_controls_decode(msg, &hil_controls);
 
-        auto hil_controls_msg = boost::make_shared<mavros_msgs::HilControls>();
+		auto hil_controls_msg = boost::make_shared<mavros_msgs::HilControls>();
 
-        hil_controls_msg->header.stamp = uas->synchronise_stamp(hil_controls.time_usec);
-        hil_controls_msg->roll_ailerons = hil_controls.roll_ailerons;
-        hil_controls_msg->pitch_elevator = hil_controls.roll_ailerons;
-        hil_controls_msg->yaw_rudder = hil_controls.yaw_rudder;
-        hil_controls_msg->throttle = hil_controls.throttle;
-        hil_controls_msg->aux1 = hil_controls.aux1;
-        hil_controls_msg->aux2 = hil_controls.aux2;
-        hil_controls_msg->aux3 = hil_controls.aux3;
-        hil_controls_msg->aux4 = hil_controls.aux4;
-        hil_controls_msg->mode = hil_controls.mode;
-        hil_controls_msg->nav_mode = hil_controls.nav_mode;
+		hil_controls_msg->header.stamp = uas->synchronise_stamp(hil_controls.time_usec);
+		hil_controls_msg->roll_ailerons = hil_controls.roll_ailerons;
+		hil_controls_msg->pitch_elevator = hil_controls.roll_ailerons;
+		hil_controls_msg->yaw_rudder = hil_controls.yaw_rudder;
+		hil_controls_msg->throttle = hil_controls.throttle;
+		hil_controls_msg->aux1 = hil_controls.aux1;
+		hil_controls_msg->aux2 = hil_controls.aux2;
+		hil_controls_msg->aux3 = hil_controls.aux3;
+		hil_controls_msg->aux4 = hil_controls.aux4;
+		hil_controls_msg->mode = hil_controls.mode;
+		hil_controls_msg->nav_mode = hil_controls.nav_mode;
 
-        hil_controls_pub.publish(hil_controls_msg);
-    }
+		hil_controls_pub.publish(hil_controls_msg);
+	}
 };
 };	// namespace mavplugin
 

--- a/mavros/src/plugins/hil_controls.cpp
+++ b/mavros/src/plugins/hil_controls.cpp
@@ -1,0 +1,78 @@
+/**
+ * @brief HilControls plugin
+ * @file hil_controls.cpp
+ * @author Pavel Vechersky <pvechersky@student.ethz.ch>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Pavel Vechersky.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <pluginlib/class_list_macros.h>
+
+#include <mavros_msgs/HilControls.h>
+
+namespace mavplugin {
+/**
+ * @brief Hil Control plugin
+ */
+class HilControlsPlugin : public MavRosPlugin {
+public:
+    HilControlsPlugin() :
+        hil_controls_nh("~hil_controls"),
+        uas(nullptr)
+    { };
+
+    void initialize(UAS &uas_)
+    {
+        uas = &uas_;
+
+        hil_controls_pub = hil_controls_nh.advertise<mavros_msgs::HilControls>("hil_controls", 10);
+    };
+
+    const message_map get_rx_handlers() {
+        return {
+                   MESSAGE_HANDLER(MAVLINK_MSG_ID_HIL_CONTROLS, &HilControlsPlugin::handle_hil_controls),
+        };
+    }
+
+private:
+    ros::NodeHandle hil_controls_nh;
+    UAS *uas;
+
+    ros::Publisher hil_controls_pub;
+
+    /* -*- rx handlers -*- */
+
+    void handle_hil_controls(const mavlink_message_t *msg, uint8_t sysid, uint8_t compid) {
+        mavlink_hil_controls_t hil_controls;
+        mavlink_msg_hil_controls_decode(msg, &hil_controls);
+
+        auto hil_controls_msg = boost::make_shared<mavros_msgs::HilControls>();
+
+        hil_controls_msg->header.stamp = ros::Time::now();
+        hil_controls_msg->roll_ailerons = hil_controls.roll_ailerons;
+        hil_controls_msg->pitch_elevator = hil_controls.roll_ailerons;
+        hil_controls_msg->yaw_rudder = hil_controls.yaw_rudder;
+        hil_controls_msg->throttle = hil_controls.throttle;
+        hil_controls_msg->aux1 = hil_controls.aux1;
+        hil_controls_msg->aux2 = hil_controls.aux2;
+        hil_controls_msg->aux3 = hil_controls.aux3;
+        hil_controls_msg->aux4 = hil_controls.aux4;
+        hil_controls_msg->mode = hil_controls.mode;
+        hil_controls_msg->nav_mode = hil_controls.nav_mode;
+
+        hil_controls_pub.publish(hil_controls_msg);
+    }
+};
+};	// namespace mavplugin
+
+PLUGINLIB_EXPORT_CLASS(mavplugin::HilControlsPlugin, mavplugin::MavRosPlugin)
+

--- a/mavros/src/plugins/hil_controls.cpp
+++ b/mavros/src/plugins/hil_controls.cpp
@@ -57,7 +57,7 @@ private:
 
         auto hil_controls_msg = boost::make_shared<mavros_msgs::HilControls>();
 
-        hil_controls_msg->header.stamp = ros::Time::now();
+        hil_controls_msg->header.stamp = uas->synchronise_stamp(hil_controls.time_usec);
         hil_controls_msg->roll_ailerons = hil_controls.roll_ailerons;
         hil_controls_msg->pitch_elevator = hil_controls.roll_ailerons;
         hil_controls_msg->yaw_rudder = hil_controls.yaw_rudder;

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_message_files(
   ExtendedState.msg
   FileEntry.msg
   GlobalPositionTarget.msg
+  HilControls.msg
   HomePosition.msg
   ManualControl.msg
   Mavlink.msg

--- a/mavros_msgs/msg/HilControls.msg
+++ b/mavros_msgs/msg/HilControls.msg
@@ -1,7 +1,8 @@
 # HilControls.msg
 #
 # ROS representation of MAVLink HIL_CONTROLS
-# See mavlink documentation
+# See mavlink message documentation here:
+# https://pixhawk.ethz.ch/mavlink/
 
 std_msgs/Header header
 float32 roll_ailerons

--- a/mavros_msgs/msg/HilControls.msg
+++ b/mavros_msgs/msg/HilControls.msg
@@ -1,0 +1,16 @@
+# HilControls.msg
+#
+# ROS representation of MAVLink HIL_CONTROLS
+# See mavlink documentation
+
+std_msgs/Header header
+float32 roll_ailerons
+float32 pitch_elevator
+float32 yaw_rudder
+float32 throttle
+float32 aux1
+float32 aux2
+float32 aux3
+float32 aux4
+uint8 mode
+uint8 nav_mode

--- a/mavros_msgs/msg/HilControls.msg
+++ b/mavros_msgs/msg/HilControls.msg
@@ -2,7 +2,7 @@
 #
 # ROS representation of MAVLink HIL_CONTROLS
 # See mavlink message documentation here:
-# https://pixhawk.ethz.ch/mavlink/
+# https://pixhawk.ethz.ch/mavlink/#HIL_CONTROLS
 
 std_msgs/Header header
 float32 roll_ailerons


### PR DESCRIPTION
Adding a plugin for publishing HIL_CONTROLS mavlink messages coming from the FCU as ROS messages in order to facilitate HIL simulation with MAVROS.