### PR TITLE
mention rotation convention and fix NED to ENU description

### DIFF
--- a/mavros/src/lib/ftf_frame_conversions.cpp
+++ b/mavros/src/lib/ftf_frame_conversions.cpp
@@ -23,9 +23,8 @@ namespace ftf {
 namespace detail {
 /**
  * @brief Static quaternion needed for rotating between ENU and NED frames
- * +PI rotation around X (North) axis follwed by +PI/2 rotation about Z (Down)
- * gives the ENU frame.  Similarly, a +PI rotation about X (East) followed by
- * a +PI/2 roation about Z (Up) gives the NED frame.
+ * NED to ENU: +PI/2 rotation about Z (Down) followed by a +PI rotation around X (old North/new East)
+ * ENU to NED: +PI/2 rotation about Z (Up) followed by a +PI rotation about X (old East/new North)
  */
 static const auto NED_ENU_Q = quaternion_from_rpy(M_PI, 0.0, M_PI_2);
 

--- a/mavros/src/lib/ftf_quaternion_utils.cpp
+++ b/mavros/src/lib/ftf_quaternion_utils.cpp
@@ -20,6 +20,7 @@ namespace ftf {
 
 /*
  * Note: order of axis are match tf2::LinearMath (bullet).
+ * YPR rotation convention -> YAW first, Pitch second, Roll third
  * Compatibility checked by unittests.
  */
 


### PR DESCRIPTION
PR out of https://github.com/mavlink/mavros/issues/892.

Considering the effort that would be needed to change the naming to `ypr` (and testing), I think we can leave it like this.