### PR TITLE
Px4 hil plugins

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(mavros_plugins
   src/plugins/hil_actuator_controls.cpp
   src/plugins/hil_sensor.cpp
   src/plugins/hil_state_quaternion.cpp
+  src/plugins/hil_gps.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(mavros_plugins
   src/plugins/hil_controls.cpp
   src/plugins/hil_actuator_controls.cpp
   src/plugins/hil_sensor.cpp
+  src/plugins/hil_state_quaternion.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library(mavros_plugins
   src/plugins/hil_sensor.cpp
   src/plugins/hil_state_quaternion.cpp
   src/plugins/hil_gps.cpp
+  src/plugins/actuator_control_target.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -124,6 +124,7 @@ add_library(mavros_plugins
   src/plugins/altitude.cpp
   src/plugins/hil_controls.cpp
   src/plugins/hil_actuator_controls.cpp
+  src/plugins/hil_sensor.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/include/mavros/hil_sensor_mixin.h
+++ b/mavros/include/mavros/hil_sensor_mixin.h
@@ -35,7 +35,7 @@ public:
 			Eigen::Vector3d gyro,
 			Eigen::Vector3d mag,
             Eigen::Vector3d pressure,
-            float temperature
+            float temperature,
 			uint32_t fields_updated)
 	{
 		mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
@@ -62,6 +62,58 @@ public:
 
 		UAS_FCU(m_uas_)->send_message_ignore_drop(sensor);
 	}
+};
+
+/**
+ * @brief This mixin adds set_hil_state_quaternion()
+ */
+template <class D>
+class SetHilSensorMixin {
+public:
+    //! Message specification: @p https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION
+    void set_hil_state_quaternion(uint64_t time_boot_us,
+                        Eigen::Vector4d quat,
+                        Eigen::Vector3d angularspeed,
+                        Eigen::Vector3d GPS,
+                        Eigen::Vector3d groundspeed,
+                        uint16_t ind_airspeed,
+                        uint16_t true_airspeed,
+                        Eigen::Vector3d acceleration)
+    {
+        mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
+        mavlink::common::msg::HIL_STATE_QUATERNION state_quat;
+        
+        // there is no target sys in this mavlink message!
+        //m_uas_->msg_set_target(sensor);
+        
+        state_quat.time_usec= time_boot_us;
+        
+        state_quat.attitude_quaternion[0]=quat(0);
+        state_quat.attitude_quaternion[1]=quat(1);
+        state_quat.attitude_quaternion[2]=quat(2);
+        state_quat.attitude_quaternion[3]=quat(3);
+        
+        state_quat.rollspeed=angularspeed.x();
+        state_quat.pitchspeed=angularspeed.y();
+        state_quat.yawspeed=angularspeed.z();
+        
+        state_quat.lat=GPS.x();
+        state_quat.lon=GPS.y();
+        state_quat.alt=GPS.z();
+        
+        state_quat.vx=groundspeed.x();
+        state_quat.vy=groundspeed.y();
+        state_quat.vz=groundspeed.z();
+        
+        state_quat.ind_airspeed=ind_airspeed;
+        state_quat.true_airspeed=true_airspeed;
+        
+        state_quat.xacc=acceleration.x();
+        state_quat.yacc=acceleration.y();
+        state_quat.zacc=acceleration.z();
+        
+        UAS_FCU(m_uas_)->send_message_ignore_drop(state_quat);
+    }
 };
 
 }	// namespace plugin

--- a/mavros/include/mavros/hil_sensor_mixin.h
+++ b/mavros/include/mavros/hil_sensor_mixin.h
@@ -1,0 +1,68 @@
+/**
+ * @brief Mixin for hil_sensor plugins
+ * @file hil_sensors_mixin.h
+ * @author Mohamed Abdelkader <mohamedashraf123@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Mohamed Abdelkader.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#pragma once
+
+#include <functional>
+#include <mavros/utils.h>
+#include <mavros/mavros_plugin.h>
+
+
+namespace mavros {
+namespace plugin {
+/**
+ * @brief This mixin adds set_hil_sensor()
+ */
+template <class D>
+class SetHilSensorMixin {
+public:
+	//! Message specification: @p https://pixhawk.ethz.ch/mavlink/#HIL_SENSOR
+	void set_hil_sensor(uint64_t time_boot_us,
+			Eigen::Vector3d acc,
+			Eigen::Vector3d gyro,
+			Eigen::Vector3d mag,
+            Eigen::Vector3d pressure,
+            float temperature
+			uint32_t fields_updated)
+	{
+		mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
+		mavlink::common::msg::HIL_SENSOR sensor;
+
+        // there is no target sys in this mavlink message!
+		//m_uas_->msg_set_target(sensor);
+
+        sensor.time_usec= time_boot_us;
+        sensor.xacc=acc.x();
+        sensor.yacc=acc.y();
+        sensor.zacc=acc.z();
+        sensor.xgyro=gyro.x();
+        sensor.ygyro=gyro.y();
+        sensor.zgyro=gyro.z();
+        sensor.xmag=mag.x();
+        sensor.ymag=mag.y();
+        sensor.zmag=mag.z();
+        sensor.abs_pressure=pressure.x();
+        sensor.diff_pressure=pressure.y();
+        sensor.pressure_alt=pressure.z();
+        sensor.temperature=temperature;
+        sensor.fields_updated=fields_updated;
+
+		UAS_FCU(m_uas_)->send_message_ignore_drop(sensor);
+	}
+};
+
+}	// namespace plugin
+}	// namespace mavros

