### PR TITLE
Plugins: add system_status to state message

### DIFF
--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -623,6 +623,7 @@ private:
 		state_msg->armed = false;
 		state_msg->guided = false;
 		state_msg->mode = "";
+		state_msg->status = enum_value(MAV_STATE::UNINIT);
 
 		state_pub.publish(state_msg);
 	}
@@ -651,6 +652,7 @@ private:
 		state_msg->armed = hb.base_mode & enum_value(MAV_MODE_FLAG::SAFETY_ARMED);
 		state_msg->guided = hb.base_mode & enum_value(MAV_MODE_FLAG::GUIDED_ENABLED);
 		state_msg->mode = m_uas->str_mode_v10(hb.base_mode, hb.custom_mode);
+		state_msg->status = hb.system_status;
 
 		state_pub.publish(state_msg);
 		hb_diag.tick(hb.type, hb.autopilot, state_msg->mode, hb.system_status);

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -623,7 +623,7 @@ private:
 		state_msg->armed = false;
 		state_msg->guided = false;
 		state_msg->mode = "";
-		state_msg->status = enum_value(MAV_STATE::UNINIT);
+		state_msg->system_status = enum_value(MAV_STATE::UNINIT);
 
 		state_pub.publish(state_msg);
 	}
@@ -652,7 +652,7 @@ private:
 		state_msg->armed = hb.base_mode & enum_value(MAV_MODE_FLAG::SAFETY_ARMED);
 		state_msg->guided = hb.base_mode & enum_value(MAV_MODE_FLAG::GUIDED_ENABLED);
 		state_msg->mode = m_uas->str_mode_v10(hb.base_mode, hb.custom_mode);
-		state_msg->status = hb.system_status;
+		state_msg->system_status = hb.system_status;
 
 		state_pub.publish(state_msg);
 		hb_diag.tick(hb.type, hb.autopilot, state_msg->mode, hb.system_status);

--- a/mavros_msgs/msg/State.msg
+++ b/mavros_msgs/msg/State.msg
@@ -8,3 +8,4 @@ bool connected
 bool armed
 bool guided
 string mode
+uint8 status

--- a/mavros_msgs/msg/State.msg
+++ b/mavros_msgs/msg/State.msg
@@ -2,10 +2,14 @@
 #
 # Known modes listed here:
 # http://wiki.ros.org/mavros/CustomModes
+#
+# For system_status values
+# see http://mavlink.org/messages/common MAV_STATE
+#
 
 std_msgs/Header header
 bool connected
 bool armed
 bool guided
 string mode
-uint8 status
+uint8 system_status


### PR DESCRIPTION
Used to know the state of APM based drone with Companion Computer. 