### PR TITLE
Trouble Compiling MAVROS 

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -2,8 +2,8 @@
 	<!-- vim: set ft=xml noet : -->
 	<!-- example launch script for ArduPilotMega based FCU's -->
 
-	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
-	<arg name="gcs_url" default="" />
+	<arg name="fcu_url" default="/dev/ttyACM0:115200" />
+	<arg name="gcs_url" default="udp://192.168.1.169:14550@192.168.1.235:14550" />
 	<arg name="tgt_system" default="1" />
 	<arg name="tgt_component" default="1" />
 	<arg name="log_output" default="screen" />

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -63,9 +63,9 @@ imu:
 local_position:
   frame_id: "fcu"
   tf:
-    send: false
-    frame_id: "local_origin"
-    child_frame_id: "fcu"
+    send: true
+    frame_id: "world"
+    child_frame_id: "base_link"
 
 # param
 # None, used for FCU params

--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -8,9 +8,10 @@ plugin_blacklist:
 - image_pub
 - 'mocap_*'
 - px4flow
-- 'vision_*'
+- vision_speed_estimate
 - distance_sensor
 - vibration
 
 plugin_whitelist: []
 #- 'sys_*'
+

--- a/mavros/launch/apm_sitl.launch
+++ b/mavros/launch/apm_sitl.launch
@@ -1,11 +1,12 @@
 <launch>
 	<!-- vim: set ft=xml noet : -->
-	<!-- example launch script for ArduPilotMega based FCU's -->
+	<!-- example launch script for ArduPilotMega based FCU's  -->
 
 	<arg name="fcu_url" default="tcp://127.0.0.1:5760" />
-	<arg name="gcs_url" default="udp://127.0.0.1@127.0.0.1:14551" />
+	<arg name="gcs_url" default="udp://127.0.0.1@127.0.0.1:14550" />
 	<arg name="tgt_system" default="1" />
 	<arg name="tgt_component" default="1" />
+	<arg name="log_output" default="screen" />
 
 	<include file="$(find mavros)/launch/node.launch">
 		<arg name="pluginlists_yaml" value="$(find mavros)/launch/apm_pluginlists.yaml" />
@@ -15,5 +16,6 @@
 		<arg name="gcs_url" value="$(arg gcs_url)" />
 		<arg name="tgt_system" value="$(arg tgt_system)" />
 		<arg name="tgt_component" value="$(arg tgt_component)" />
+		<arg name="log_output" value="$(arg log_output)" />
 	</include>
 </launch>

--- a/mavros/launch/apm_sitl.launch
+++ b/mavros/launch/apm_sitl.launch
@@ -1,0 +1,19 @@
+<launch>
+	<!-- vim: set ft=xml noet : -->
+	<!-- example launch script for ArduPilotMega based FCU's -->
+
+	<arg name="fcu_url" default="tcp://127.0.0.1:5760" />
+	<arg name="gcs_url" default="udp://127.0.0.1@127.0.0.1:14551" />
+	<arg name="tgt_system" default="1" />
+	<arg name="tgt_component" default="1" />
+
+	<include file="$(find mavros)/launch/node.launch">
+		<arg name="pluginlists_yaml" value="$(find mavros)/launch/apm_pluginlists.yaml" />
+		<arg name="config_yaml" value="$(find mavros)/launch/apm_config.yaml" />
+
+		<arg name="fcu_url" value="$(arg fcu_url)" />
+		<arg name="gcs_url" value="$(arg gcs_url)" />
+		<arg name="tgt_system" value="$(arg tgt_system)" />
+		<arg name="tgt_component" value="$(arg tgt_component)" />
+	</include>
+</launch>

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -1,7 +1,7 @@
 # Common configuration for PX4 autopilot
 #
 # node:
-startup_px4_usb_quirk: true
+startup_px4_usb_quirk: false
 
 # --- system plugins ---
 

--- a/mavros/launch/px4_sitl.launch
+++ b/mavros/launch/px4_sitl.launch
@@ -1,0 +1,21 @@
+<launch>
+	<!-- vim: set ft=xml noet : -->
+	<!-- example launch script for PX4 based FCU's -->
+
+	<arg name="fcu_url" default="udp://127.0.0.1@127.0.0.1:14556" />
+	<arg name="gcs_url" default="udp://127.0.0.1:14551@127.0.0.1:14550" />
+	<arg name="tgt_system" default="1" />
+	<arg name="tgt_component" default="1" />
+	<arg name="log_output" default="screen" />
+
+	<include file="$(find mavros)/launch/node.launch">
+		<arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
+		<arg name="config_yaml" value="$(find mavros)/launch/px4_config.yaml" />
+
+		<arg name="fcu_url" value="$(arg fcu_url)" />
+		<arg name="gcs_url" value="$(arg gcs_url)" />
+		<arg name="tgt_system" value="$(arg tgt_system)" />
+		<arg name="tgt_component" value="$(arg tgt_component)" />
+		<arg name="log_output" value="$(arg log_output)" />
+	</include>
+</launch>

--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -388,9 +388,9 @@ private:
 	ros::Timer shedule_timer;			//!< for startup shedule fetch
 	ros::Timer timeout_timer;			//!< for timeout resend
 
-	static constexpr int BOOTUP_TIME_MS = 10000;	//!< APM boot time
+	static constexpr int BOOTUP_TIME_MS = 30000;	//!< APM boot time
 	static constexpr int PARAM_TIMEOUT_MS = 1000;	//!< Param wait time
