### PR TITLE
README: fixed a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ MAVLink extendable communication node for ROS.
 mavros package
 --------------
 
-It is the main package, please see it's [README][mrrm].
+It is the main package, please see its [README][mrrm].
 Here you may read [installation instructions][inst].
 
 
 mavros\_extras package
 ----------------------
 
-This package contain some extra nodes and plugins for mavros, please see it's [README][exrm].
+This package contains some extra nodes and plugins for mavros, please see its [README][exrm].
 
 
 libmavconn package
 ------------------
 
-This package contain mavconn library, see it's [README][libmc].
+This package contain mavconn library, see its [README][libmc].
 LibMAVConn may be used outside of ROS environment.
 
 
@@ -44,13 +44,13 @@ Please see [README][test] first!
 mavros\_msgs package
 --------------------
 
-This package contain messages and services used in mavros.
+This package contains messages and services used in mavros.
 
 
 Support forums and chats
 ------------------------
 
-Please ask your questions not related to bugs/feauture requests on:
+Please ask your questions not related to bugs/feauture or requests on:
 
 - [px4users Google Group (Mailing List) ](https://groups.google.com/forum/#!forum/px4users)
 - [Mavros on Gitter IM](https://gitter.im/mavlink/mavros)


### PR DESCRIPTION
A couple of typos fixed in the main README.md

it's -> its (where appropriate)
contain -> contains (ditto)