--- a/mavros/include/mavros/hil_sensor_mixin.h
+++ b/mavros/include/mavros/hil_sensor_mixin.h
@@ -31,12 +31,12 @@ class SetHilSensorMixin {
 public:
 	//! Message specification: @p https://pixhawk.ethz.ch/mavlink/#HIL_SENSOR
 	void set_hil_sensor(uint64_t time_boot_us,
-			Eigen::Vector3d acc,
-			Eigen::Vector3d gyro,
-			Eigen::Vector3d mag,
-            Eigen::Vector3d pressure,
-            float temperature,
-			uint32_t fields_updated)
+                        float xacc, float yacc, float zacc,
+                        float xgyro, float ygyro, float zgyro,
+                        float xmag, float ymag, float zmag,
+                        float abs_pressure, float diff_pressure, float pressure_alt,
+                        float temperature,
+                        uint32_t fields_updated)
 	{
 		mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
 		mavlink::common::msg::HIL_SENSOR sensor;
@@ -45,18 +45,18 @@ public:
 		//m_uas_->msg_set_target(sensor);
 
         sensor.time_usec= time_boot_us;
-        sensor.xacc=acc.x();
-        sensor.yacc=acc.y();
-        sensor.zacc=acc.z();
-        sensor.xgyro=gyro.x();
-        sensor.ygyro=gyro.y();
-        sensor.zgyro=gyro.z();
-        sensor.xmag=mag.x();
-        sensor.ymag=mag.y();
-        sensor.zmag=mag.z();
-        sensor.abs_pressure=pressure.x();
-        sensor.diff_pressure=pressure.y();
-        sensor.pressure_alt=pressure.z();
+        sensor.xacc=xacc;
+        sensor.yacc=yacc;
+        sensor.zacc=zacc;
+        sensor.xgyro=xgyro;
+        sensor.ygyro=ygyro;
+        sensor.zgyro=zgyro;
+        sensor.xmag=xmag;
+        sensor.ymag=ymag;
+        sensor.zmag=zmag;
+        sensor.abs_pressure=abs_pressure;
+        sensor.diff_pressure=diff_pressure;
+        sensor.pressure_alt=pressure_alt;
         sensor.temperature=temperature;
         sensor.fields_updated=fields_updated;
 
@@ -72,13 +72,12 @@ class SetHilStateQuaternionMixin {
 public:
     //! Message specification: @p https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION
     void set_hil_state_quaternion(uint64_t time_boot_us,
-                        Eigen::Vector4d quat,
-                        Eigen::Vector3d angularspeed,
-                        Eigen::Vector3d GPS,
-                        Eigen::Vector3d groundspeed,
-                        uint16_t ind_airspeed,
-                        uint16_t true_airspeed,
-                        Eigen::Vector3d acceleration)
+                                  float qw, float qx, float qy, float qz,
+                                  float rollspeed, float pitchspeed, float yawspeed,
+                                  int32_t lat, int32_t lon, int32_t alt,
+                                  int16_t vx, int16_t vy, int16_t vz,
+                                  uint16_t ind_airspeed, uint16_t true_airspeed,
+                                  int16_t xacc, int16_t yacc, int16_t zacc)
     {
         mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
         mavlink::common::msg::HIL_STATE_QUATERNION state_quat;
@@ -88,29 +87,29 @@ public:
         
         state_quat.time_usec= time_boot_us;
         
-        state_quat.attitude_quaternion[0]=quat(0);
-        state_quat.attitude_quaternion[1]=quat(1);
-        state_quat.attitude_quaternion[2]=quat(2);
-        state_quat.attitude_quaternion[3]=quat(3);
+        state_quat.attitude_quaternion[0]=qw;
+        state_quat.attitude_quaternion[1]=qx;
+        state_quat.attitude_quaternion[2]=qy;
+        state_quat.attitude_quaternion[3]=qz;
         
-        state_quat.rollspeed=angularspeed.x();
-        state_quat.pitchspeed=angularspeed.y();
-        state_quat.yawspeed=angularspeed.z();
+        state_quat.rollspeed=rollspeed;
+        state_quat.pitchspeed=pitchspeed;
+        state_quat.yawspeed=yawspeed;
         
-        state_quat.lat=GPS.x();
-        state_quat.lon=GPS.y();
-        state_quat.alt=GPS.z();
+        state_quat.lat=lat;
+        state_quat.lon=lon;
+        state_quat.alt=alt;
         
-        state_quat.vx=groundspeed.x();
-        state_quat.vy=groundspeed.y();
-        state_quat.vz=groundspeed.z();
+        state_quat.vx=vx;
+        state_quat.vy=vy;
+        state_quat.vz=vz;
         
         state_quat.ind_airspeed=ind_airspeed;
         state_quat.true_airspeed=true_airspeed;
         
-        state_quat.xacc=acceleration.x();
-        state_quat.yacc=acceleration.y();
-        state_quat.zacc=acceleration.z();
+        state_quat.xacc=xacc;
+        state_quat.yacc=yacc;
+        state_quat.zacc=zacc;
         
         UAS_FCU(m_uas_)->send_message_ignore_drop(state_quat);
     }

--- a/mavros/include/mavros/hil_sensor_mixin.h
+++ b/mavros/include/mavros/hil_sensor_mixin.h
@@ -115,5 +115,41 @@ public:
     }
 };
 
