### PR TITLE
launch: add optional respawn_mavros arg

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -7,6 +7,7 @@
 	<arg name="tgt_system" default="1" />
 	<arg name="tgt_component" default="1" />
 	<arg name="log_output" default="screen" />
+	<arg name="respawn_mavros" default="false" />
 
 	<include file="$(find mavros)/launch/node.launch">
 		<arg name="pluginlists_yaml" value="$(find mavros)/launch/apm_pluginlists.yaml" />
@@ -17,5 +18,6 @@
 		<arg name="tgt_system" value="$(arg tgt_system)" />
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 		<arg name="log_output" value="$(arg log_output)" />
+		<arg name="respawn_mavros" default="$(arg respawn_mavros)" />
 	</include>
 </launch>

--- a/mavros/launch/node.launch
+++ b/mavros/launch/node.launch
@@ -10,8 +10,9 @@
 	<arg name="config_yaml" />
 	<arg name="log_output" default="screen" />
 	<arg name="fcu_protocol" default="v2.0" />
+	<arg name="respawn_mavros" default="false" />
 
-	<node pkg="mavros" type="mavros_node" name="mavros" required="true" clear_params="true" output="$(arg log_output)">
+	<node pkg="mavros" type="mavros_node" name="mavros" required="$(eval not respawn_mavros)" clear_params="true" output="$(arg log_output)" respawn="$(arg respawn_mavros)">
 		<param name="fcu_url" value="$(arg fcu_url)" />
 		<param name="gcs_url" value="$(arg gcs_url)" />
 		<param name="target_system_id" value="$(arg tgt_system)" />

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -8,6 +8,7 @@
 	<arg name="tgt_component" default="1" />
 	<arg name="log_output" default="screen" />
 	<arg name="fcu_protocol" default="v2.0" />
+	<arg name="respawn_mavros" default="false" />
 
 	<include file="$(find mavros)/launch/node.launch">
 		<arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
@@ -19,5 +20,6 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 		<arg name="log_output" value="$(arg log_output)" />
 		<arg name="fcu_protocol" value="$(arg fcu_protocol)" />
+		<arg name="respawn_mavros" default="$(arg respawn_mavros)" />
 	</include>
 </launch>


### PR DESCRIPTION
I can see cases were we don't want our system to kill all the nodes if the mavros node dies. Instead, allow the user to specify a new `respawn_mavros` argument if they want the mavros node to respawn rather than kill the whole roslaunch.

The argument name was chosen based on gazebo's launch file (see [empty_world.launch](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/9cbc4bfd9b0caf763387cb203f6bf695071cae07/gazebo_ros/launch/empty_world.launch#L17)), so this should feel familiar to users.