### PR TITLE
Add reasonable local_position default covariance and use tf2 for odom

### DIFF
--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -117,15 +117,19 @@ private:
 		odom->pose.pose = pose->pose;
 		for (int i=0; i< 3; i++) {
 			// linear velocity
-			odom->twist.covariance[i + 6*i] = 0.0001;
+			odom->twist.covariance[i + 6*i] = 1;
 			// angular velocity
-			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 0.0001;
+			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1;
 			// position/ attitude
 			if (i==2) {
+				// z
 				odom->pose.covariance[i + 6*i] = 1000;
+				// yaw
 				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1000;
 			} else {
+				// x, y
 				odom->pose.covariance[i + 6*i] = 1000;
+				// roll, pitch
 				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1000;
 			}
 		}

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -117,16 +117,16 @@ private:
 		odom->pose.pose = pose->pose;
 		for (int i=0; i< 3; i++) {
 			// linear velocity
-			odom->twist.covariance[i + 6*i] = 1e-4;
+			odom->twist.covariance[i + 6*i] = 1e-6;
 			// angular velocity
-			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-4;
+			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
 			// position/ attitude
 			if (i==2) {
-				odom->pose.covariance[i + 6*i] = 1e-4;
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-4;
+				odom->pose.covariance[i + 6*i] = 1;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
 			} else {
-				odom->pose.covariance[i + 6*i] = 1e-4;
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-4;
+				odom->pose.covariance[i + 6*i] = 1e-6;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
 			}
 		}
 

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -117,16 +117,16 @@ private:
 		odom->pose.pose = pose->pose;
 		for (int i=0; i< 3; i++) {
 			// linear velocity
-			odom->twist.covariance[i + 6*i] = 1e-6;
+			odom->twist.covariance[i + 6*i] = 1e-4;
 			// angular velocity
-			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-4;
 			// position/ attitude
 			if (i==2) {
-				odom->pose.covariance[i + 6*i] = 1;
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+				odom->pose.covariance[i + 6*i] = 1e-4;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-4;
 			} else {
-				odom->pose.covariance[i + 6*i] = 1e-6;
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+				odom->pose.covariance[i + 6*i] = 1e-4;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-4;
 			}
 		}
 

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -117,16 +117,16 @@ private:
 		odom->pose.pose = pose->pose;
 		for (int i=0; i< 3; i++) {
 			// linear velocity
-			odom->twist.covariance[i + 6*i] = 1e-6;
+			odom->twist.covariance[i + 6*i] = 0.0001;
 			// angular velocity
-			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 0.0001;
 			// position/ attitude
 			if (i==2) {
-				odom->pose.covariance[i + 6*i] = 1;
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+				odom->pose.covariance[i + 6*i] = 1000;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1000;
 			} else {
-				odom->pose.covariance[i + 6*i] = 1e-6;
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+				odom->pose.covariance[i + 6*i] = 1000;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1000;
 			}
 		}
 

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -113,7 +113,22 @@ private:
 		odom->child_frame_id = tf_child_frame_id;
 		tf::vectorEigenToMsg(baselink_linear, odom->twist.twist.linear);
 		odom->twist.twist.angular = baselink_angular_msg;
+		// reasonable defaults for covariance
 		odom->pose.pose = pose->pose;
+		for (int i=0; i< 3; i++) {
+			// linear velocity
+			odom->twist.covariance[i + 6*i] = 1e-6;
+			// angular velocity
+			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+			// position/ attitude
+			if (i==2) {
+				odom->pose.covariance[i + 6*i] = 1;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+			} else {
+				odom->pose.covariance[i + 6*i] = 1e-6;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
+			}
+		}
 
 		//--------------- Publish Data ---------------//
 		local_odom.publish(odom);

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -117,20 +117,20 @@ private:
 		odom->pose.pose = pose->pose;
 		for (int i=0; i< 3; i++) {
 			// linear velocity
-			odom->twist.covariance[i + 6*i] = 1;
+			odom->twist.covariance[i + 6*i] = 1e-6;
 			// angular velocity
-			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1;
+			odom->twist.covariance[(i + 3) + 6*(i + 3)] = 1e-6;
 			// position/ attitude
 			if (i==2) {
 				// z
-				odom->pose.covariance[i + 6*i] = 1000;
+				odom->pose.covariance[i + 6*i] = 1e4;
 				// yaw
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1000;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e4;
 			} else {
 				// x, y
-				odom->pose.covariance[i + 6*i] = 1000;
+				odom->pose.covariance[i + 6*i] = 1e4;
 				// roll, pitch
-				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1000;
+				odom->pose.covariance[(i + 3) + 6*(i + 3)] = 1e4;
 			}
 		}
 


### PR DESCRIPTION
This uses tf2 for the odom plugin and listens to the passed child_frame_id and frame_id fields. It also adds reasonable defaults for local_position default covariance.