### PR TITLE
compile also with boost >= 1.66.0

### DIFF
--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -41,13 +41,19 @@ static bool resolve_address_udp(io_service &io, size_t chan, std::string host, u
 	error_code ec;
 
 	udp::resolver::query query(host, "");
-	std::for_each(resolver.resolve(query, ec), udp::resolver::iterator(),
-			[&](const udp::endpoint & q_ep) {
-				ep = q_ep;
-				ep.port(port);
-				result = true;
-				logDebug(PFXd "host %s resolved as %s", chan, host.c_str(), to_string_ss(ep).c_str());
-			});
+	
+	auto fn = [&](const udp::endpoint & q_ep) {
+		ep = q_ep;
+		ep.port(port);
+		result = true;
+		logDebug(PFXd "host %s resolved as %s", chan, host.c_str(), to_string_ss(ep).c_str());
+	};
+
+#if BOOST_ASIO_VERSION >= 101200
+	for (auto q_ep : resolver.resolve(query, ec)) fn(q_ep);
+#else
+	std::for_each(resolver.resolve(query, ec), udp::resolver::iterator(), fn);
+#endif
 
 	if (ec) {
 		logWarn(PFXd "resolve error: %s", chan, ec.message().c_str());


### PR DESCRIPTION
In boost 1.66.0, which includes boost-asio 1.12.0, the asio interfaces have been changed to follow the "C++ Extensions for Networking" Technical Specification [1]. As a consequence, resolvers now produce ranges rather than iterators.

This commits retains the original behaviour selecting the begin iterator from the provided range when using boost >= 1.66.0.

A preprocessing directive ensures backwards compatibility using the provided boost-asio version [2].

The issue was identified in a build with the cross-compilation tool chain provided in the meta-ros OpenEmbedded layer [3].

[1] http://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html
[2] https://github.com/boostorg/asio/commit/0c9cbdfbf217146c096265b5eb56089e8cebe608
[3] http://github.com/bmwcarit/meta-ros