### PR TITLE
libmavconn : enable low-latency mode on Linux

### DIFF
--- a/libmavconn/include/mavconn/serial.h
+++ b/libmavconn/include/mavconn/serial.h
@@ -22,6 +22,10 @@
 #include <mavconn/interface.h>
 #include <mavconn/msgbuffer.h>
 
+#if defined(__linux__)
+#include <linux/serial.h>
+#endif
+
 namespace mavconn {
 /**
  * @brief Serial interface


### PR DESCRIPTION
Some common USB-UART converters like the FTDI accumulate individual bytes from the serial link in order to send them in a single USB packet ("Nagling" - https://en.wikipedia.org/wiki/Nagle%27s_algorithm). This commit sets the ASYNC_LOW_LATENCY flag, which the FTDI kernel driver interprets as a request to drop the Nagling timer to 1ms (i.e send all accumulated bytes after 1ms.)

This reduces average link RTT to under 5ms at 921600 baud (it is 20-30 ms on master), and enables the use of mavros in systems where low latency is required to get good performance for e.g estimation and controls. As a side effect, this also greatly increases performance of timesync on serial links and prevents the hard-resets we've been seeing.