-	static constexpr int LIST_TIMEOUT_MS = 30000;	//!< Receive all time
+	static constexpr int LIST_TIMEOUT_MS = 40000;	//!< Receive all time
 	static constexpr int RETRIES_COUNT = 3;
 
 	const ros::Duration BOOTUP_TIME_DT;

--- a/mavros_extras/launch/kbteleop.launch
+++ b/mavros_extras/launch/kbteleop.launch
@@ -1,0 +1,6 @@
+<launch>
+	<arg name="teleop_args" default="-rc" />
+	
+	<node pkg="mavros_extras" type="mavkbteleop" name="mavkbteleop" args="$(arg teleop_args)" required="True" output="screen">
+	</node>
+</launch>

--- a/mavros_extras/launch/st290_joy.yaml
+++ b/mavros_extras/launch/st290_joy.yaml
@@ -1,0 +1,16 @@
+# Joystic configuration for Logitech F710 gamepad
+# TODO: check scale, button map
+axes_map:
+  roll: 0
+  pitch: 1
+  yaw: 3
+  throttle: 2
+axes_scale:
+  roll: 1.0
+  pitch: 1.0
+  yaw: 1.0
+  throttle: 1.0
+button_map:
+  takeoff: 0
+  arm: 1
+  disarm: 2

--- a/mavros_extras/launch/teleop.launch
+++ b/mavros_extras/launch/teleop.launch
@@ -4,13 +4,15 @@
 
 	<!-- <include file="$(find mavros)/launch/px4.launch" /> -->
 
-	<arg name="teleop_args" default="-att" />
-
+	<arg name="teleop_args" default="-rc" />
+	
+	
 	<node pkg="joy" type="joy_node" name="joy" required="True">
 		<param name="autorepeat_rate" value="5" /> <!-- Minimal update rate, Hz -->
+		<param name="dev" type="string" value="/dev/input/js1" />
 	</node>
 
 	<node pkg="mavros_extras" type="mavteleop" name="mavteleop" args="$(arg teleop_args)" required="True" output="screen">
-		<rosparam command="load" file="$(find mavros_extras)/launch/f710_joy.yaml" />
+		<rosparam command="load" file="$(find mavros_extras)/launch/st290_joy.yaml" />
 	</node>
 </launch>

--- a/mavros_extras/scripts/mavkbteleop
+++ b/mavros_extras/scripts/mavkbteleop
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# vim:set ts=4 sw=4 et:
+#
+# Copyright 2014 Vladimir Ermakov.
+#
+# This file is part of the mavros package and subject to the license terms
+# in the top-level LICENSE file of the mavros repository.
+# https://github.com/mavlink/mavros/tree/master/LICENSE.md
+
+from __future__ import print_function
+
+import argparse
+
+import rospy
+import sys, select, termios, tty
+from tf.transformations import quaternion_from_euler
+from sensor_msgs.msg import Joy
+from std_msgs.msg import Header, Float64
+from geometry_msgs.msg import PoseStamped, TwistStamped, Vector3, Quaternion, Point
+from mavros.msg import OverrideRCIn
+from mavros.srv import CommandBool
+from mavros.srv import CommandTOL
+from mavros.srv import SetMode
+
+def getKey():
+    tty.setraw(sys.stdin.fileno())
+    rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
+    if rlist:
+        key = sys.stdin.read(1)
+    else:
+        key = ''
+
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+    return key
+
+
+def arm(args, state):
+    try:
+        arming_cl = rospy.ServiceProxy(args.mavros_ns + "/cmd/arming", CommandBool)
+        ret = arming_cl(value=state)
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("ARM Request failed.")
+    else:
+        rospy.loginfo("ARM Request success.")
+
+def takeoff(args):
+    try:
+        takeoff_cl = rospy.ServiceProxy(args.mavros_ns + "/cmd/takeoff", CommandTOL)
+        
+        ret = takeoff_cl(altitude=2, latitude=0, longitude=0, min_pitch=0, yaw=0)
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("TAKEOFF Request failed.")
+    else:
+        rospy.loginfo("TAKEOFF Request success.")
+
+def set_mode(args, mode):
+    try:
+        setmode_cl = rospy.ServiceProxy(args.mavros_ns + "/set_mode", SetMode)
+        
+        ret = setmode_cl(base_mode=0, custom_mode="ALT_HOLD")
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("SET MODE Request failed.")
+    else:
+        rospy.loginfo("SET MODE Request success.")
+
+
+def rc_override_control(args):
+    
+    rospy.init_node("mavteleop")
+    rospy.loginfo("MAV-Teleop: RC Override control type.")
+    
+
+    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override_joy", OverrideRCIn, queue_size=10)
+    
+    throttle_ch = 1000
+
+    
+    while(1):
+        roll = 1500
+	pitch = 1500
+        key = getKey()
+        #rospy.loginfo("Key: %s", key)
+        if key == 'a':
+            arm(args, True)
+        elif key == 'd':
+            arm(args, False)
+        elif key == 't':
+	    takeoff(args)
+	elif key == 'h':
+            set_mode(args, "ALT_HOLD")
+        elif key == 'r': #UP
+	    throttle_ch+=10
+	elif key == 'f': #FIX
+	    throttle_ch=1500
+	elif key == 'v': #DOWN
+	    throttle_ch-=10 
+	elif key == 'j': #LEFT
+	    roll=1600   
+	elif key == 'l': #RIGHT
+	    roll=1400   
+	elif key == 'i': #FORWARD
+	    pitch=1600 
+	elif key == 'k': #BACKWARD
+	    pitch=1400  	    
+	if (key == '\x03'):
+            break
+        
+        rc = OverrideRCIn()
+        rc.channels[0] = roll
+        rc.channels[1] = pitch
+        rc.channels[2] = throttle_ch
+        rc.channels[3] = 1500 #yaw
+        rc.channels[4] = 1000
+        rc.channels[5] = 1000
+        rc.channels[6] = 1000
+        rc.channels[7] = 1000
+        
+        #rospy.loginfo("Channels: %d %d %d %d", rc.channels[0], rc.channels[1],rc.channels[2] , rc.channels[3])
+        
+        override_pub.publish(rc)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Teleoperation script for Copter-UAV")
+    parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default="/mavros")
+    parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument('-rc', '--rc-override', action='store_true', help="use rc override control type")
+    mode_group.add_argument('-att', '--sp-attitude', action='store_true', help="use attitude setpoint control type")
+    mode_group.add_argument('-vel', '--sp-velocity', action='store_true', help="use velocity setpoint control type")
+    mode_group.add_argument('-pos', '--sp-position', action='store_true', help="use position setpoint control type")
+
+    args = parser.parse_args(rospy.myargv(argv=sys.argv)[1:])
+
+    if args.rc_override:
+        rc_override_control(args)
+
+
+if __name__ == '__main__':
+    settings = termios.tcgetattr(sys.stdin)
+    main()
+

