### PR TITLE
obstacle_distance: measurament units 

### DIFF
--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -70,11 +70,11 @@ private:
 
 		obstacle.time_usec = req->header.stamp.toNSec() / 1000;					//!< [milisecs]
 		obstacle.sensor_type = utils::enum_value(MAV_DISTANCE_SENSOR::LASER);			//!< defaults is laser type (depth sensor, Lidar)
-		std::copy(req->ranges.begin(), req->ranges.begin() + n, obstacle.distances.begin());	//!< [centimeters]
+		std::copy(req->ranges.begin(), req->ranges.begin() + n, obstacle.distances.begin());	//!< [1 unit 1 cm]
 		std::fill(obstacle.distances.begin() + n, obstacle.distances.end(), UINT16_MAX);	//!< fill the rest of the array values as "Unknown"
 		obstacle.increment = req->angle_increment * RAD_TO_DEG;					//!< [degrees]
-		obstacle.min_distance = req->range_min / 1e2;						//!< [centimeters]
-		obstacle.max_distance = req->range_max / 1e2;						//!< [centimeters]
+		obstacle.min_distance = req->range_min;							//!< [1 unit 1 cm]
+		obstacle.max_distance = req->range_max;							//!< [1 unit 1 cm]
 
 		ROS_DEBUG_STREAM_NAMED("obstacle_distance", "OBSDIST: sensor type: " << utils::to_string_enum<MAV_DISTANCE_SENSOR>(obstacle.sensor_type)
 										     << " distances: " << std::string(obstacle.distances.begin(), obstacle.distances.end())


### PR DESCRIPTION
`min_distance` and `max_distance` are `uint16_t` in the obstacle_distance mavlink message. It makes more sense to keep them as units and transform them into cm where the message gets used. 
I'll update also the mavlink message description. @TSC21 what do you think? 

FYI @ChristophTobler 