### PR TITLE
Blacklist HIL for APM since it is not relevent

### DIFF
--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -3,6 +3,7 @@ plugin_blacklist:
 - actuator_control
 - ftp
 - safety_area
+- hil
 # extras
 - altitude
 - debug_value


### PR DESCRIPTION
Ardupilot doesn't support hardware in the loop so this plugin is not needed.

Additionally, this prevents, but doesn't fix, the issue in #822 