--- a/mavros_extras/scripts/mavkbteleop
+++ b/mavros_extras/scripts/mavkbteleop
@@ -59,6 +59,32 @@ def takeoff(args):
     else:
         rospy.loginfo("TAKEOFF Request success.")
 
+def land(args):
+    try:
+        land_cl = rospy.ServiceProxy(args.mavros_ns + "/cmd/land", CommandTOL)
+        
+        ret = land_cl(altitude=0, latitude=0, longitude=0, min_pitch=0, yaw=0)
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("LAND Request failed.")
+    else:
+        rospy.loginfo("LAND Request success.")        
+
+def guided(args, state):
+    try:
+        guided_cl = rospy.ServiceProxy(args.mavros_ns + "/cmd/guided_enable", CommandBool)
+        
+        ret = guided_cl(value=state)
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("GUIDED Request failed.")
+    else:
+        rospy.loginfo("GUIDED Request success.")
+
 def set_mode(args, mode):
     try:
         setmode_cl = rospy.ServiceProxy(args.mavros_ns + "/set_mode", SetMode)
@@ -80,6 +106,7 @@ def rc_override_control(args):
     
 
     override_pub = rospy.Publisher(args.mavros_ns + "/rc/override", OverrideRCIn, queue_size=10)
+    pos_pub = rospy.Publisher(args.mavros_ns + "/setpoint_position/local", PoseStamped, queue_size=10)
     
     throttle_ch = 1000
 
@@ -88,13 +115,23 @@ def rc_override_control(args):
         roll = 1500
 	pitch = 1500
         key = getKey()
-        #rospy.loginfo("Key: %s", key)
+        #rospy.loginfo("Key: %s", key)        
         if key == 'a':
             arm(args, True)
         elif key == 'd':
             arm(args, False)
         elif key == 't':
 	    takeoff(args)
+	elif key == 'l':
+	    land(args)
+	elif key == 'z':  
+	    pose = PoseStamped(header=Header(stamp=rospy.get_rostime()))
+	    pose.pose.position = Point(x=0.0, y=0.0, z=2.0)
+	    q = quaternion_from_euler(0, 0, 0.0)
+	    pose.pose.orientation = Quaternion(*q)
+	    pos_pub.publish(pose)  
+	elif key == 'G':
+	    set_mode(args, "GUIDED")
 	elif key == 'H':
             set_mode(args, "ALT_HOLD")
         elif key == 'L':
@@ -112,7 +149,21 @@ def rc_override_control(args):
 	elif key == 'i': #FORWARD
 	    pitch=1600 
 	elif key == 'k': #BACKWARD
-	    pitch=1400  	    
+	    pitch=1400  	
+	elif key == '0': #FIX
+	    throttle_ch=1000  
+	elif key == '1':
+	    throttle_ch=1100    
+	elif key == '2':
+	    throttle_ch=1200    	    
+	elif key == '3':
+	    throttle_ch=1300
+	elif key == '4':
+	    throttle_ch=1400
+	elif key == '5':
+	    throttle_ch=1500
+	elif key == '6':
+	    throttle_ch=1600	    	    
 	if (key == '\x03'):
             break
         

--- a/mavros_extras/scripts/mavkbteleop
+++ b/mavros_extras/scripts/mavkbteleop
@@ -63,7 +63,7 @@ def set_mode(args, mode):
     try:
         setmode_cl = rospy.ServiceProxy(args.mavros_ns + "/set_mode", SetMode)
         
-        ret = setmode_cl(base_mode=0, custom_mode="ALT_HOLD")
+        ret = setmode_cl(base_mode=0, custom_mode=mode)
     except rospy.ServiceException as ex:
         fault(ex)
 
@@ -79,7 +79,7 @@ def rc_override_control(args):
     rospy.loginfo("MAV-Teleop: RC Override control type.")
     
 
