### PR TITLE
mavros.ftp error correction in python

### DIFF
--- a/mavros/src/mavros/ftp.py
+++ b/mavros/src/mavros/ftp.py
@@ -76,6 +76,7 @@ class FTPFile(object):
         try:
             ret = open_(file_path=path, mode=m)
         except rospy.ServiceException as ex:
+            reset_server()
             raise IOError(str(ex))
 
         _check_raise_errno(ret)

--- a/mavros/src/mavros/ftp.py
+++ b/mavros/src/mavros/ftp.py
@@ -53,6 +53,9 @@ class FTPFile(object):
     def __del__(self):
         self.close()
 
+    def __exit__(self):
+        self.close()
+
     def open(self, path, mode):
         """
         Supported modes:


### PR DESCRIPTION
This patch solves two problems with using mavros.ftp on python.

First - close ftp-resource on Ctrl+C interrupt
Second - reset connection when an mavftp error (Busy, File already opened) occurs