+/**
+ * @brief This mixin adds set_hil_gps()
+ */
+template <class D>
+class SetHilGPSMixin {
+public:
+    //! Message specification: @p https://pixhawk.ethz.ch/mavlink/#HIL_GPS
+    void set_hil_gps(uint64_t time_boot_us, uint8_t fix_type,
+			int32_t lat, int32_t lon, int32_t alt,
+			uint16_t eph, uint16_t epv, uint16_t vel, 
+			int16_t vn, int16_t ve, int16_t vd,
+			uint16_t cog,
+			uint8_t satellites_visible)
+    {
+        mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
+        mavlink::common::msg::HIL_GPS gps;
+        
+        // there is no target sys in this mavlink message!
+        
+        gps.time_usec		= time_boot_us;
+	gps.fix_type		=fix_type;
+	gps.lat			=lat;
+	gps.lon			=lon;
+	gps.alt			=alt;
+	gps.eph			=eph;
+	gps.epv			=epv;
+	gps.vel			=vel;
+	gps.vn			=vn;
+	gps.ve			=ve;
+	gps.vd			=vd;
+	gps.cog			=cog;
+	gps.satellites_visible	=satellites_visible
+        UAS_FCU(m_uas_)->send_message_ignore_drop(gps);
+    }
+};
+
 }	// namespace plugin
 }	// namespace mavros

--- a/mavros/include/mavros/hil_sensor_mixin.h
+++ b/mavros/include/mavros/hil_sensor_mixin.h
@@ -68,7 +68,7 @@ public:
  * @brief This mixin adds set_hil_state_quaternion()
  */
 template <class D>