-    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override_joy", OverrideRCIn, queue_size=10)
+    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override", OverrideRCIn, queue_size=10)
     
     throttle_ch = 1000
 
@@ -95,8 +95,10 @@ def rc_override_control(args):
             arm(args, False)
         elif key == 't':
 	    takeoff(args)
-	elif key == 'h':
+	elif key == 'H':
             set_mode(args, "ALT_HOLD")
+        elif key == 'L':
+            set_mode(args, "LOITER")
         elif key == 'r': #UP
 	    throttle_ch+=10
 	elif key == 'f': #FIX

--- a/mavros_extras/scripts/mavkbteleop
+++ b/mavros_extras/scripts/mavkbteleop
@@ -15,7 +15,7 @@ import rospy
 import sys, select, termios, tty
 from tf.transformations import quaternion_from_euler
 from sensor_msgs.msg import Joy
-from std_msgs.msg import Header, Float64
+from std_msgs.msg import Header, Float64, Empty
 from geometry_msgs.msg import PoseStamped, TwistStamped, Vector3, Quaternion, Point
 from mavros.msg import OverrideRCIn
 from mavros.srv import CommandBool
@@ -105,8 +105,9 @@ def rc_override_control(args):
     rospy.loginfo("MAV-Teleop: RC Override control type.")
     
 
-    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override", OverrideRCIn, queue_size=10)
+    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override_joy", OverrideRCIn, queue_size=10)
     pos_pub = rospy.Publisher(args.mavros_ns + "/setpoint_position/local", PoseStamped, queue_size=10)
+    test_video_lag_pub = rospy.Publisher("/test_video_lag", Empty, queue_size=1)
     
     throttle_ch = 1000
 
@@ -126,10 +127,20 @@ def rc_override_control(args):
 	    land(args)
 	elif key == 'z':  
 	    pose = PoseStamped(header=Header(stamp=rospy.get_rostime()))
-	    pose.pose.position = Point(x=0.0, y=0.0, z=2.0)
+	    pose.pose.position = Point(x=0.0, y=0.0, z=2.3)
 	    q = quaternion_from_euler(0, 0, 0.0)
 	    pose.pose.orientation = Quaternion(*q)
 	    pos_pub.publish(pose)  
+	elif key == 'x':  
+	    pose = PoseStamped(header=Header(stamp=rospy.get_rostime()))
+	    pose.pose.position = Point(x=0.0, y=0.0, z=0.3)
+	    q = quaternion_from_euler(0, 0, 0.0)
+	    pose.pose.orientation = Quaternion(*q)
+	    pos_pub.publish(pose)      
+	elif key == 'q':  
+	    msg = Empty()
+	    test_video_lag_pub.publish(msg)  
+	    rospy.loginfo("Test video lag")
 	elif key == 'G':
 	    set_mode(args, "GUIDED")
 	elif key == 'H':
@@ -142,14 +153,14 @@ def rc_override_control(args):
 	    throttle_ch=1500
 	elif key == 'v': #DOWN
 	    throttle_ch-=10 
-	elif key == 'j': #LEFT
-	    roll=1600   
-	elif key == 'l': #RIGHT
-	    roll=1400   
-	elif key == 'i': #FORWARD
-	    pitch=1600 
-	elif key == 'k': #BACKWARD
-	    pitch=1400  	
+	#elif key == 'j': #LEFT
+	#    roll=1600   
+	#elif key == 'l': #RIGHT
+	#    roll=1400   
+	#elif key == 'i': #FORWARD
+	#    pitch=1600 
+	#elif key == 'k': #BACKWARD
+	#    pitch=1400  	
 	elif key == '0': #FIX
 	    throttle_ch=1000  
 	elif key == '1':

--- a/mavros_extras/scripts/mavteleop
+++ b/mavros_extras/scripts/mavteleop
@@ -19,6 +19,8 @@ from std_msgs.msg import Header, Float64
 from geometry_msgs.msg import PoseStamped, TwistStamped, Vector3, Quaternion, Point
 from mavros.msg import OverrideRCIn
 from mavros.srv import CommandBool
+from mavros.srv import CommandTOL
+from mavros.srv import SetMode
 
 
 def arduino_map(x, inmin, inmax, outmin, outmax):
@@ -83,10 +85,35 @@ def arm(args, state):
         fault(ex)
 
     if not ret.success:
-        rospy.loginfo("Request failed.")
+        rospy.loginfo("ARM Request failed.")
     else:
-        rospy.loginfo("Request success.")
+        rospy.loginfo("ARM Request success.")
 
+def takeoff(args):
+    try:
+        takeoff_cl = rospy.ServiceProxy(args.mavros_ns + "/cmd/takeoff", CommandTOL)
+        
+        ret = takeoff_cl(altitude=2, latitude=0, longitude=0, min_pitch=0, yaw=0)
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("TAKEOFF Request failed.")
+    else:
+        rospy.loginfo("TAKEOFF Request success.")
+
+def set_mode(args, mode):
+    try:
+        setmode_cl = rospy.ServiceProxy(args.mavros_ns + "/set_mode", SetMode)
+        
+        ret = setmode_cl(base_mode=0, custom_mode="ALT_HOLD")
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+    if not ret.success:
+        rospy.loginfo("SET MODE Request failed.")
+    else:
+        rospy.loginfo("SET MODE Request success.")
 
 def load_map(m, n):
     for k, v in m.iteritems():
