### PR TITLE
waypoint: Publish current waypoint seq

### DIFF
--- a/mavros/src/plugins/waypoint.cpp
+++ b/mavros/src/plugins/waypoint.cpp
@@ -674,6 +674,7 @@ private:
 		for (auto &it : waypoints) {
 			wpl->waypoints.push_back(it.to_msg());
 		}
+		wpl->seq = wp_cur_active;
 
 		lock.unlock();
 		wp_list_pub.publish(wpl);

--- a/mavros_msgs/msg/WaypointList.msg
+++ b/mavros_msgs/msg/WaypointList.msg
@@ -1,1 +1,2 @@
+uint16 seq
 mavros_msgs/Waypoint[] waypoints


### PR DESCRIPTION
This PR makes the current waypoint sequence number more accessible.

Currently finding the sequence number requires iterating through `/mavros/mission/waypoints` and checking `is_current`.

This PR adds seq field to the waypointlist message outside of the waypoint array.

As discussed in https://github.com/mavlink/mavros/pull/798#issuecomment-327745029.