### PR TITLE
Add ability to send STATUSTEXT messages

### DIFF
--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -21,6 +21,7 @@
 #include <mavros_msgs/StreamRate.h>
 #include <mavros_msgs/SetMode.h>
 #include <mavros_msgs/CommandLong.h>
+#include <mavros_msgs/StatusText.h>
 
 #ifdef HAVE_SENSOR_MSGS_BATTERYSTATE_MSG
 #include <sensor_msgs/BatteryState.h>
@@ -466,6 +467,8 @@ public:
 		state_pub = nh.advertise<mavros_msgs::State>("state", 10, true);
 		extended_state_pub = nh.advertise<mavros_msgs::ExtendedState>("extended_state", 10);
 		batt_pub = nh.advertise<BatteryMsg>("battery", 10);
+		statustext_pub = nh.advertise<mavros_msgs::StatusText>("statustext/recv", 10);
+		statustext_sub = nh.subscribe("statustext/send", 10, &SystemStatusPlugin::statustext_cb, this);
 		rate_srv = nh.advertiseService("set_stream_rate", &SystemStatusPlugin::set_rate_cb, this);
 		mode_srv = nh.advertiseService("set_mode", &SystemStatusPlugin::set_mode_cb, this);
 
@@ -502,6 +505,8 @@ private:
 	ros::Publisher state_pub;
 	ros::Publisher extended_state_pub;
 	ros::Publisher batt_pub;
+	ros::Publisher statustext_pub;
+	ros::Subscriber statustext_sub;
 	ros::ServiceServer rate_srv;
 	ros::ServiceServer mode_srv;
 
@@ -710,8 +715,13 @@ private:
 	void handle_statustext(const mavlink::mavlink_message_t *msg, mavlink::common::msg::STATUSTEXT &textm)
 	{
 		auto text = mavlink::to_string(textm.text);
-
 		process_statustext_normal(textm.severity, text);
+
+		auto st_msg = boost::make_shared<mavros_msgs::StatusText>();
+		st_msg->header.stamp = ros::Time::now();
+		st_msg->severity = textm.severity;
+		st_msg->text = text;
+		statustext_pub.publish(st_msg);
 	}
 
 	void handle_meminfo(const mavlink::mavlink_message_t *msg, mavlink::ardupilotmega::msg::MEMINFO &mem)
@@ -901,6 +911,20 @@ private:
 			// publish connection change
 			publish_disconnection();
 		}
+	}
+
+	/* -*- subscription callbacks -*- */
+
+	void statustext_cb(const mavros_msgs::StatusText::ConstPtr &req) {
+		mavlink::common::msg::STATUSTEXT statustext {};
+		statustext.severity = req->severity;
+
+		// Limit the length of the string by null-terminating at the 50-th character
+		ROS_WARN_COND_NAMED(req->text.length() >= statustext.text.size(), "sys",
+				"Status text too long: truncating...");
+		mavlink::set_string_z(statustext.text, req->text);
+
+		UAS_FCU(m_uas)->send_message_ignore_drop(statustext);
 	}
 
 	/* -*- ros callbacks -*- */

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -35,6 +35,7 @@ add_message_files(
   RCOut.msg
   RadioStatus.msg
   State.msg
+  StatusText.msg
   Thrust.msg
   VFR_HUD.msg
   Vibration.msg

--- a/mavros_msgs/msg/StatusText.msg
+++ b/mavros_msgs/msg/StatusText.msg
@@ -1,0 +1,17 @@
+# STATUSTEXT message representation
+# https://mavlink.io/en/messages/common.html#STATUSTEXT
+
+# Severity levels
+uint8 EMERGENCY = 0
+uint8 ALERT = 1
+uint8 CRITICAL = 2
+uint8 ERROR = 3
+uint8 WARNING = 4
+uint8 NOTICE = 5
+uint8 INFO = 6
+uint8 DEBUG = 7
+
+# Fields
+std_msgs/Header header
+uint8 severity
+string text


### PR DESCRIPTION
This adds the ability to listen to and send STATUSTEXT messages to the FCU. Sent STATUSTEXT can then be received by QGroundControl (and read out if the severity is high enough) automatically over telemetry as if they were sent by the FCU.

To make use of this, one needs to enable mavlink forwarding on the FCU. On PX4, that can be achieved with the `-f` command when running `mavlink start`.