### PR TITLE
Solving default frame consistency in config files

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -19,7 +19,7 @@ sys:
 
 # sys_time
 time:
-  time_ref_source: "base_link"  # time_reference source
+  time_ref_source: "fcu"  # time_reference source
   timesync_mode: NONE
   timesync_avg_alpha: 0.6 # timesync averaging factor
 
@@ -50,6 +50,7 @@ global_position:
   tf:
     send: false               # send TF?
     frame_id: "map"  # TF frame_id
+    global_frame_id: "earth"  # TF earth frame_id
     child_frame_id: "base_link" # TF child_frame_id
 
 # imu_pub

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -69,6 +69,7 @@ local_position:
     send: false
     frame_id: "map"
     child_frame_id: "base_link"
+    send_fcu: false
 
 # param
 # None, used for FCU params

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -44,12 +44,12 @@ cmd:
 
 # global_position
 global_position:
-  frame_id: "fcu"           # pose and fix frame_id
+  frame_id: "map"           # pose and fix frame_id
   rot_covariance: 99999.0   # covariance for attitude?
   use_relative_alt: true    # use relative altitude for local coordinates
   tf:
     send: false               # send TF?
-    frame_id: "local_origin"  # TF frame_id
+    frame_id: "map"  # TF frame_id
     child_frame_id: "fcu_utm" # TF child_frame_id
 
 # imu_pub
@@ -63,10 +63,10 @@ imu:
 
 # local_position
 local_position:
-  frame_id: "fcu"
+  frame_id: "map"
   tf:
     send: false
-    frame_id: "local_origin"
+    frame_id: "map"
     child_frame_id: "fcu"
 
 # param

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -169,7 +169,7 @@ fake_gps:
 # px4flow
 px4flow:
   frame_id: "px4flow"
-  ranger_fov: !degrees 0.0  # XXX TODO
+  ranger_fov: !degrees 6.8  # XXX TODO
   ranger_min_range: 0.3     # meters
   ranger_max_range: 5.0     # meters
 
@@ -188,6 +188,16 @@ vision_speed:
 # vibration
 vibration:
   frame_id: "vibration"
+
+copter_visualization:
+  fixed_frame_id: "map"
+  child_frame_id: "base_link"
+  marker_scale: 1.0
+  num_rotors: 4
+  arm_len: 0.22
+  body_width: 0.15
+  body_height: 0.10
+  max_track_size: 1000
 
 # adsb
 # None

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -19,7 +19,7 @@ sys:
 
 # sys_time
 time:
-  time_ref_source: "fcu"  # time_reference source
+  time_ref_source: "base_link"  # time_reference source
   timesync_mode: NONE
   timesync_avg_alpha: 0.6 # timesync averaging factor
 
@@ -50,11 +50,11 @@ global_position:
   tf:
     send: false               # send TF?
     frame_id: "map"  # TF frame_id
-    child_frame_id: "fcu" # TF child_frame_id
+    child_frame_id: "base_link" # TF child_frame_id
 
 # imu_pub
 imu:
-  frame_id: "fcu"
+  frame_id: "base_link"
   # need find actual values
   linear_acceleration_stdev: 0.0003
   angular_velocity_stdev: !degrees 0.02
@@ -67,7 +67,7 @@ local_position:
   tf:
     send: false
     frame_id: "map"
-    child_frame_id: "fcu"
+    child_frame_id: "base_link"
 
 # param
 # None, used for FCU params

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -50,7 +50,7 @@ global_position:
   tf:
     send: false               # send TF?
     frame_id: "map"  # TF frame_id
-    child_frame_id: "fcu_utm" # TF child_frame_id
+    child_frame_id: "fcu" # TF child_frame_id
 
 # imu_pub
 imu:

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -187,19 +187,12 @@ vision_speed:
 
 # vibration
 vibration:
-  frame_id: "vibration"
-
-copter_visualization:
-  fixed_frame_id: "map"
-  child_frame_id: "base_link"
-  marker_scale: 1.0
-  num_rotors: 4
-  arm_len: 0.22
-  body_width: 0.15
-  body_height: 0.10
-  max_track_size: 1000
+  frame_id: "base_link"
 
 # adsb
 # None
+
+odometry:
+  estimator_type: 3 # check enum MAV_ESTIMATOR_TYPE in <http://mavlink.org/messages/common>
 
 # vim:set ts=2 sw=2 et:

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -169,7 +169,7 @@ fake_gps:
 # px4flow
 px4flow:
   frame_id: "px4flow"
-  ranger_fov: !degrees 6.8  # XXX TODO
+  ranger_fov: !degrees 6.8  # 6.8 degreens at 5 meters, 31 degrees at 1 meter
   ranger_min_range: 0.3     # meters
   ranger_max_range: 5.0     # meters
 

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -200,7 +200,7 @@ vision_speed:
 
 # vibration
 vibration:
-  frame_id: "vibration"
+  frame_id: "base_link"
 
 # adsb
 # None
@@ -209,13 +209,4 @@ vibration:
 odometry:
   estimator_type: 3 # check enum MAV_ESTIMATOR_TYPE in <http://mavlink.org/messages/common>
 
-copter_visualization:
-  fixed_frame_id: "map"
-  child_frame_id: "base_link"
-  marker_scale: 1.0
-  num_rotors: 4
-  arm_len: 0.22
-  body_width: 0.15
-  body_height: 0.10
-  max_track_size: 1000
 # vim:set ts=2 sw=2 et:

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -171,6 +171,7 @@ fake_gps:
   satellites_visible: 5   # virtual number of visible satellites
   fix_type: 3             # type of GPS fix (default: 3D)
   tf:
+    listen: false
     send: false           # send TF?
     frame_id: "map"       # TF frame_id
     child_frame_id: "fix" # TF child_frame_id
@@ -181,7 +182,7 @@ fake_gps:
 # px4flow
 px4flow:
   frame_id: "px4flow"
-  ranger_fov: !degrees 0.0  # XXX TODO
+  ranger_fov: !degrees 6.8  # 6.8 degreens at 5 meters, 31 degrees at 1 meter
   ranger_min_range: 0.3     # meters
   ranger_max_range: 5.0     # meters
 
@@ -208,4 +209,13 @@ vibration:
 odometry:
   estimator_type: 3 # check enum MAV_ESTIMATOR_TYPE in <http://mavlink.org/messages/common>
 
+copter_visualization:
+  fixed_frame_id: "map"
+  child_frame_id: "base_link"
+  marker_scale: 1.0
+  num_rotors: 4
+  arm_len: 0.22
+  body_width: 0.15
+  body_height: 0.10
+  max_track_size: 1000
 # vim:set ts=2 sw=2 et:

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -19,7 +19,7 @@ sys:
 
 # sys_time
 time:
-  time_ref_source: "base_link"  # time_reference source
+  time_ref_source: "fcu"  # time_reference source
   timesync_mode: MAVLINK
   timesync_avg_alpha: 0.6 # timesync averaging factor
 

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -44,12 +44,12 @@ cmd:
 
 # global_position
 global_position:
-  frame_id: "fcu"           # pose and fix frame_id
+  frame_id: "map"           # pose and fix frame_id
   rot_covariance: 99999.0   # covariance for attitude?
   use_relative_alt: true    # use relative altitude for local coordinates
   tf:
     send: false               # send TF?
-    frame_id: "local_origin"  # TF frame_id
+    frame_id: "map"  # TF frame_id
     global_frame_id: "earth"  # TF earth frame_id
     child_frame_id: "fcu_utm" # TF child_frame_id
 
@@ -64,10 +64,10 @@ imu:
 
 # local_position
 local_position:
-  frame_id: "fcu"
+  frame_id: "map"
   tf:
     send: false
