### PR TITLE
scripts: fix typos and improve help messages consistency

### DIFF
--- a/mavros/scripts/mavcmd
+++ b/mavros/scripts/mavcmd
@@ -194,9 +194,9 @@ def do_trigger_control(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Commad line tool for sending commands to MAVLink device.")
+    parser = argparse.ArgumentParser(description="Command line tool for sending commands to MAVLink device.")
     parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default="/mavros")
-    parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output")
     parser.add_argument('--wait', action='store_true', help="Wait for establishing FCU connection")
     subarg = parser.add_subparsers()
 
@@ -223,9 +223,9 @@ def main():
     int_args.add_argument('param2', type=float, help="param2")
     int_args.add_argument('param3', type=float, help="param3")
     int_args.add_argument('param4', type=float, help="param4")
-    int_args.add_argument('x', type=int, help="latitude in deg*1E7 or X*1E4 m")
-    int_args.add_argument('y', type=int, help="longitude in deg*1E7 or Y*1E4 m")
-    int_args.add_argument('z', type=float, help="altitude in m, depending on frame")
+    int_args.add_argument('x', type=int, help="Latitude in deg*1E7 or X*1E4 m")
+    int_args.add_argument('y', type=int, help="Longitude in deg*1E7 or Y*1E4 m")
+    int_args.add_argument('z', type=float, help="Altitude in m, depending on frame")
 
     # Note: arming service provided by mavsafety
 
@@ -240,7 +240,7 @@ def main():
     takeoff_args = subarg.add_parser('takeoff', help="Request takeoff")
     takeoff_args.set_defaults(func=do_takeoff)
     takeoff_args.add_argument('min_pitch', type=float, help="Min pitch")
-    takeoff_args.add_argument('yaw', type=float, help="Desiered Yaw")
+    takeoff_args.add_argument('yaw', type=float, help="Desired Yaw")
     takeoff_args.add_argument('latitude', type=float, help="Latitude")
     takeoff_args.add_argument('longitude', type=float, help="Longitude")
     takeoff_args.add_argument('altitude', type=float, help="Altitude")
@@ -254,23 +254,23 @@ def main():
 
     takeoff_cur_args = subarg.add_parser('takeoffcur', help="Request takeoff from current GPS coordinates")
     takeoff_cur_args.set_defaults(func=do_takeoff_cur_gps)
-    takeoff_cur_args.add_argument('-a', '--any-gps', action="store_true", help="Try find GPS topic (warn: could be dangerous!)")
+    takeoff_cur_args.add_argument('-a', '--any-gps', action="store_true", help="Try to find GPS topic (warn: could be dangerous!)")
     takeoff_cur_args.add_argument('min_pitch', type=float, help="Min pitch")
-    takeoff_cur_args.add_argument('yaw', type=float, help="Desiered Yaw")
+    takeoff_cur_args.add_argument('yaw', type=float, help="Desired Yaw")
     takeoff_cur_args.add_argument('altitude', type=float, help="Altitude")
 
     land_cur_args = subarg.add_parser('landcur', help="Request land on current GPS coordinates")
     land_cur_args.set_defaults(func=do_land_cur_gps)
-    land_cur_args.add_argument('-a', '--any-gps', action="store_true", help="Try find GPS topic (warn: could be dangerous!)")
+    land_cur_args.add_argument('-a', '--any-gps', action="store_true", help="Try to find GPS topic (warn: could be dangerous!)")
     land_cur_args.add_argument('yaw', type=float, help="Desired Yaw")
     land_cur_args.add_argument('altitude', type=float, help="Altitude")
 
-    trigger_ctrl_args = subarg.add_parser('trigger_control', help="Control onboard camera trigerring system (PX4)")
+    trigger_ctrl_args = subarg.add_parser('trigger_control', help="Control onboard camera triggering system (PX4)")
     trigger_ctrl_args.set_defaults(func=do_trigger_control)
     trigger_en_group = trigger_ctrl_args.add_mutually_exclusive_group()