@@ -109,7 +136,7 @@ def rc_override_control(args):
     for k, v in rc_channels.iteritems():
         v.load_param()
 
-    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override", OverrideRCIn, queue_size=10)
+    override_pub = rospy.Publisher(args.mavros_ns + "/rc/override_joy", OverrideRCIn, queue_size=10)
 
     def joy_cb(joy):
         # get axes normalized to -1.0..+1.0 RPY, 0.0..1.0 T
@@ -131,6 +158,10 @@ def rc_override_control(args):
             arm(args, True)
         elif get_buttons(joy,'disarm') == 1:
             arm(args, False)
+        elif get_buttons(joy,'takeoff') == 1:
+	    takeoff(args)
+	elif get_buttons(joy,'land') == 1:
+            set_mode(args, "ALT_HOLD")
 
         set_chan('roll', roll)
         set_chan('pitch', pitch)
@@ -151,10 +182,10 @@ def attitude_setpoint_control(args):
     load_map(axes_scale, '~axes_scale/')
     load_map(button_map, '~button_map/')
 
-    att_pub = rospy.Publisher(args.mavros_ns + "/setpoint/attitude", PoseStamped, queue_size=10)
-    thd_pub = rospy.Publisher(args.mavros_ns + "/setpoint/att_throttle", Float64, queue_size=10)
+    att_pub = rospy.Publisher(args.mavros_ns + "/setpoint_attitude/attitude", PoseStamped, queue_size=10)
+    thd_pub = rospy.Publisher(args.mavros_ns + "/setpoint_attitude/att_throttle", Float64, queue_size=10)
 
-    if rospy.get_param(args.mavros_ns + "/setpoint/attitude/reverse_throttle", False):
+    if rospy.get_param(args.mavros_ns + "/setpoint_attitude/attitude/reverse_throttle", False):
         def thd_normalize(v):
             return v
     else:
@@ -196,7 +227,7 @@ def velocity_setpoint_control(args):
     load_map(axes_scale, '~axes_scale/')
     load_map(button_map, '~button_map/')
 
-    vel_pub = rospy.Publisher(args.mavros_ns + "/setpoint/cmd_vel", TwistStamped, queue_size=10)
+    vel_pub = rospy.Publisher(args.mavros_ns + "/setpoint_velocity/cmd_vel", TwistStamped, queue_size=10)
 
     def joy_cb(joy):
         # get axes normalized to -1.0..+1.0 RPYT
@@ -206,6 +237,11 @@ def velocity_setpoint_control(args):
         throttle = get_axis(joy, 'throttle')
 
         rospy.logdebug("RPYT: %f, %f, %f, %f", roll, pitch, yaw, throttle)
+        
+        if get_buttons(joy,'arm') == 1:
+            arm(args, True)
+        elif get_buttons(joy,'disarm') == 1:
+            arm(args, False)
 
         # Based on QGC UAS joystickinput_settargets branch
         # not shure that it really need inegrating, as it done in QGC.
@@ -230,7 +266,7 @@ def position_setpoint_control(args):
     load_map(axes_scale, '~axes_scale/')
     load_map(button_map, '~button_map/')
 
-    pos_pub = rospy.Publisher(args.mavros_ns + "/setpoint/local_position", PoseStamped, queue_size=10)
+    pos_pub = rospy.Publisher(args.mavros_ns + "/setpoint_position/local", PoseStamped, queue_size=10)
 
     def joy_cb(joy):
         global px, py, pz
@@ -239,6 +275,11 @@ def position_setpoint_control(args):
         pitch = get_axis(joy, 'pitch')
         yaw = get_axis(joy, 'yaw')
         throttle = get_axis(joy, 'throttle')
+        
+        if get_buttons(joy,'arm') == 1:
+            arm(args, True)
+        elif get_buttons(joy,'disarm') == 1:
+            arm(args, False)
 
         # TODO: need integrate by time, joy_cb() called with variable frequency
         px -= pitch


### PR DESCRIPTION
Hi, 

By using Aurelian Roy's helper scripts to setup Gazebo SITL/ROS, I've been experiencing issues to compile the workspace. 

Link: 
https://github.com/AurelienRoy/ardupilot_sitl_ros_tutorial/tree/master/scripts

What I did: 

(src has been initialised)
wstool set -t src mavros --git https://github.com/alexbuyval/mavros.git
wstool update -t src

The issue is in step 5, when catkin_make. 

OS: Ubuntu 14.04.3 LTS 

The same error will occur if I compile mavros from other sources such as: 
git clone https://github.com/mavlink/mavros.git
git clone https://github.com/erlerobot/mavros.git


I have tried installing the whole OS again from scratch for 2 times but the same error occur. 

Please advice. 