-    frame_id: "local_origin"
+    frame_id: "map"
     child_frame_id: "fcu"
     send_fcu: false
 

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -19,7 +19,7 @@ sys:
 
 # sys_time
 time:
-  time_ref_source: "fcu"  # time_reference source
+  time_ref_source: "base_link"  # time_reference source
   timesync_mode: MAVLINK
   timesync_avg_alpha: 0.6 # timesync averaging factor
 
@@ -51,11 +51,11 @@ global_position:
     send: false               # send TF?
     frame_id: "map"  # TF frame_id
     global_frame_id: "earth"  # TF earth frame_id
-    child_frame_id: "fcu" # TF child_frame_id
+    child_frame_id: "base_link" # TF child_frame_id
 
 # imu_pub
 imu:
-  frame_id: "fcu"
+  frame_id: "base_link"
   # need find actual values
   linear_acceleration_stdev: 0.0003
   angular_velocity_stdev: !degrees 0.02
@@ -68,7 +68,7 @@ local_position:
   tf:
     send: false
     frame_id: "map"
-    child_frame_id: "fcu"
+    child_frame_id: "base_link"
     send_fcu: false
 
 # param

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -51,7 +51,7 @@ global_position:
     send: false               # send TF?
     frame_id: "map"  # TF frame_id
     global_frame_id: "earth"  # TF earth frame_id
-    child_frame_id: "fcu_utm" # TF child_frame_id
+    child_frame_id: "fcu" # TF child_frame_id
 
 # imu_pub
 imu:

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -60,7 +60,7 @@ public:
 		gp_nh.param("rot_covariance", rot_cov, 99999.0);
 		gp_nh.param("use_relative_alt", use_relative_alt, true);
 		// tf subsection
-		gp_nh.param("tf/send", tf_send, true);
+		gp_nh.param("tf/send", tf_send, false);
 		gp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
 		gp_nh.param<std::string>("tf/global_frame_id", tf_global_frame_id, "earth");	// The global_origin should be represented as "earth" coordinate frame (ECEF) (REP 105)
 		gp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "base_link");

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -48,13 +48,13 @@ public:
 		lp_nh.param<std::string>("frame_id", frame_id, "map");
 		// Important tf subsection
 		// Report the transform from world to base_link here.
-		lp_nh.param("tf/send", tf_send, true);
+		lp_nh.param("tf/send", tf_send, false);
 		lp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
 		lp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "base_link");
 		// Debug tf info
 		// broadcast the following transform: (can be expanded to more if desired)
 		// NED -> aircraft
-		lp_nh.param("tf/send_fcu",tf_send_fcu,false);
+		lp_nh.param("tf/send_fcu", tf_send_fcu, false);
 
 		local_position = lp_nh.advertise<geometry_msgs::PoseStamped>("pose", 10);
 		local_velocity = lp_nh.advertise<geometry_msgs::TwistStamped>("velocity", 10);

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -428,8 +428,8 @@ public:
 		double conn_heartbeat_d;
 		double min_voltage;
 
-		nh.param("conn/timeout", conn_timeout_d, 30.0);
-		nh.param("sys/min_voltage", min_voltage, 6.0);
+		nh.param("conn/timeout", conn_timeout_d, 10.0);
+		nh.param("sys/min_voltage", min_voltage, 10.0);
 		nh.param("sys/disable_diag", disable_diag, false);
 
 		// rate parameter

--- a/mavros/src/plugins/waypoint.cpp
+++ b/mavros/src/plugins/waypoint.cpp
@@ -146,7 +146,7 @@ public:
 
 		wp_state = WP::IDLE;
 
-		wp_nh.param("pull_after_gcs", do_pull_after_gcs, false);
+		wp_nh.param("pull_after_gcs", do_pull_after_gcs, true);
 
 		wp_list_pub = wp_nh.advertise<mavros_msgs::WaypointList>("waypoints", 2, true);
 		pull_srv = wp_nh.advertiseService("pull", &WaypointPlugin::pull_cb, this);