-    trigger_en_group.add_argument('-e', '--enable', dest='trigger_enable', action='store_true', default=True, help="enable camera trigger (default)")
-    trigger_en_group.add_argument('-d', '--disable', dest='trigger_enable', action='store_false', help="disable camera trigger")
-    trigger_ctrl_args.add_argument('-i', '--integration-time', default=0.0, type=float, required=False, help="set/update shutter integration time for camera")
+    trigger_en_group.add_argument('-e', '--enable', dest='trigger_enable', action='store_true', default=True, help="Enable camera trigger (default)")
+    trigger_en_group.add_argument('-d', '--disable', dest='trigger_enable', action='store_false', help="Disable camera trigger")
+    trigger_ctrl_args.add_argument('-i', '--integration-time', default=0.0, type=float, required=False, help="Set/update shutter integration time for camera")
 
     args = parser.parse_args(rospy.myargv(argv=sys.argv)[1:])
 

--- a/mavros/scripts/mavparam
+++ b/mavros/scripts/mavparam
@@ -63,34 +63,34 @@ def do_set(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Commad line tool for getting, setting, parameters from MAVLink device.")
+    parser = argparse.ArgumentParser(description="Command line tool for getting and setting parameters from MAVLink device.")
     parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default="/mavros")
-    parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output")
     subarg = parser.add_subparsers()
 
-    load_args = subarg.add_parser('load', help="load parameters from file")
+    load_args = subarg.add_parser('load', help="Load parameters from file")
     load_args.set_defaults(func=do_load)
-    load_args.add_argument('file', type=argparse.FileType('rb'), help="input file")
+    load_args.add_argument('file', type=argparse.FileType('rb'), help="Input file")
     load_format = load_args.add_mutually_exclusive_group()
     load_format.add_argument('-mp', '--mission-planner', action="store_true", help="Select MissionPlanner param file format")
     load_format.add_argument('-qgc', '--qgroundcontrol', action="store_true", help="Select QGroundControl param file format")
 
-    dump_args = subarg.add_parser('dump', help="dump parameters to file")
+    dump_args = subarg.add_parser('dump', help="Dump parameters to file")
     dump_args.set_defaults(func=do_dump)
-    dump_args.add_argument('file', type=argparse.FileType('wb'), help="output file")
-    dump_args.add_argument('-f', '--force', action="store_true", help="Force pull params from FCU, not cache.")
+    dump_args.add_argument('file', type=argparse.FileType('wb'), help="Output file")
+    dump_args.add_argument('-f', '--force', action="store_true", help="Force pull params from FCU, not cache")
     dump_format = dump_args.add_mutually_exclusive_group()
     dump_format.add_argument('-mp', '--mission-planner', action="store_true", help="Select MissionPlanner param file format")
     dump_format.add_argument('-qgc', '--qgroundcontrol', action="store_true", help="Select QGroundControl param file format")
 
-    get_args = subarg.add_parser('get', help="get parameter")
+    get_args = subarg.add_parser('get', help="Get parameter")
     get_args.set_defaults(func=do_get)
     get_args.add_argument('param_id', help="Parameter ID string")
 
-    set_args = subarg.add_parser('set', help="set parameter")
+    set_args = subarg.add_parser('set', help="Set parameter")
     set_args.set_defaults(func=do_set)
     set_args.add_argument('param_id', help="Parameter ID string")
-    set_args.add_argument('value', help="new value")
+    set_args.add_argument('value', help="New value")
 
     args = parser.parse_args(rospy.myargv(argv=sys.argv)[1:])
 

--- a/mavros/scripts/mavsafety
+++ b/mavros/scripts/mavsafety
@@ -65,9 +65,9 @@ def do_safetyarea(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Commad line tool for manipulating safty on MAVLink device.")
+    parser = argparse.ArgumentParser(description="Command line tool for manipulating safety on MAVLink device.")
     parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default="/mavros")
-    parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output")
     subarg = parser.add_subparsers()
 
     arm_args = subarg.add_parser('arm', help="Arm motors")

--- a/mavros/scripts/mavsetp
+++ b/mavros/scripts/mavsetp
@@ -92,13 +92,10 @@ def do_local_selector(args):
         do_local_accel(args)
 
 