-class SetHilSensorMixin {
+class SetHilStateQuaternionMixin {
 public:
     //! Message specification: @p https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION
     void set_hil_state_quaternion(uint64_t time_boot_us,

--- a/mavros/include/mavros/hil_sensor_mixin.h
+++ b/mavros/include/mavros/hil_sensor_mixin.h
@@ -146,7 +146,7 @@ public:
 	gps.ve			=ve;
 	gps.vd			=vd;
 	gps.cog			=cog;
-	gps.satellites_visible	=satellites_visible
+	gps.satellites_visible	=satellites_visible;
         UAS_FCU(m_uas_)->send_message_ignore_drop(gps);
     }
 };

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -72,7 +72,10 @@
 		<description>Publish HIL controls values</description>
 	</class>
     <class name="hil_sensor" type="mavros::std_plugins::HilSensorPlugin" base_class_type="mavros::plugin::PluginBase">
-        <description>Publish HIL Sensor values in NED</description>
+        <description>Send HIL Sensor values in NED to FCU</description>
+    </class>
+    <class name="hil_state_quaternion" type="mavros::std_plugins::HilStateQuaternionPlugin" base_class_type="mavros::plugin::PluginBase">
+        <description>Send HIL_STATE_QUATERNION to FCU</description>
     </class>
 </library>
 

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -71,11 +71,14 @@
 	<class name="hil_actuator_controls" type="mavros::std_plugins::HilActuatorControlsPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish HIL controls values</description>
 	</class>
-    <class name="hil_sensor" type="mavros::std_plugins::HilSensorPlugin" base_class_type="mavros::plugin::PluginBase">
-        <description>Send HIL Sensor values in NED to FCU</description>
-    </class>
-    <class name="hil_state_quaternion" type="mavros::std_plugins::HilStateQuaternionPlugin" base_class_type="mavros::plugin::PluginBase">
-        <description>Send HIL_STATE_QUATERNION to FCU</description>
-    </class>
+	<class name="hil_sensor" type="mavros::std_plugins::HilSensorPlugin" base_class_type="mavros::plugin::PluginBase">
+	<description>Send HIL Sensor values in NED to FCU</description>
+	</class>
+	<class name="hil_state_quaternion" type="mavros::std_plugins::HilStateQuaternionPlugin" base_class_type="mavros::plugin::PluginBase">
+	<description>Send HIL_STATE_QUATERNION to FCU</description>
+	</class>
+	<class name="hil_gps" type="mavros::std_plugins::HilGPSPlugin" base_class_type="mavros::plugin::PluginBase">
+	<description>Send HIL_GPS to FCU</description>
+	</class>
 </library>
 

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -80,5 +80,8 @@
 	<class name="hil_gps" type="mavros::std_plugins::HilGPSPlugin" base_class_type="mavros::plugin::PluginBase">
 	<description>Send HIL_GPS to FCU</description>
 	</class>
+	<class name="actuator_control_target" type="mavros::std_plugins::ActuatorControlTargetPlugin" base_class_type="mavros::plugin::PluginBase">
+	<description>Get Actuator Control Target from FCU</description>
+	</class>
 </library>
 

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -71,5 +71,8 @@
 	<class name="hil_actuator_controls" type="mavros::std_plugins::HilActuatorControlsPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish HIL controls values</description>
 	</class>
+    <class name="hil_sensor" type="mavros::std_plugins::HilSensorPlugin" base_class_type="mavros::plugin::PluginBase">
+        <description>Publish HIL Sensor values in NED</description>
+    </class>
 </library>
 

--- a/mavros/src/plugins/actuator_control_target.cpp
+++ b/mavros/src/plugins/actuator_control_target.cpp
@@ -57,7 +57,7 @@ private:
 		actuator_control_target_msg->header.stamp = m_uas->synchronise_stamp(actuator_control_target.time_usec);
 
 		actuator_control_target_msg->group_mlx = actuator_control_target.group_mlx;
-		for(i=0; i<8; i++){
+		for(int i=0; i<8; i++){
 			actuator_control_target_msg->controls[i]=actuator_control_target.controls[i];
 		}
 

--- a/mavros/src/plugins/actuator_control_target.cpp
+++ b/mavros/src/plugins/actuator_control_target.cpp
@@ -1,0 +1,72 @@
+/**
+ * @brief ActuatorControlTarget plugin
+ * @file actuator_control_target.cpp
+ * @author Mohamed Abdelkader Zahana <mohamedashraf123@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Mohamed Abdelkader Zahana.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+
+#include <mavros_msgs/ActuatorControlTarget.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief Actuator Control Target plugin
+ */
+class ActuatorControlTargetPlugin : public plugin::PluginBase {
+public:
+	ActuatorControlTargetPlugin() : PluginBase(),
+		actuator_control_target_nh("~")
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		actuator_control_target_pub = actuator_control_target_nh.advertise<mavros_msgs::ActuatorControlTarget>("actuator_control_target", 10);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return {
+			       make_handler(&ActuatorControlTargetPlugin::handle_actuator_control_target),
+		};
+	}
+
+private:
+	ros::NodeHandle actuator_control_target_nh;
+
+	ros::Publisher actuator_control_target_pub;
+
+	/* -*- rx handlers -*- */
+
+	void handle_actuator_control_target(const mavlink::mavlink_message_t *msg, mavlink::common::msg::ACTUATOR_CONTROL_TARGET &actuator_control_target)
+	{
+		auto actuator_control_target_msg = boost::make_shared<mavros_msgs::ActuatorControlTarget>();
+
+		actuator_control_target_msg->header.stamp = m_uas->synchronise_stamp(actuator_control_target.time_usec);
+
+		actuator_control_target_msg->group_mlx = actuator_control_target.group_mlx;
+		for(i=0; i<8; i++){
+			actuator_control_target_msg->controls[i]=actuator_control_target.controls[i];
+		}
+
+		actuator_control_target_pub.publish(actuator_control_target_msg);
+	}
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::ActuatorControlTargetPlugin, mavros::plugin::PluginBase)
+

--- a/mavros/src/plugins/hil_controls.cpp
+++ b/mavros/src/plugins/hil_controls.cpp
@@ -33,7 +33,7 @@ public:
 	{
 		PluginBase::initialize(uas_);
 		last_time = ros::Time(0.0);
-		control_period = ros::Duration(0.025);	// 40hz
+		control_period = ros::Duration(0.1);	// 40hz
 
 		hil_controls_pub = hil_controls_nh.advertise<mavros_msgs::HilControls>("hil_controls", 10);
 	}

--- a/mavros/src/plugins/hil_controls.cpp
+++ b/mavros/src/plugins/hil_controls.cpp
@@ -33,7 +33,7 @@ public:
 	{
 		PluginBase::initialize(uas_);
 		last_time = ros::Time(0.0);
-		control_period = ros::Duration(0.1);	// 40hz
+		control_period = ros::Duration(0.025);	// 40hz
 
 		hil_controls_pub = hil_controls_nh.advertise<mavros_msgs::HilControls>("hil_controls", 10);
 	}

--- a/mavros/src/plugins/hil_gps.cpp
+++ b/mavros/src/plugins/hil_gps.cpp
@@ -1,0 +1,101 @@
+/**
+ * @brief HilGPS plugin
+ * @file hil_gps.cpp
+ * @author Mohamed Abdelkader <mohamedashraf123@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Mohamed Abdelkader.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <mavros/hil_sensor_mixin.h>
+#include <eigen_conversions/eigen_msg.h>
+
+#include <mavros_msgs/HilGPS.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief HIL GPS plugin
+ *
+ * Send HIL GPS to FCU controller.
+ */
+class HilGPSPlugin : public plugin::PluginBase,
+    private plugin::SetHilGPSMixin<HilGPSPlugin> {
+public:
+	HilGPSPlugin() : PluginBase(),
+		gps_nh("~hil_gps")
+
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+
+		hilGPS_sub = gps_nh.subscribe("hilgps", 10, &HilGPSPlugin::gps_cb, this);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return { /* Rx disabled */ };
+	}
+
+private:
+	friend class SetHilSensorMixin;
+        
+	ros::NodeHandle gps_nh;
+
+	ros::Subscriber hilGPS_sub;
+
+
+	/* -*- mid-level helpers -*- */
+
+	/**
+	 * @brief Send hil_gps to FCU.
+	 *
+	 * @warning
+	 */
+	void send_hil_gps(const ros::Time &stamp,
+                         uint8_t fix_type,
+			int32_t lat, int32_t lon, int32_t alt,
+			uint16_t eph, uint16_t epv, uint16_t vel, 
+			int16_t vn, int16_t ve, int16_t vd,
+			uint16_t cog,
+			uint8_t satellites_visible) {
+
+		set_hil_gps(stamp.toNSec() / 1000,
+			fix_type,
+			lat, lon, alt,
+			eph, epv, vel, 
+			vn, ve, vd,
+			cog,
+			satellites_visible);
+	}
+
+	/* -*- callbacks -*- */
+        
+
+	void gps_cb(const mavros_msgs::HilGPS::ConstPtr &req) {
+            
+            send_hil_gps(req->header.stamp,
+                            req->fix_type,
+                            req->lat, req->lon, req->alt,
+                            req->eph, req->epv, req->vel,
+                            req->vn, req->ve, req->vd,
+                            req->cog,
+                            req->satellites_visible);
+        }
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::HilGPSPlugin, mavros::plugin::PluginBase)

--- a/mavros/src/plugins/hil_gps.cpp
+++ b/mavros/src/plugins/hil_gps.cpp
@@ -49,7 +49,7 @@ public:
 	}
 
 private:
-	friend class SetHilSensorMixin;
+	friend class SetHilGPSMixin;
         
 	ros::NodeHandle gps_nh;
 

