### PR TITLE
Proposing fix to Eigen::Vector3d UAS::quaternion_to_rpy(const Eigen::Quaterniond &q). New implementation works in the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].

### DIFF
--- a/mavros/src/lib/uas_quaternion_utils.cpp
+++ b/mavros/src/lib/uas_quaternion_utils.cpp
@@ -34,27 +34,27 @@ Eigen::Quaterniond UAS::quaternion_from_rpy(const Eigen::Vector3d &rpy)
 
 Eigen::Vector3d UAS::quaternion_to_rpy(const Eigen::Quaterniond &q)
 {
-    // Following the example of Vladimir Ermakov, I use the equations from this wikipedia article
-    // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-		// This function is injective for the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].
-    // Note that the Eigen implementation is not good for YPR, because of the output range, which would be:
-		//   	[code using Eigen EulerAngles] rpy = q.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
-    //    [in docs    Eigen EulerAngles] valid range of EulerAngles: yaw, pitch, roll in the ranges [0:pi]x[-pi:pi]x[-pi:pi]
-		//    see: https://eigen.tuxfamily.org/dox/group__Geometry__Module.html#gac3d90b12b21e1aaa2a9de9b0e45e6b7c
+	// Following the example of Vladimir Ermakov, I use the equations from this wikipedia article
+	// https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+	// This function is injective for the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].
+	// Note that the Eigen implementation is not good for YPR, because of the output range, which would be:
+	//      [code using Eigen EulerAngles] rpy = q.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+	//    [in docs    Eigen EulerAngles] valid range of EulerAngles: yaw, pitch, roll in the ranges [0:pi]x[-pi:pi]x[-pi:pi]
+	//    see: https://eigen.tuxfamily.org/dox/group__Geometry__Module.html#gac3d90b12b21e1aaa2a9de9b0e45e6b7c
 
-    const double &qw = q.w();
-    const double &qx = q.x();
-    const double &qy = q.y();
-    const double &qz = q.z();
+	const double &qw = q.w();
+	const double &qx = q.x();
+	const double &qy = q.y();
+	const double &qz = q.z();
 
-    Eigen::Vector3d rpy;
-    /* roll  */ rpy.x() = std::atan2(2. * (qw*qx + qy*qz), 1. - 2. * (qx*qx + qy*qy));
-    double sin_pitch = 2. * (qw*qy - qz*qx);
-    sin_pitch = sin_pitch >  1.0 ?  1.0 : sin_pitch;
-    sin_pitch = sin_pitch < -1.0 ? -1.0 : sin_pitch;
-    /* pitch */ rpy.y() = std::asin( sin_pitch  );
-    /* yaw   */ rpy.z() = std::atan2(2. * (qw*qz + qx*qy), 1. - 2. * (qy*qy + qz*qz));
-    return rpy;
+	Eigen::Vector3d rpy;
+	/* roll  */ rpy.x() = std::atan2(2. * (qw * qx + qy * qz), 1. - 2. * (qx * qx + qy * qy));
+	double sin_pitch = 2. * (qw * qy - qz * qx);
+	sin_pitch = sin_pitch >  1.0 ?  1.0 : sin_pitch;
+	sin_pitch = sin_pitch < -1.0 ? -1.0 : sin_pitch;
+	/* pitch */ rpy.y() = std::asin( sin_pitch  );
+	/* yaw   */ rpy.z() = std::atan2(2. * (qw * qz + qx * qy), 1. - 2. * (qy * qy + qz * qz));
+	return rpy;
 }
 
 double UAS::quaternion_get_yaw(const Eigen::Quaterniond &q)

--- a/mavros/src/lib/uas_quaternion_utils.cpp
+++ b/mavros/src/lib/uas_quaternion_utils.cpp
@@ -34,8 +34,27 @@ Eigen::Quaterniond UAS::quaternion_from_rpy(const Eigen::Vector3d &rpy)
 
 Eigen::Vector3d UAS::quaternion_to_rpy(const Eigen::Quaterniond &q)
 {
-	// YPR - ZYX
-	return q.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    // Following the example of Vladimir Ermakov, I use the equations from this wikipedia article
+    // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+		// This function is injective for the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].
+    // Note that the Eigen implementation is not good for YPR, because of the output range, which would be:
+		//   	[code using Eigen EulerAngles] rpy = q.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+    //    [in docs    Eigen EulerAngles] valid range of EulerAngles: yaw, pitch, roll in the ranges [0:pi]x[-pi:pi]x[-pi:pi]
+		//    see: https://eigen.tuxfamily.org/dox/group__Geometry__Module.html#gac3d90b12b21e1aaa2a9de9b0e45e6b7c
+
+    const double &qw = q.w();
+    const double &qx = q.x();
+    const double &qy = q.y();
+    const double &qz = q.z();
+
+    Eigen::Vector3d rpy;
+    /* roll  */ rpy.x() = std::atan2(2. * (qw*qx + qy*qz), 1. - 2. * (qx*qx + qy*qy));
+    double sin_pitch = 2. * (qw*qy - qz*qx);
+    sin_pitch = sin_pitch >  1.0 ?  1.0 : sin_pitch;
+    sin_pitch = sin_pitch < -1.0 ? -1.0 : sin_pitch;
+    /* pitch */ rpy.y() = std::asin( sin_pitch  );
+    /* yaw   */ rpy.z() = std::atan2(2. * (qw*qz + qx*qy), 1. - 2. * (qy*qy + qz*qz));
+    return rpy;
 }
 
 double UAS::quaternion_get_yaw(const Eigen::Quaterniond &q)

