### PR TITLE
Fixed build dependency for msg creation in MATLAB

### DIFF
--- a/mavros_msgs/package.xml
+++ b/mavros_msgs/package.xml
@@ -19,6 +19,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  
   <exec_depend>message_runtime</exec_depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
Using MATLAB and roboticsSupportPackages to read and convert a ROSbag to timeseries.
The messages i'm interested in are the /mavros/setpoint_raw/attitude.msg, but is not a standard message known by MATLAB.

So using the rosgenmsg('/home/user/catkin_ws/mavros') gave the error that the std_msgs and geometry_msgs didn't exist. This is because in the Package.xml they are define as depend, not as build_depend.

After fixing this, everything worked fine.