Error Message : 
```
Scanning dependencies of target mavconn
[  4%] Building CXX object mavros/libmavconn/CMakeFiles/mavconn.dir/src/mavlink_helpers.cpp.o
[  4%] Building CXX object mavros/libmavconn/CMakeFiles/mavconn.dir/src/interface.cpp.o
/home/karkin96/catkin_ws/src/mavros/libmavconn/src/interface.cpp: In member function ‘mavconn::MsgBuffer* mavconn::MAVConnInterface::new_msgbuffer(const mavlink_message_t*, uint8_t, uint8_t)’:
/home/karkin96/catkin_ws/src/mavros/libmavconn/src/interface.cpp:89:28: error: too few arguments to function ‘uint16_t mavlink_finalize_message_chan(mavlink_message_t*, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)’
     mavlink_crcs[msg.msgid]);
                            ^
In file included from /opt/ros/indigo/include/mavlink/v1.0/ardupilotmega/../protocol.h:85:0,
                 from /opt/ros/indigo/include/mavlink/v1.0/ardupilotmega/ardupilotmega.h:30,
                 from /opt/ros/indigo/include/mavlink/v1.0/ardupilotmega/mavlink.h:33,
                 from /home/karkin96/catkin_ws/src/mavros/libmavconn/include/mavconn/mavlink_dialect.h:56,
                 from /home/karkin96/catkin_ws/src/mavros/libmavconn/include/mavconn/interface.h:38,
                 from /home/karkin96/catkin_ws/src/mavros/libmavconn/src/interface.cpp:22:
/opt/ros/indigo/include/mavlink/v1.0/ardupilotmega/../mavlink_helpers.h:68:25: note: declared here
 MAVLINK_HELPER uint16_t mavlink_finalize_message_chan(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id, 
                         ^
make[2]: *** [mavros/libmavconn/CMakeFiles/mavconn.dir/src/interface.cpp.o] Error 1
make[1]: *** [mavros/libmavconn/CMakeFiles/mavconn.dir/all] Error 2
make: *** [all] Error 2
Invoking "make" failed
```



Rospack List: 