--- a/mavros_extras/launch/px4flow_config.yaml
+++ b/mavros_extras/launch/px4flow_config.yaml
@@ -25,7 +25,7 @@ image:
 
 px4flow:
   frame_id: "px4flow"
-  ranger_fov: !degrees 0.0  # XXX TODO
+  ranger_fov: !degrees 6.8  # XXX TODO
   ranger_min_range: 0.3     # meters
   ranger_max_range: 5.0     # meters
 

--- a/mavros_extras/launch/px4flow_config.yaml
+++ b/mavros_extras/launch/px4flow_config.yaml
@@ -25,7 +25,7 @@ image:
 
 px4flow:
   frame_id: "px4flow"
-  ranger_fov: !degrees 6.8  # XXX TODO
+  ranger_fov: !degrees 6.8  # 6.8 degreens at 5 meters, 31 degrees at 1 meter
   ranger_min_range: 0.3     # meters
   ranger_max_range: 5.0     # meters
 

--- a/mavros_extras/src/copter_visualization.cpp
+++ b/mavros_extras/src/copter_visualization.cpp
@@ -206,11 +206,11 @@ int main(int argc, char *argv[])
 	int num_rotors;
 	double arm_len, body_width, body_height;
 
-	priv_nh.param<std::string>("fixed_frame_id", fixed_frame_id, "local_origin");
-	priv_nh.param<std::string>("child_frame_id", child_frame_id, "fcu");
+	priv_nh.param<std::string>("fixed_frame_id", fixed_frame_id, "map");
+	priv_nh.param<std::string>("child_frame_id", child_frame_id, "base_link");
 
 	priv_nh.param("marker_scale", marker_scale, 1.0);
-	priv_nh.param("num_rotors", num_rotors, 6);
+	priv_nh.param("num_rotors", num_rotors, 4);
 	priv_nh.param("arm_len", arm_len, 0.22 );
 	priv_nh.param("body_width", body_width, 0.15 );
 	priv_nh.param("body_height", body_height, 0.10 );

--- a/mavros_extras/src/plugins/fake_gps.cpp
+++ b/mavros_extras/src/plugins/fake_gps.cpp
@@ -77,7 +77,7 @@ public:
 		// default origin/starting point: Zürich geodetic coordinates
 		fp_nh.param("geo_origin/lat", origin_lat, 47.3667);	// [degrees]
 		fp_nh.param("geo_origin/lon", origin_lon, 8.5500);	// [degrees]
-		fp_nh.param("geo_origin/alt", origin_alt, 6371000.0);	// [meters - height over the WGS-84 ellipsoid]
+		fp_nh.param("geo_origin/alt", origin_alt, 408.0);	// [meters - height over the WGS-84 ellipsoid]
 
 		// init map origin with geodetic coordinates
 		map_origin = {origin_lat, origin_lon, origin_alt};
@@ -106,7 +106,7 @@ public:
 		// tf params
 		fp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
 		fp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "fix");