--- a/mavros/src/plugins/hil_sensor.cpp
+++ b/mavros/src/plugins/hil_sensor.cpp
@@ -31,7 +31,7 @@ class HilSensorPlugin : public plugin::PluginBase,
     private plugin::SetHilSensorMixin<HilSensorPlugin> {
 public:
 	HilSensorPlugin() : PluginBase(),
-		sp_nh("~hil_sensor"),
+		sensor_nh("~hil_sensor"),
 
 	{ }
 

--- a/mavros/src/plugins/hil_sensor.cpp
+++ b/mavros/src/plugins/hil_sensor.cpp
@@ -31,7 +31,7 @@ class HilSensorPlugin : public plugin::PluginBase,
     private plugin::SetHilSensorMixin<HilSensorPlugin> {
 public:
 	HilSensorPlugin() : PluginBase(),
-		sensor_nh("~hil_sensor"),
+		sensor_nh("~hil_sensor")
 
 	{ }
 

--- a/mavros/src/plugins/hil_sensor.cpp
+++ b/mavros/src/plugins/hil_sensor.cpp
@@ -63,18 +63,19 @@ private:
 	 *
 	 * @warning
 	 */
-	void send_hil_sensor(const ros::Time &stamp, Eigen::Vector3d &acc,
-                         Eigen::Vector3d &gyro,
-                         Eigen::Vector3d &mag,
-                         Eigen::Vector3d &pressure,
+	void send_hil_sensor(const ros::Time &stamp,
+                         float xacc, float yacc, float zacc,
+                         float xgyro, float ygyro, float zgyro,
+                         float xmag, float ymag, float zmag,
+                         float abs_pressure, float diff_pressure, float pressure_alt,
                          float temperature,
                          uint32_t fields_updated) {
 
 		set_hil_sensor(stamp.toNSec() / 1000,
-					acc,
-					gyro,
-					mag,
-					pressure,
+					xacc, yacc, zacc,
+					xgyro, ygyro, zgyro,
+					xmag, ymag, zmag,
+					abs_pressure, diff_pressure, pressure_alt,
 					temperature,
 					fields_updated);
 	}
@@ -83,21 +84,12 @@ private:
         
 
 		void sensor_cb(const mavros_msgs::HilSensor::ConstPtr &req) {
-            Eigen::Vector3d acc;
-            Eigen::Vector3d gyro;
-            Eigen::Vector3d mag;
-            Eigen::Vector3d pressure;
-            
-            tf::vectorMsgToEigen(req->acc, acc);
-            tf::vectorMsgToEigen(req->gyro, gyro);
-            tf::vectorMsgToEigen(req->mag, mag);
-            tf::vectorMsgToEigen(req->pressure, pressure);
             
             send_hil_sensor(req->header.stamp,
-                            acc,
-                            gyro,
-                            mag,
-                            pressure,
+                            req->xacc, req->yacc, req->zacc,
+                            req->xgyro, req->ygyro, req->zgyro,
+                            req->xmag, req->ymag, req->zmag,
+                            req->abs_pressure, req->diff_pressure, req->pressure_alt,
                             req->temperature,
                             req->fields_updated);
         }

--- a/mavros/src/plugins/hil_sensor.cpp
+++ b/mavros/src/plugins/hil_sensor.cpp
@@ -1,0 +1,109 @@
+/**
+ * @brief HilSensor plugin
+ * @file hil_sensor.cpp
+ * @author Mohamed Abdelkader <mohamedashraf123@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Mohamed Abdelkader.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <mavros/hil_sensor_mixin.h>
+#include <eigen_conversions/eigen_msg.h>
+
+#include <mavros_msgs/HilSensor.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief HIL Sensor plugin
+ *
+ * Send HIL sensor to FCU controller.
+ */
+class HilSensorPlugin : public plugin::PluginBase,
+    private plugin::SetHilSensorMixin<HilSensorPlugin> {
+public:
+	HilSensorPlugin() : PluginBase(),
+		sp_nh("~hil_sensor"),
+
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+
+		hilSensor_sub = sensor_nh.subscribe("imu_ned", 10, &HilSensorPlugin::sensor_cb, this);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return { /* Rx disabled */ };
+	}
+
+private:
+	friend class SetHilSensorMixin;
+        
+	ros::NodeHandle sensor_nh;
+
+	ros::Subscriber hilSensor_sub;
+
+
+	/* -*- mid-level helpers -*- */
+
+	/**
+	 * @brief Send hil_sensor to FCU.
+	 *
+	 * @warning
+	 */
+	void send_hil_sensor(const ros::Time &stamp, Eigen::Vector3d &acc,
+                         Eigen::Vector3d &gyro,
+                         Eigen::Vector3d &mag,
+                         Eigen::Vector3d &pressure,
+                         float temperature,
+                         uint32_t fields_updated) {
+
+		set_hil_sensor(stamp.toNSec() / 1000,
+					acc,
+					gyro,
+					mag,
+					pressure,
+					temperature,
+					fields_updated);
+	}
+
+	/* -*- callbacks -*- */
+        
+
+		void sensor_cb(const mavros_msgs::HilSensor::ConstPtr &req) {
+            Eigen::Vector3d acc;
+            Eigen::Vector3d gyro;
+            Eigen::Vector3d mag;
+            Eigen::Vector3d pressure;
+            
+            tf::vectorMsgToEigen(req->acc, acc);
+            tf::vectorMsgToEigen(req->gyro, gyro);
+            tf::vectorMsgToEigen(req->mag, mag);
+            tf::vectorMsgToEigen(req->pressure, pressure);
+            
+            send_hil_sensor(req->header.stamp,
+                            acc,
+                            gyro,
+                            mag,
+                            pressure,
+                            req->temperature,
+                            req->fields_updated);
+        }
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::HilSensorPlugin, mavros::plugin::PluginBase)

--- a/mavros/src/plugins/hil_state_quaternion.cpp
+++ b/mavros/src/plugins/hil_state_quaternion.cpp
@@ -31,7 +31,7 @@ class HilStateQuaternionPlugin : public plugin::PluginBase,
     private plugin::SetHilStateQuaternionMixin<HilStateQuaternionPlugin> {
 public:
 	HilStateQuaternionPlugin() : PluginBase(),
-		sp_nh("~hil_state_quaternion"),
+		state_quat_nh("~hil_state_quaternion"),
 
 	{ }
 

--- a/mavros/src/plugins/hil_state_quaternion.cpp
+++ b/mavros/src/plugins/hil_state_quaternion.cpp
@@ -31,7 +31,7 @@ class HilStateQuaternionPlugin : public plugin::PluginBase,
     private plugin::SetHilStateQuaternionMixin<HilStateQuaternionPlugin> {
 public:
 	HilStateQuaternionPlugin() : PluginBase(),
-		state_quat_nh("~hil_state_quaternion"),
+		state_quat_nh("~hil_state_quaternion")
 
 	{ }
 

--- a/mavros/src/plugins/hil_state_quaternion.cpp
+++ b/mavros/src/plugins/hil_state_quaternion.cpp
@@ -85,7 +85,7 @@ private:
 
 		void state_quat_cb(const mavros_msgs::HilStateQuaternion::ConstPtr &req) {
             
-            send_hil_sensor(req->header.stamp,
+            send_hil_state_quaternion(req->header.stamp,
                             req->quat_wxyz[0], req->quat_wxyz[1], req->quat_wxyz[2], req->quat_wxyz[3],
                             req->rollspeed,req->pitchspeed, req->yawspeed,
                             req->lat, req->lon, req->alt,

--- a/mavros/src/plugins/hil_state_quaternion.cpp
+++ b/mavros/src/plugins/hil_state_quaternion.cpp
@@ -1,0 +1,116 @@
+/**
+ * @brief HilStateQuaternion plugin
+ * @file hil_state_quaternion.cpp
+ * @author Mohamed Abdelkader <mohamedashraf123@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2016 Mohamed Abdelkader.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <mavros/hil_sensor_mixin.h>// TODO: add SetHilStateQuaternionMixin
+#include <eigen_conversions/eigen_msg.h>
+
+#include <mavros_msgs/HilStateQuaternion.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief HIL State Quaternion plugin
+ *
+ * Send HIL_STATE_QUATERNION msg to FCU controller.
+ */
+class HilStateQuaternionPlugin : public plugin::PluginBase,
+    private plugin::SetHilStateQuaternionMixin<HilStateQuaternionPlugin> {
+public:
+	HilStateQuaternionPlugin() : PluginBase(),
+		sp_nh("~hil_state_quaternion"),
+
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+
+		hilStateQuaternion_sub = state_quat_nh.subscribe("hil_state", 10, &HilStateQuaternionPlugin::state_quat_cb, this);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return { /* Rx disabled */ };
+	}
+
+private:
+	friend class SetHilStateQuaternionMixin;
+        
+	ros::NodeHandle state_quat_nh;
+
+	ros::Subscriber hilStateQuaternion_sub;
+
+
+	/* -*- mid-level helpers -*- */
+
+	/**
+	 * @brief Send hil_state_quaternion to FCU.
+	 *
+	 */
+	void send_hil_state_quaternion(const ros::Time &stamp,
+                                   Eigen::Vector4d &quat,
+                                   Eigen::Vector3d &angularspeed,
+                                   Eigen::Vector3d &GPS,
+                                   Eigen::Vector3d &groundspeed,
+                                   uint16_t ind_airspeed,
+                                   uint16_t true_airspeed,
+                                   Eigen::Vector3d acceleration) {
+
+		set_hil_state_quaternion(stamp.toNSec() / 1000,
+					quat,
+					angularspeed,
+					GPS,
+					groundspeed,
+					ind_airspeed,
+					true_airspeed,
+                    acceleration);
+	}
+
+	/* -*- callbacks -*- */
+        
+
+		void state_quat_cb(const mavros_msgs::HilStateQuaternion::ConstPtr &req) {
+            Eigen::Vector4d quat;
+            Eigen::Vector3d angularspeed;
+            Eigen::Vector3d GPS;
+            Eigen::Vector3d groundspeed;
+            uint16_t ind_airspeed;
+            uint16_t true_airspeed;
+            Eigen::Vector3d acceleration;
+            
+            tf::vectorMsgToEigen(req->quaternion_wxyz, quat);
+            tf::vectorMsgToEigen(req->angularspeed, angularspeed);
+            tf::vectorMsgToEigen(req->GPS, GPS);
+            tf::vectorMsgToEigen(req->groundspeed, groundspeed);
+            tf::vectorMsgToEigen(req->acceleration, acceleration);
+            
+            send_hil_sensor(req->header.stamp,
+                            quat,
+                            angularspeed,
+                            GPS,
+                            groundspeed,
+                            req->ind_airspeed,
+                            req->true_airspeed,
+                            acceleration);
+        }
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::HilStateQuaternionPlugin, mavros::plugin::PluginBase)

--- a/mavros/src/plugins/hil_state_quaternion.cpp
+++ b/mavros/src/plugins/hil_state_quaternion.cpp
@@ -63,50 +63,36 @@ private:
 	 *
 	 */
 	void send_hil_state_quaternion(const ros::Time &stamp,
-                                   Eigen::Vector4d &quat,
-                                   Eigen::Vector3d &angularspeed,
-                                   Eigen::Vector3d &GPS,
-                                   Eigen::Vector3d &groundspeed,
-                                   uint16_t ind_airspeed,
-                                   uint16_t true_airspeed,
-                                   Eigen::Vector3d acceleration) {
+                                   float qw, float qx, float qy, float qz,
+                                   float rollspeed, float pitchspeed, float yawspeed,
+                                   int32_t lat, int32_t lon, int32_t alt,
+                                   int16_t vx, int16_t vy, int16_t vz,
+                                   uint16_t ind_airspeed, uint16_t true_airspeed,
+                                   int16_t xacc, int16_t yacc, int16_t zacc) {
 
 		set_hil_state_quaternion(stamp.toNSec() / 1000,
-					quat,
-					angularspeed,
-					GPS,
-					groundspeed,
+					qw, qx, qy, qz,
+					rollspeed, pitchspeed, yawspeed,
+					lat, lon, alt,
+					vx, vy, vz,
 					ind_airspeed,
 					true_airspeed,
-                    acceleration);
+                    xacc, yacc, zacc);
 	}
 
 	/* -*- callbacks -*- */
         
 
 		void state_quat_cb(const mavros_msgs::HilStateQuaternion::ConstPtr &req) {
-            Eigen::Vector4d quat;
-            Eigen::Vector3d angularspeed;
-            Eigen::Vector3d GPS;
-            Eigen::Vector3d groundspeed;
-            uint16_t ind_airspeed;
-            uint16_t true_airspeed;
-            Eigen::Vector3d acceleration;
-            
-            tf::vectorMsgToEigen(req->quaternion_wxyz, quat);
-            tf::vectorMsgToEigen(req->angularspeed, angularspeed);
-            tf::vectorMsgToEigen(req->GPS, GPS);
-            tf::vectorMsgToEigen(req->groundspeed, groundspeed);
-            tf::vectorMsgToEigen(req->acceleration, acceleration);
             
             send_hil_sensor(req->header.stamp,
-                            quat,
-                            angularspeed,
-                            GPS,
-                            groundspeed,
+                            req->quat_wxyz[0], req->quat_wxyz[1], req->quat_wxyz[2], req->quat_wxyz[3],
+                            req->rollspeed,req->pitchspeed, req->yawspeed,
+                            req->lat, req->lon, req->alt,
+                            req->vx, req->vy, req->vz,
                             req->ind_airspeed,
                             req->true_airspeed,
-                            acceleration);
+                            req->xacc, req->yacc, req->zacc);
         }
 };
 }	// namespace std_plugins

--- a/mavros_extras/src/plugins/mocap_fake_gps.cpp
+++ b/mavros_extras/src/plugins/mocap_fake_gps.cpp
@@ -145,7 +145,7 @@ private:
 		pos.eph = 2;
 		pos.epv = 2;
 		pos.fix_type = 3;
-		pos.satellites_visible = 5;
+		pos.satellites_visible = 10;
 		UAS_FCU(m_uas)->send_message_ignore_drop(pos);
 	}
 };

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -19,6 +19,8 @@ add_message_files(
   GlobalPositionTarget.msg
   HilActuatorControls.msg
   HilControls.msg
+  HilSensor.msg
+  HilStateQuaternion.msg
   HomePosition.msg
   ManualControl.msg
   Mavlink.msg

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -37,6 +37,7 @@ add_message_files(
   Vibration.msg
   Waypoint.msg
   WaypointList.msg
+  ActuatorControlTarget.msg
 )
 
 add_service_files(

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ add_message_files(
   HilControls.msg
   HilSensor.msg
   HilStateQuaternion.msg
+  HilGPS.msg
   HomePosition.msg
   ManualControl.msg
   Mavlink.msg

--- a/mavros_msgs/msg/ActuatorControlTarget.msg
+++ b/mavros_msgs/msg/ActuatorControlTarget.msg
@@ -1,0 +1,9 @@
+# ActuatorControlTarget.msg
+#
+# ROS representation of MAVLink HIL_ACTUATOR_CONTROLS
+# See mavlink message documentation here:
+# https://pixhawk.ethz.ch/mavlink/#ACTUATOR_CONTROL_TARGET
+
+std_msgs/Header header
+float32[8] controls
+uint8 group_mlx

--- a/mavros_msgs/msg/HilGPS.msg
+++ b/mavros_msgs/msg/HilGPS.msg
@@ -1,0 +1,19 @@
+# HilControls.msg
+#
+# ROS representation of MAVLink HIL_GPS
+# See mavlink message documentation here:
+# https://pixhawk.ethz.ch/mavlink/#HIL_GPS
+
+std_msgs/Header header
+uint8 fix_type
+int32 lat
+int32 lon
+int32 alt
+uint16 eph
+uint16 epv
+uint16 vel
+int16 vn
+int16 ve
+int16 vd
+uint16 cog
+uint8 satellites_visible

--- a/mavros_msgs/msg/HilSensor.msg
+++ b/mavros_msgs/msg/HilSensor.msg
@@ -5,9 +5,17 @@
 # https://pixhawk.ethz.ch/mavlink/#HIL_SENSOR
 
 std_msgs/Header header
-float32[3] acc # has xacc, yacc, zacc
-float32[3] gyro # has xgyro, ygyro, zgyro
-float32[3] mag # has xmag, ymag, zmag
-float32[3] pressure # has abs_pressure, diff_presuure, pressure_alt
-float32 temperature
+float32 xacc
+float32 yacc
+float32 zacc
+float32 xgyro
+float32 ygyro
+float32 zgyro
+float32 xmag
+float32 ymag
+float32 zmag
+float32 abs_pressure
+float32 diff_pressure
+float32 pressure_alt
+flat32 temperature
 uint32 fields_updated

--- a/mavros_msgs/msg/HilSensor.msg
+++ b/mavros_msgs/msg/HilSensor.msg
@@ -1,0 +1,21 @@
+# HilSensor.msg
+#
+# ROS representation of MAVLink HIL_SENSOR
+# See mavlink message documentation here:
+# https://pixhawk.ethz.ch/mavlink/#HIL_SENSOR
+
+std_msgs/Header header
+float32 xacc
+float32 yacc
+float32 zacc
+float32 xgyro
+float32 ygyro
+float32 zgyro
+float32 xmag
+float32 ymag
+float32 zmag
+float32 abs_pressure
+float32 diff_pressure
+float32 pressure_alt
+float32 temperature
+uint32 fields_updated

--- a/mavros_msgs/msg/HilSensor.msg
+++ b/mavros_msgs/msg/HilSensor.msg
@@ -17,5 +17,5 @@ float32 zmag
 float32 abs_pressure
 float32 diff_pressure
 float32 pressure_alt
-flat32 temperature
+float32 temperature
 uint32 fields_updated

--- a/mavros_msgs/msg/HilSensor.msg
+++ b/mavros_msgs/msg/HilSensor.msg
@@ -5,17 +5,9 @@
 # https://pixhawk.ethz.ch/mavlink/#HIL_SENSOR
 
 std_msgs/Header header
-float32 xacc
-float32 yacc
-float32 zacc
-float32 xgyro
-float32 ygyro
-float32 zgyro
-float32 xmag
-float32 ymag
-float32 zmag
-float32 abs_pressure
-float32 diff_pressure
-float32 pressure_alt
+float32[3] acc # has xacc, yacc, zacc
+float32[3] gyro # has xgyro, ygyro, zgyro
+float32[3] mag # has xmag, ymag, zmag
+float32[3] pressure # has abs_pressure, diff_presuure, pressure_alt
 float32 temperature
 uint32 fields_updated

--- a/mavros_msgs/msg/HilStateQuaternion.msg
+++ b/mavros_msgs/msg/HilStateQuaternion.msg
@@ -6,9 +6,17 @@
 
 std_msgs/Header header
 float32[4] quaternion_wxyz
-float32[3] angularspeed # has rollspeed, pitchspeed, yawspeed (rad/s)
-int32[3] GPS # has lat *1E7, lon *1E7, alt *1000(millimeters)
-int16[3] groundspeed # has vx, vy, vz (cm/s)
+float32 rollspeed
+float32 pitchspeed
+float32 yawspeed
+int32 lat
+int32 lon
+int32 alt
+int16 vx
+int16 vy
+int16 vz
 uint16 ind_airspeed
 uint16 true_airspeed
-int16[3] acceleration # has xacc, yacc, zacc in milli g
+int16 xacc
+int16 yacc
+int16 zacc

--- a/mavros_msgs/msg/HilStateQuaternion.msg
+++ b/mavros_msgs/msg/HilStateQuaternion.msg
@@ -5,18 +5,10 @@
 # https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION
 
 std_msgs/Header header
-float32[4] attitude_quaternion
-float32 rollspeed
-float32 pitchspeed
-float32 yawspeed
-int32 lat
-int32 lon
-int32 alt
-int16 vx
-int16 vy
-int16 vz
+float32[4] quaternion_wxyz
+float32[3] angularspeed # has rollspeed, pitchspeed, yawspeed (rad/s)
+int32[3] GPS # has lat *1E7, lon *1E7, alt *1000(millimeters)
+int16[3] groundspeed # has vx, vy, vz (cm/s)
 uint16 ind_airspeed
 uint16 true_airspeed
-int16 xacc
-int16 yacc
-int16 zacc
+int16[3] acceleration # has xacc, yacc, zacc in milli g

--- a/mavros_msgs/msg/HilStateQuaternion.msg
+++ b/mavros_msgs/msg/HilStateQuaternion.msg
@@ -1,0 +1,22 @@
+# HilStateQuaternion.msg
+#
+# ROS representation of MAVLink HIL_STATE_QUATERNION
+# See mavlink message documentation here:
+# https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION
+
+std_msgs/Header header
+float32[4] attitude_quaternion
+float32 rollspeed
+float32 pitchspeed
+float32 yawspeed
+int32 lat
+int32 lon
+int32 alt
+int16 vx
+int16 vy
+int16 vz
+uint16 ind_airspeed
+uint16 true_airspeed
+int16 xacc
+int16 yacc
+int16 zacc

--- a/mavros_msgs/msg/HilStateQuaternion.msg
+++ b/mavros_msgs/msg/HilStateQuaternion.msg
@@ -5,7 +5,7 @@
 # https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION
 
 std_msgs/Header header
-float32[4] quaternion_wxyz
+float32[4] quat_wxyz
 float32 rollspeed
 float32 pitchspeed
 float32 yawspeed


### PR DESCRIPTION
This branch adds support for MAVLink messages that are used in HIL with PX4 firmware.

Added messages:
- HilGPS, HilControls, HILSensor, HilStateQuaternion, ActuatorControlTarget

Plugins:
- hil_controls, hil_sensor, hil_state_quaternion, hil_gps, actuator_control_target

This is demonstrated with VREP simulator. [Demo video](https://www.youtube.com/watch?v=NoEw4upSE4M&feature=youtu.be)