--- a/mavros/test/test_quaternion_utils.cpp
+++ b/mavros/test/test_quaternion_utils.cpp
@@ -53,13 +53,44 @@ TEST(UAS, quaternion_from_rpy__paranoic_check)
 
 TEST(UAS, quaternion_to_rpy__123)
 {
+	// This test should work in the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].
+	double r, p, y;
+	r =  1.;
+	p = -1.;
+	y =  M_PI - epsilon;
+
 	// this test only works on positive rpy: 0..pi
-	auto q = UAS::quaternion_from_rpy(1.0, 2.0, 3.0);
+	auto q = UAS::quaternion_from_rpy(r, p, y);
 	auto rpy = UAS::quaternion_to_rpy(q);
 
-	EXPECT_NEAR(1.0, rpy.x(), epsilon);
-	EXPECT_NEAR(2.0, rpy.y(), epsilon);
-	EXPECT_NEAR(3.0, rpy.z(), epsilon);
+	EXPECT_NEAR(r, rpy.x(), epsilon);
+	EXPECT_NEAR(p, rpy.y(), epsilon);
+	EXPECT_NEAR(y, rpy.z(), epsilon);
+}
+
+TEST(UAS, quaternion_to_rpy__full_yaw_range)
+{
+	// This test should work in the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].
+  double Yi = -M_PI + epsilon; // yaw_init
+	double Ye = +M_PI - epsilon; // yaw_end
+
+	int N = 10;
+	double step = (Ye - Yi)/(N-1);
+	double r, p, y;
+	r = +M_PI/3.;
+	p = -M_PI/3.;
+	for (int i=0; i<N; i++) {
+	  r = r * -1.;
+		p = p * -1.;
+		y = Yi + step * i;
+
+		auto q = UAS::quaternion_from_rpy(r,p,y);
+		auto rpy = UAS::quaternion_to_rpy(q);
+
+		EXPECT_NEAR(r, rpy.x(), epsilon);
+		EXPECT_NEAR(p, rpy.y(), epsilon);
+		EXPECT_NEAR(y, rpy.z(), epsilon);
+	}
 }
 
 TEST(UAS, quaternion_to_rpy__pm_pi)
@@ -68,13 +99,15 @@ TEST(UAS, quaternion_to_rpy__pm_pi)
 
 	// in degrees
 	const ssize_t min = -180;
-	const ssize_t max = 180;
-	const ssize_t step = 15;
+	const ssize_t max =  180;
+	const ssize_t min_P = -90 + epsilon;
+	const ssize_t max_P = +90;
+	const ssize_t step = 15 - epsilon;
 
 	const auto test_orientation = UAS::quaternion_from_rpy(1.0, 2.0, 3.0);
 
 	for (ssize_t roll = min; roll <= max; roll += step) {
-		for (ssize_t pitch = min; pitch <= max; pitch += step) {
+		for (ssize_t pitch = min_P; pitch <= max_P; pitch += step) {
 			for (ssize_t yaw = min; yaw <= max; yaw += step) {
 
 				Eigen::Vector3d expected_deg(roll, pitch, yaw);

--- a/mavros/test/test_quaternion_utils.cpp
+++ b/mavros/test/test_quaternion_utils.cpp
@@ -71,16 +71,16 @@ TEST(UAS, quaternion_to_rpy__123)
 TEST(UAS, quaternion_to_rpy__full_yaw_range)
 {
 	// This test should work in the range: yaw in [-pi,pi], pitch in [-pi/2,+pi/2] and roll in [-pi,+pi].
-  double Yi = -M_PI + epsilon; // yaw_init
-	double Ye = +M_PI - epsilon; // yaw_end
+	double Yi = -M_PI + epsilon;	// yaw_init
+	double Ye = +M_PI - epsilon;	// yaw_end
 
 	int N = 10;
-	double step = (Ye - Yi)/(N-1);
+	double step = (Ye - Yi) / (N - 1);
 	double r, p, y;
-	r = +M_PI/3.;
-	p = -M_PI/3.;
-	for (int i=0; i<N; i++) {
-	  r = r * -1.;
+	r = +M_PI / 3.;
+	p = -M_PI / 3.;
+	for (int i = 0; i < N; i++) {
+		r = r * -1.;
 		p = p * -1.;
 		y = Yi + step * i;
 


### PR DESCRIPTION
Pull request related to this issue (see explanation in the issue):
github issue https://github.com/mavlink/mavros/issues/444#issuecomment-291604800

Main modification to the function:
```
mavros/mavros/src/lib/uas_quaternion_utils.cpp
  Eigen::Vector3d UAS::quaternion_to_rpy(const Eigen::Quaterniond &q)
```

I have tested the new implementation with the test cases (only with minor modifications):
```
mavros/mavros/test/test_quaternion_utils.cpp
  TEST(UAS, quaternion_to_rpy__123)
  TEST(UAS, quaternion_to_rpy__full_yaw_range)
  TEST(UAS, quaternion_to_rpy__pm_pi)
```

I have added the changes so far only to the the indigo-devel branch, and tested them with: [Ubuntu 14.04], [ROS Indigo] and [mavros indigo-devel branch].