-		fp_nh.param("tf/rate_limit", tf_rate, 50.0);
+		fp_nh.param("tf/rate_limit", tf_rate, 10.0);
 
 		if (use_mocap) {
 			if (mocap_transform) {	// MoCap data in TransformStamped msg

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -44,13 +44,13 @@ public:
 
 		flow_nh.param<std::string>("frame_id", frame_id, "px4flow");
 
-        /**
-         * @note Default rangefinder is Maxbotix HRLV-EZ4 
-         * This is a narrow beam (60cm wide at 5 meters,
-         * but also at 1 meter). 6.8 degrees at 5 meters, 31 degrees
-         * at 1 meter
-         */
-        flow_nh.param("ranger_fov", ranger_fov, 0.119428926);
+		/**
+		 * @note Default rangefinder is Maxbotix HRLV-EZ4 
+		 * This is a narrow beam (60cm wide at 5 meters,
+		 * but also at 1 meter). 6.8 degrees at 5 meters, 31 degrees
+		 * at 1 meter
+		 */
+		flow_nh.param("ranger_fov", ranger_fov, 0.119428926);
 
 		flow_nh.param("ranger_min_range", ranger_min_range, 0.3);
 		flow_nh.param("ranger_max_range", ranger_max_range, 5.0);
@@ -63,7 +63,7 @@ public:
 	Subscriptions get_subscriptions()
 	{
 		return {
-			       make_handler(&PX4FlowPlugin::handle_optical_flow_rad)
+			make_handler(&PX4FlowPlugin::handle_optical_flow_rad)
 		};
 	}
 

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -45,7 +45,9 @@ public:
 		flow_nh.param<std::string>("frame_id", frame_id, "px4flow");
 
 		/** Default rangefinder is Maxbotix HRLV-EZ4 */
-		flow_nh.param("ranger_fov", ranger_fov, 0.0);	/** @todo Check MAxbotix HRLV-EZ4 Field-of-View */
+		flow_nh.param("ranger_fov", ranger_fov, 0.119428926);	/** @todo Check MAxbotix HRLV-EZ4 Field-of-View 
+                                                                    This is a narrow beam (60cm wide at 5 meters, but also at 1 meter) 
+                                                                    6.8 degrees at 5 meters, 31 degrees at 1 meter */
 		flow_nh.param("ranger_min_range", ranger_min_range, 0.3);
 		flow_nh.param("ranger_max_range", ranger_max_range, 5.0);
 

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -44,10 +44,14 @@ public:
 
 		flow_nh.param<std::string>("frame_id", frame_id, "px4flow");
 
-		/** Default rangefinder is Maxbotix HRLV-EZ4 */
-		flow_nh.param("ranger_fov", ranger_fov, 0.119428926);	/** @todo Check MAxbotix HRLV-EZ4 Field-of-View 
-                                                                    This is a narrow beam (60cm wide at 5 meters, but also at 1 meter) 
-                                                                    6.8 degrees at 5 meters, 31 degrees at 1 meter */
+        /**
+         * @note Default rangefinder is Maxbotix HRLV-EZ4 
+         * This is a narrow beam (60cm wide at 5 meters,
+         * but also at 1 meter). 6.8 degrees at 5 meters, 31 degrees
+         * at 1 meter
+         */
+        flow_nh.param("ranger_fov", ranger_fov, 0.119428926);
+
 		flow_nh.param("ranger_min_range", ranger_min_range, 0.3);
 		flow_nh.param("ranger_max_range", ranger_max_range, 5.0);
 

--- a/mavros_extras/src/plugins/vibration.cpp
+++ b/mavros_extras/src/plugins/vibration.cpp
@@ -36,7 +36,7 @@ public:
 	{
 		PluginBase::initialize(uas_);
 
-		vibe_nh.param<std::string>("frame_id", frame_id, "vibration");
+		vibe_nh.param<std::string>("frame_id", frame_id, "base_link");
 
 		vibration_pub = vibe_nh.advertise<mavros_msgs::Vibration>("raw/vibration", 10);
 	}

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -49,7 +49,7 @@ public:
 		sp_nh.param("tf/listen", tf_listen, false);
 		sp_nh.param<std::string>("tf/frame_id", tf_frame_id, "map");
 		sp_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "vision_estimate");
-		sp_nh.param("tf/rate_limit", tf_rate, 50.0);
+		sp_nh.param("tf/rate_limit", tf_rate, 10.0);
 
 		if (tf_listen) {
 			ROS_INFO_STREAM_NAMED("vision_pose", "Listen to vision transform " << tf_frame_id


### PR DESCRIPTION
Solving default frame consistency in config files #789 

* Changing the `local_origin` frame to `map` for consistency.
* Correction of the `global_position/frame_id` and `local_position/frame_id` to map frame