### PR TITLE
extras: add covariance parsing to VISION_POSITION_ESTIMATE

### DIFF
--- a/mavros/include/mavros/frame_tf.h
+++ b/mavros/include/mavros/frame_tf.h
@@ -377,7 +377,7 @@ inline Eigen::Quaterniond mavlink_to_quaternion(const std::array<float, 4> &q)
 }
 
 /**
- * @brief Store Covariance matrix to MAVLink float[n] format
+ * @brief Convert covariance matrix to MAVLink float[n] format
  */
 template<class T, std::size_t SIZE>
 inline void covariance_to_mavlink(const T &cov, std::array<float, SIZE> &covmsg)
@@ -386,12 +386,12 @@ inline void covariance_to_mavlink(const T &cov, std::array<float, SIZE> &covmsg)
 }
 
 /**
- * @brief Store half upper right triangular of 9d Covariance matrix to MAVLink float[n] format
+ * @brief Convert half upper right triangular of a covariance matrix to MAVLink float[n] format
  */
-inline void covariance9d_urt_to_mavlink(const Covariance9d &cov, std::array<float, 45> &covmsg)
+template<class T, std::size_t SIZE>
+inline void covariance_urt_to_mavlink(const T &covmap, std::array<float, SIZE> &covmsg)
 {
-	EigenMapConstCovariance9d m(cov.data());
-
+	auto m = covmap;
 	auto out = covmsg.begin();
 
 	for (size_t x = 0; x < m.cols(); x++)

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -153,7 +153,7 @@ private:
 
 		lpos.time_usec = stamp_usec;
 		lpos.estimator_type = utils::enum_value(estimator_type);
-		ftf::covariance9d_urt_to_mavlink(cov_full, lpos.covariance);
+		ftf::covariance_urt_to_mavlink(cov_full_map, lpos.covariance);
 
 		// [[[cog:
 		// for a, b in (('', 'pos_ned'), ('v', 'lin_vel_ned'), ('a', 'zerov3f')):


### PR DESCRIPTION
Updates `vision_pose_estimate` plugin so it can send the covariance matrix also. Follows the Mavlink spec update in https://github.com/mavlink/mavlink/pull/724. Requires a `mavlunk-gbp-release` update.
Also, generalizes `covariance9d_urt_to_mavlink` to `covariance_urt_to_mavlink` so to be able to parse URT values for matrices of other sizes.