-# TODO: other stuff
-
-
 def main():
-    parser = argparse.ArgumentParser(description="Commad line tool for control the device by setpoints.")
+    parser = argparse.ArgumentParser(description="Command line tool for controlling the device by setpoints.")
     parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default="/mavros")
-    parser.add_argument('-V', '--verbose', action='store_true', help="verbose output")
+    parser.add_argument('-V', '--verbose', action='store_true', help="Verbose output")
     subarg = parser.add_subparsers()
 
     local_args = subarg.add_parser('local', help="Send local setpoint")

--- a/mavros/scripts/mavwp
+++ b/mavros/scripts/mavwp
@@ -179,36 +179,36 @@ def do_set_current(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Commad line tool for manipulating mission on MAVLink device.")
+    parser = argparse.ArgumentParser(description="Command line tool for manipulating missions on MAVLink device.")
     parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default="/mavros")
-    parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output")
     subarg = parser.add_subparsers()
 
     if not no_prettytable:
         show_args = subarg.add_parser('show', help="Show waypoints")
-        show_args.add_argument('-f', '--follow', action='store_true', help="watch and show new data")
-        show_args.add_argument('-p', '--pull', action='store_true', help="pull waypoints from FCU before show")
+        show_args.add_argument('-f', '--follow', action='store_true', help="Watch and show new data")
+        show_args.add_argument('-p', '--pull', action='store_true', help="Pull waypoints from FCU before show")
         show_args.set_defaults(func=do_show)
 
-    load_args = subarg.add_parser('load', help="load waypoints from file")
+    load_args = subarg.add_parser('load', help="Load waypoints from file")
     load_args.set_defaults(func=do_load)
     load_args.add_argument('-p', '--preserve-home', action='store_true', help="Preserve home location (WP 0, APM only)")
-    load_args.add_argument('-s', '--start-index', type=int, default=0, help="waypoint start index for partial updating (APM only)")
-    load_args.add_argument('-e', '--end-index', type=int, default=0, help="waypoint end index for partial updating (APM only, default: last element in waypoint list)")
-    load_args.add_argument('file', type=argparse.FileType('rb'), help="input file (QGC/MP format)")
+    load_args.add_argument('-s', '--start-index', type=int, default=0, help="Waypoint start index for partial updating (APM only)")
+    load_args.add_argument('-e', '--end-index', type=int, default=0, help="Waypoint end index for partial updating (APM only, default: last element in waypoint list)")
+    load_args.add_argument('file', type=argparse.FileType('rb'), help="Input file (QGC/MP format)")
 
-    pull_args = subarg.add_parser('pull', help="pull waypoints from FCU")
+    pull_args = subarg.add_parser('pull', help="Pull waypoints from FCU")
     pull_args.set_defaults(func=do_pull)
 
-    dump_args = subarg.add_parser('dump', help="dump waypoints to file")
+    dump_args = subarg.add_parser('dump', help="Dump waypoints to file")
     dump_args.set_defaults(func=do_dump)
-    dump_args.add_argument('file', type=argparse.FileType('wb'), help="output file (QGC format)")
+    dump_args.add_argument('file', type=argparse.FileType('wb'), help="Output file (QGC format)")
 
-    clear_args = subarg.add_parser('clear', help="clear waypoints on device")
+    clear_args = subarg.add_parser('clear', help="Clear waypoints on device")
     clear_args.set_defaults(func=do_clear)
 
-    setcur_args = subarg.add_parser('setcur', help="set current waypoints on device")
-    setcur_args.add_argument('seq', type=int, help="waypoint seq id")
+    setcur_args = subarg.add_parser('setcur', help="Set current waypoints on device")
+    setcur_args.add_argument('seq', type=int, help="Waypoint seq id")
     setcur_args.set_defaults(func=do_set_current)
 
     args = parser.parse_args(rospy.myargv(argv=sys.argv)[1:])


### PR DESCRIPTION
Some typos as I go:

commad -> command
safty -> safety
desiered -> desired

Start help messages with a capital letter.

Even though it seems trivial, I tested my commit with `catkin build` and `catkin run_tests` and everything succeeded.