### PR TITLE
Vision plugin fixes, Camera trigger fixes

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -365,7 +365,7 @@ private:
 		return send_command_long_and_wait(false,
 				enum_value(MAV_CMD::DO_TRIGGER_CONTROL), 1,
 				(req.trigger_enable)? 1.0 : 0.0,
-				req.integration_time,
+				req.cycle_time,
 				0, 0, 0, 0, 0,
 				res.success, res.result);
 	}

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -125,7 +125,8 @@ private:
 
 		auto position = ftf::transform_frame_enu_ned(Eigen::Vector3d(tr.translation()));
 		auto rpy = ftf::quaternion_to_rpy(
-				ftf::transform_orientation_enu_ned(Eigen::Quaterniond(tr.rotation())));
+				ftf::transform_orientation_enu_ned(
+				ftf::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation()))));
 
 		vision_position_estimate(stamp.toNSec() / 1000, position, rpy);
 	}

--- a/mavros_msgs/srv/CommandTriggerControl.srv
+++ b/mavros_msgs/srv/CommandTriggerControl.srv
@@ -1,7 +1,7 @@
 # Type for controlling onboard camera trigerring system
 
 bool    trigger_enable		# Trigger on/off control
-float32 integration_time	# Shutter integration time. Zero to use current onboard value.
+float32 cycle_time		# Camera trigger cycle time. Zero to use current onboard value.
 ---
 bool success
 uint8 result


### PR DESCRIPTION
1. Fixes a long-term bug in the vision plugin. Yaw between ENU and NED will now be rotated correctly. This was already done correctly in the `mocap` plugin (https://github.com/mavlink/mavros/blob/master/mavros_extras/src/plugins/mocap_pose_estimate.cpp#L117), but we were missing it in `vision_pose`.

2. Minor renaming in camera trigger interface to match PX4 naming conventions.

@vooon Please review and merge. These have been tested extensively both in PX4 SITL (with laser-scan odometry) and on hardware.