### PR TITLE
add HIL_ACTUATOR_CONTROLS mavlink message

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(mavros_plugins
   src/plugins/manual_control.cpp
   src/plugins/altitude.cpp
   src/plugins/hil_controls.cpp
+  src/plugins/hil_actuator_controls.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -65,7 +65,10 @@
 	<class name="altitude" type="mavros::std_plugins::AltitudePlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish altitude values</description>
 	</class>
-        <class name="hil_controls" type="mavros::std_plugins::HilControlsPlugin" base_class_type="mavros::plugin::PluginBase">
+	<class name="hil_controls" type="mavros::std_plugins::HilControlsPlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>Publish HIL controls values (deprecated message)</description>
+	</class>
+	<class name="hil_actuator_controls" type="mavros::std_plugins::HilActuatorControlsPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish HIL controls values</description>
 	</class>
 </library>

--- a/mavros/src/plugins/hil_actuator_controls.cpp
+++ b/mavros/src/plugins/hil_actuator_controls.cpp
@@ -1,0 +1,73 @@
+/**
+ * @brief HilActuatorControls plugin
+ * @file hil_actuator_controls.cpp
+ * @author Pavel Vechersky <pvechersky@student.ethz.ch>
+ * @author Beat Küng <beat-kueng@gmx.net>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Pavel Vechersky & Beat Küng.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+
+#include <mavros_msgs/HilActuatorControls.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief Hil Actuator Control plugin
+ */
+class HilActuatorControlsPlugin : public plugin::PluginBase {
+public:
+	HilActuatorControlsPlugin() : PluginBase(),
+		hil_actuator_controls_nh("~")
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		hil_actuator_controls_pub = hil_actuator_controls_nh.advertise<mavros_msgs::HilActuatorControls>("hil_actuator_controls", 10);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return {
+			       make_handler(&HilActuatorControlsPlugin::handle_hil_actuator_controls),
+		};
+	}
+
+private:
+	ros::NodeHandle hil_actuator_controls_nh;
+
+	ros::Publisher hil_actuator_controls_pub;
+
+	/* -*- rx handlers -*- */
+
+	void handle_hil_actuator_controls(const mavlink::mavlink_message_t *msg, mavlink::common::msg::HIL_ACTUATOR_CONTROLS &hil_actuator_controls)
+	{
+		auto hil_actuator_controls_msg = boost::make_shared<mavros_msgs::HilActuatorControls>();
+
+		hil_actuator_controls_msg->header.stamp = m_uas->synchronise_stamp(hil_actuator_controls.time_usec);
+		for (int i = 0; i < 16; ++i) {
+			hil_actuator_controls_msg->controls[i] = hil_actuator_controls.controls[i];
+		}
+		hil_actuator_controls_msg->mode = hil_actuator_controls.mode;
+		hil_actuator_controls_msg->flags = hil_actuator_controls.flags;
+
+		hil_actuator_controls_pub.publish(hil_actuator_controls_msg);
+	}
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::HilActuatorControlsPlugin, mavros::plugin::PluginBase)
+

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_message_files(
   ExtendedState.msg
   FileEntry.msg
   GlobalPositionTarget.msg
+  HilActuatorControls.msg
   HilControls.msg
   HomePosition.msg
   ManualControl.msg

--- a/mavros_msgs/msg/HilActuatorControls.msg
+++ b/mavros_msgs/msg/HilActuatorControls.msg
@@ -1,0 +1,10 @@
+# HilActuatorControls.msg
+#
+# ROS representation of MAVLink HIL_ACTUATOR_CONTROLS
+# See mavlink message documentation here:
+# https://pixhawk.ethz.ch/mavlink/#HIL_ACTUATOR_CONTROLS
+
+std_msgs/Header header
+float32[16] controls
+uint8 mode
+uint64 flags

--- a/mavros_msgs/msg/HilControls.msg
+++ b/mavros_msgs/msg/HilControls.msg
@@ -1,6 +1,7 @@
 # HilControls.msg
 #
 # ROS representation of MAVLink HIL_CONTROLS
+# (deprecated, use HIL_ACTUATOR_CONTROLS instead)
 # See mavlink message documentation here:
 # https://pixhawk.ethz.ch/mavlink/#HIL_CONTROLS
 


### PR DESCRIPTION
This is the replacement message for the HIL_CONTROLS message.

I couldn't actually test if this compiles because I don't have ROS installed.