### PR TITLE
CMake: explicitly link the atomic library

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(mavros
   src/lib/rosconsole_bridge.cpp
 )
 target_link_libraries(mavros
+  atomic
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
   ${GeographicLib_LIBRARIES}


### PR DESCRIPTION
For arm & mips architecture, the linker must explicitly be asked to link the atomic library (with `-latomic`).

Otherwise, the linking fails with:

```
| devel/lib/libmavros.so: undefined reference to `__atomic_load_8'
| devel/lib/libmavros.so: undefined reference to `__atomic_store_8'
| collect2: error: ld returned 1 exit status
```

Linking `atomic` unconditionally as library is strictly needed only for arm & mips, but it seems not to imply any further differences with other architectures. Hence, this commit simply adds `atomic` unconditionally for a uniform handling of all machine architectures.

This is an alternative solution to the proposed solution in #790.

The issue was discovered cross-compiling mavros in meta-ros, the OpenEmbedded layer for ROS. Some further pointers are available at:

  https://github.com/bmwcarit/meta-ros/issues/525