### PR TITLE
README: add link to ArduPilot gitter chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please ask your questions not related to bugs/feauture or requests on:
 - [px4users Google Group (Mailing List) ](https://groups.google.com/forum/#!forum/px4users)
 - [Mavros on Gitter IM](https://gitter.im/mavlink/mavros)
 - [PX4/Firmware on Gitter IM](https://gitter.im/PX4/Firmware)
+- [ArduPilot/VisionProjects on Gitter IM](https://gitter.im/ArduPilot/ardupilot/VisionProjects)
 
 We'd like to keep the project bugtracker as free as possible, so please contact via the above methods. You can also PM us via Gitter.
 


### PR DESCRIPTION
Add link to help mavros with ArduPilot users find help.