### PR TITLE
launch: remove setpoint-attitude from apm blacklist

### DIFF
--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -3,7 +3,6 @@ plugin_blacklist:
 - actuator_control
 - ftp
 - safety_area
-- setpoint_attitude
 # extras
 - image_pub
 - 'mocap_*'


### PR DESCRIPTION
Ardupilot supports the SET_ATTITUDE_TARGET mavlink message so the setpoint-attitude should be removed from the blacklist.  This has been tested by a user.
