### PR TITLE
launch : remove vision_pose_estimate from blacklist on ardupilot

### DIFF
--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -11,7 +11,7 @@ plugin_blacklist:
 - mocap_pose_estimate
 - px4flow
 - vibration
-- 'vision_*'
+- vision_speed_estimate
 
 plugin_whitelist: []
 #- 'sys_*'


### PR DESCRIPTION
it is now support in Master starting from https://github.com/ArduPilot/ardupilot/commit/12fd19ea265babe6be716e7159d91d8f95be3512