### PR TITLE
GPS fix's frame_id changed to body-fixed.

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -44,7 +44,8 @@ cmd:
 
 # global_position
 global_position:
-  frame_id: "map"           # pose and fix frame_id
+  frame_id: "map"             # origin frame
+  child_frame_id: "base_link" # body-fixed frame
   rot_covariance: 99999.0   # covariance for attitude?
   use_relative_alt: true    # use relative altitude for local coordinates
   tf:

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -44,7 +44,8 @@ cmd:
 
 # global_position
 global_position:
-  frame_id: "map"           # pose and fix frame_id
+  frame_id: "map"             # origin frame
+  child_frame_id: "base_link" # body-fixed frame
   rot_covariance: 99999.0   # covariance for attitude?
   use_relative_alt: true    # use relative altitude for local coordinates
   tf:

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -116,8 +116,8 @@ private:
 	ros::Subscriber gp_set_global_origin_sub;
 	ros::Subscriber hp_sub;
 
-	std::string frame_id;       //!< origin frame for topic headers
-	std::string child_frame_id; //!< body-fixed frame for topic headers
+	std::string frame_id;				//!< origin frame for topic headers
+	std::string child_frame_id;	//!< body-fixed frame for topic headers
 	std::string tf_frame_id;	//!< origin for TF
 	std::string tf_global_frame_id;	//!< global origin for TF
 	std::string tf_child_frame_id;	//!< frame for TF and Pose

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -116,7 +116,7 @@ private:
 	ros::Subscriber gp_set_global_origin_sub;
 	ros::Subscriber hp_sub;
 
-	std::string frame_id;				//!< origin frame for topic headers
+	std::string frame_id;		//!< origin frame for topic headers
 	std::string child_frame_id;	//!< body-fixed frame for topic headers
 	std::string tf_frame_id;	//!< origin for TF
 	std::string tf_global_frame_id;	//!< global origin for TF

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -192,7 +192,7 @@ private:
 			auto vel = boost::make_shared<geometry_msgs::TwistStamped>();
 
 			vel->header.stamp = fix->header.stamp;
-			vel->header.frame_id = child_frame_id;
+			vel->header.frame_id = frame_id;
 
 			// From nmea_navsat_driver
 			vel->twist.linear.x = speed * std::sin(course);


### PR DESCRIPTION
According to [ROS](http://docs.ros.org/jade/api/sensor_msgs/html/msg/NavSatFix.html), frame_id of NavSatFix message is 
> This is a Euclidean frame relative to the vehicle, not a reference  ellipsoid.

So, usually, this should be `base_link`, not `map`.
Some ROS packages (like [robot_localization](http://wiki.ros.org/robot_localization)) rely on it to be specified exactly this way. 

This pull request adds child_frame_id parameter for global_position plugin and uses it for 

- global_position/global/header/frame_id
- global_position/raw/fix/header/frame_id
- global_position/local/child_frame_id (to make it complete)