actionlib /opt/ros/indigo/share/actionlib
actionlib_msgs /opt/ros/indigo/share/actionlib_msgs
actionlib_tutorials /opt/ros/indigo/share/actionlib_tutorials
angles /opt/ros/indigo/share/angles
arducopter_sitl_ros /home/karkin96/catkin_ws/src/arducopter_sitl_ros
bond /opt/ros/indigo/share/bond
bondcpp /opt/ros/indigo/share/bondcpp
bondpy /opt/ros/indigo/share/bondpy
camera_calibration /opt/ros/indigo/share/camera_calibration
camera_calibration_parsers /opt/ros/indigo/share/camera_calibration_parsers
camera_info_manager /opt/ros/indigo/share/camera_info_manager
catkin /opt/ros/indigo/share/catkin
catkin_simple /home/karkin96/catkin_ws/src/catkin_simple
class_loader /opt/ros/indigo/share/class_loader
cmake_modules /opt/ros/indigo/share/cmake_modules
collada_parser /opt/ros/indigo/share/collada_parser
collada_urdf /opt/ros/indigo/share/collada_urdf
compressed_depth_image_transport /opt/ros/indigo/share/compressed_depth_image_transport
compressed_image_transport /opt/ros/indigo/share/compressed_image_transport
control_msgs /opt/ros/indigo/share/control_msgs
cpp_common /opt/ros/indigo/share/cpp_common
cv_bridge /opt/ros/indigo/share/cv_bridge
depth_image_proc /opt/ros/indigo/share/depth_image_proc
diagnostic_aggregator /opt/ros/indigo/share/diagnostic_aggregator
diagnostic_analysis /opt/ros/indigo/share/diagnostic_analysis
diagnostic_common_diagnostics /opt/ros/indigo/share/diagnostic_common_diagnostics
diagnostic_msgs /opt/ros/indigo/share/diagnostic_msgs
diagnostic_updater /opt/ros/indigo/share/diagnostic_updater
driver_base /opt/ros/indigo/share/driver_base
dynamic_reconfigure /opt/ros/indigo/share/dynamic_reconfigure
eigen_conversions /opt/ros/indigo/share/eigen_conversions
eigen_stl_containers /opt/ros/indigo/share/eigen_stl_containers
filters /opt/ros/indigo/share/filters
gazebo_msgs /opt/ros/indigo/share/gazebo_msgs
gazebo_plugins /opt/ros/indigo/share/gazebo_plugins
gazebo_ros /opt/ros/indigo/share/gazebo_ros
gencpp /opt/ros/indigo/share/gencpp
genlisp /opt/ros/indigo/share/genlisp
genmsg /opt/ros/indigo/share/genmsg
genpy /opt/ros/indigo/share/genpy
geodesy /opt/ros/indigo/share/geodesy
geographic_msgs /opt/ros/indigo/share/geographic_msgs
geometric_shapes /opt/ros/indigo/share/geometric_shapes
geometry_msgs /opt/ros/indigo/share/geometry_msgs
gl_dependency /opt/ros/indigo/share/gl_dependency
glog_catkin /home/karkin96/catkin_ws/src/glog_catkin
image_geometry /opt/ros/indigo/share/image_geometry
image_proc /opt/ros/indigo/share/image_proc
image_rotate /opt/ros/indigo/share/image_rotate
image_transport /opt/ros/indigo/share/image_transport
image_view /opt/ros/indigo/share/image_view
interactive_marker_tutorials /opt/ros/indigo/share/interactive_marker_tutorials
interactive_markers /opt/ros/indigo/share/interactive_markers
joint_state_publisher /opt/ros/indigo/share/joint_state_publisher
joy /opt/ros/indigo/share/joy
kdl_conversions /opt/ros/indigo/share/kdl_conversions
kdl_parser /opt/ros/indigo/share/kdl_parser
laser_assembler /opt/ros/indigo/share/laser_assembler
laser_filters /opt/ros/indigo/share/laser_filters
laser_geometry /opt/ros/indigo/share/laser_geometry
libmavconn /home/karkin96/catkin_ws/src/mavros/libmavconn
librviz_tutorial /opt/ros/indigo/share/librviz_tutorial
map_msgs /opt/ros/indigo/share/map_msgs
mav_msgs /home/karkin96/catkin_ws/src/mav_comm/mav_msgs
mavlink /opt/ros/indigo/share/mavlink
mavros /home/karkin96/catkin_ws/src/mavros/mavros
mavros_extras /home/karkin96/catkin_ws/src/mavros/mavros_extras
mavros_msgs /opt/ros/indigo/share/mavros_msgs
media_export /opt/ros/indigo/share/media_export
message_filters /opt/ros/indigo/share/message_filters
message_generation /opt/ros/indigo/share/message_generation
message_runtime /opt/ros/indigo/share/message_runtime
mk /opt/ros/indigo/share/mk
nav_msgs /opt/ros/indigo/share/nav_msgs
nodelet /opt/ros/indigo/share/nodelet
nodelet_topic_tools /opt/ros/indigo/share/nodelet_topic_tools
nodelet_tutorial_math /opt/ros/indigo/share/nodelet_tutorial_math
octomap /opt/ros/indigo/share/octomap
octomap_msgs /opt/ros/indigo/share/octomap_msgs
octomap_ros /opt/ros/indigo/share/octomap_ros
orocos_kdl /opt/ros/indigo/share/orocos_kdl
pcl_conversions /opt/ros/indigo/share/pcl_conversions
pcl_msgs /opt/ros/indigo/share/pcl_msgs
pcl_ros /opt/ros/indigo/share/pcl_ros
planning_msgs /home/karkin96/catkin_ws/src/mav_comm/planning_msgs
pluginlib /opt/ros/indigo/share/pluginlib
pluginlib_tutorials /opt/ros/indigo/share/pluginlib_tutorials
pointcloud_to_laserscan /opt/ros/indigo/share/pointcloud_to_laserscan
polled_camera /opt/ros/indigo/share/polled_camera
pr2_description /opt/ros/indigo/share/pr2_description
python_orocos_kdl /opt/ros/indigo/share/python_orocos_kdl
python_qt_binding /opt/ros/indigo/share/python_qt_binding
qt_dotgraph /opt/ros/indigo/share/qt_dotgraph
qt_gui /opt/ros/indigo/share/qt_gui
qt_gui_cpp /opt/ros/indigo/share/qt_gui_cpp
qt_gui_py_common /opt/ros/indigo/share/qt_gui_py_common
qwt_dependency /opt/ros/indigo/share/qwt_dependency
random_numbers /opt/ros/indigo/share/random_numbers
resource_retriever /opt/ros/indigo/share/resource_retriever
robot_state_publisher /opt/ros/indigo/share/robot_state_publisher
rosbag /opt/ros/indigo/share/rosbag
rosbag_migration_rule /opt/ros/indigo/share/rosbag_migration_rule
rosbag_storage /opt/ros/indigo/share/rosbag_storage
rosbash /opt/ros/indigo/share/rosbash
rosboost_cfg /opt/ros/indigo/share/rosboost_cfg
rosbuild /opt/ros/indigo/share/rosbuild
rosclean /opt/ros/indigo/share/rosclean
rosconsole /opt/ros/indigo/share/rosconsole
rosconsole_bridge /opt/ros/indigo/share/rosconsole_bridge
roscpp /opt/ros/indigo/share/roscpp
roscpp_serialization /opt/ros/indigo/share/roscpp_serialization
roscpp_traits /opt/ros/indigo/share/roscpp_traits
roscpp_tutorials /opt/ros/indigo/share/roscpp_tutorials
roscreate /opt/ros/indigo/share/roscreate
rosgraph /opt/ros/indigo/share/rosgraph
rosgraph_msgs /opt/ros/indigo/share/rosgraph_msgs
roslang /opt/ros/indigo/share/roslang
roslaunch /opt/ros/indigo/share/roslaunch
roslib /opt/ros/indigo/share/roslib
roslint /opt/ros/indigo/share/roslint
roslisp /opt/ros/indigo/share/roslisp
roslz4 /opt/ros/indigo/share/roslz4
rosmake /opt/ros/indigo/share/rosmake
rosmaster /opt/ros/indigo/share/rosmaster
rosmsg /opt/ros/indigo/share/rosmsg
rosnode /opt/ros/indigo/share/rosnode
rosout /opt/ros/indigo/share/rosout
rospack /opt/ros/indigo/share/rospack
rosparam /opt/ros/indigo/share/rosparam
rospy /opt/ros/indigo/share/rospy
rospy_tutorials /opt/ros/indigo/share/rospy_tutorials
rosservice /opt/ros/indigo/share/rosservice
rostest /opt/ros/indigo/share/rostest
rostime /opt/ros/indigo/share/rostime
rostopic /opt/ros/indigo/share/rostopic
rosunit /opt/ros/indigo/share/rosunit
roswtf /opt/ros/indigo/share/roswtf
rotors_control /home/karkin96/catkin_ws/src/rotors_simulator/rotors_control
rotors_description /home/karkin96/catkin_ws/src/rotors_simulator/rotors_description
rotors_gazebo /home/karkin96/catkin_ws/src/rotors_simulator/rotors_gazebo
rotors_gazebo_plugins /home/karkin96/catkin_ws/src/rotors_simulator/rotors_gazebo_plugins
rotors_joy_interface /home/karkin96/catkin_ws/src/rotors_simulator/rotors_joy_interface
rotors_model /home/karkin96/catkin_ws/src/rotors_simulator/rotors_model
rqt_action /opt/ros/indigo/share/rqt_action
rqt_bag /opt/ros/indigo/share/rqt_bag
rqt_bag_plugins /opt/ros/indigo/share/rqt_bag_plugins
rqt_console /opt/ros/indigo/share/rqt_console
rqt_dep /opt/ros/indigo/share/rqt_dep
rqt_graph /opt/ros/indigo/share/rqt_graph
rqt_gui /opt/ros/indigo/share/rqt_gui
rqt_gui_cpp /opt/ros/indigo/share/rqt_gui_cpp
rqt_gui_py /opt/ros/indigo/share/rqt_gui_py
rqt_image_view /opt/ros/indigo/share/rqt_image_view
rqt_launch /opt/ros/indigo/share/rqt_launch
rqt_logger_level /opt/ros/indigo/share/rqt_logger_level
rqt_moveit /opt/ros/indigo/share/rqt_moveit
rqt_msg /opt/ros/indigo/share/rqt_msg
rqt_nav_view /opt/ros/indigo/share/rqt_nav_view
rqt_plot /opt/ros/indigo/share/rqt_plot
rqt_pose_view /opt/ros/indigo/share/rqt_pose_view
rqt_publisher /opt/ros/indigo/share/rqt_publisher
rqt_py_common /opt/ros/indigo/share/rqt_py_common
rqt_py_console /opt/ros/indigo/share/rqt_py_console
rqt_reconfigure /opt/ros/indigo/share/rqt_reconfigure
rqt_robot_dashboard /opt/ros/indigo/share/rqt_robot_dashboard
rqt_robot_monitor /opt/ros/indigo/share/rqt_robot_monitor
rqt_robot_steering /opt/ros/indigo/share/rqt_robot_steering
rqt_runtime_monitor /opt/ros/indigo/share/rqt_runtime_monitor
rqt_rviz /opt/ros/indigo/share/rqt_rviz
rqt_service_caller /opt/ros/indigo/share/rqt_service_caller
rqt_shell /opt/ros/indigo/share/rqt_shell
rqt_srv /opt/ros/indigo/share/rqt_srv
rqt_tf_tree /opt/ros/indigo/share/rqt_tf_tree
rqt_top /opt/ros/indigo/share/rqt_top
rqt_topic /opt/ros/indigo/share/rqt_topic
rqt_web /opt/ros/indigo/share/rqt_web
rviz /opt/ros/indigo/share/rviz
rviz_plugin_tutorials /opt/ros/indigo/share/rviz_plugin_tutorials
rviz_python_tutorial /opt/ros/indigo/share/rviz_python_tutorial
self_test /opt/ros/indigo/share/self_test
sensor_msgs /opt/ros/indigo/share/sensor_msgs
shape_msgs /opt/ros/indigo/share/shape_msgs
smach /opt/ros/indigo/share/smach
smach_msgs /opt/ros/indigo/share/smach_msgs
smach_ros /opt/ros/indigo/share/smach_ros
smclib /opt/ros/indigo/share/smclib
stage /opt/ros/indigo/share/stage
stage_ros /opt/ros/indigo/share/stage_ros
std_msgs /opt/ros/indigo/share/std_msgs
std_srvs /opt/ros/indigo/share/std_srvs
stereo_image_proc /opt/ros/indigo/share/stereo_image_proc
stereo_msgs /opt/ros/indigo/share/stereo_msgs
test_mavros /home/karkin96/catkin_ws/src/mavros/test_mavros
tf /opt/ros/indigo/share/tf
tf2 /opt/ros/indigo/share/tf2
tf2_geometry_msgs /opt/ros/indigo/share/tf2_geometry_msgs
tf2_kdl /opt/ros/indigo/share/tf2_kdl
tf2_msgs /opt/ros/indigo/share/tf2_msgs
tf2_py /opt/ros/indigo/share/tf2_py
tf2_ros /opt/ros/indigo/share/tf2_ros
tf2_sensor_msgs /opt/ros/indigo/share/tf2_sensor_msgs
tf_conversions /opt/ros/indigo/share/tf_conversions
theora_image_transport /opt/ros/indigo/share/theora_image_transport
topic_tools /opt/ros/indigo/share/topic_tools
trajectory_msgs /opt/ros/indigo/share/trajectory_msgs
turtle_actionlib /opt/ros/indigo/share/turtle_actionlib
turtle_tf /opt/ros/indigo/share/turtle_tf
turtle_tf2 /opt/ros/indigo/share/turtle_tf2
turtlesim /opt/ros/indigo/share/turtlesim
unique_id /opt/ros/indigo/share/unique_id
urdf /opt/ros/indigo/share/urdf
urdf_parser_plugin /opt/ros/indigo/share/urdf_parser_plugin
urdf_tutorial /opt/ros/indigo/share/urdf_tutorial
uuid_msgs /opt/ros/indigo/share/uuid_msgs
visualization_marker_tutorials /opt/ros/indigo/share/visualization_marker_tutorials
visualization_msgs /opt/ros/indigo/share/visualization_msgs
xacro /opt/ros/indigo/share/xacro
xmlrpcpp /opt/ros/indigo/share/xmlrpcpp