### PR TITLE
imu plugin: fix pressure units

### DIFF
--- a/mavros/src/plugins/imu.cpp
+++ b/mavros/src/plugins/imu.cpp
@@ -394,7 +394,7 @@ private:
 			auto static_pressure_msg = boost::make_shared<sensor_msgs::FluidPressure>();
 
 			static_pressure_msg->header = header;
-			static_pressure_msg->fluid_pressure = imu_hr.abs_pressure * MILLIBAR_TO_PASCAL;
+			static_pressure_msg->fluid_pressure = imu_hr.abs_pressure;
 
 			static_press_pub.publish(static_pressure_msg);
 		}
@@ -408,7 +408,7 @@ private:
 			auto differential_pressure_msg = boost::make_shared<sensor_msgs::FluidPressure>();
 
 			differential_pressure_msg->header = header;
-			differential_pressure_msg->fluid_pressure = imu_hr.diff_pressure * MILLIBAR_TO_PASCAL;
+			differential_pressure_msg->fluid_pressure = imu_hr.diff_pressure;
 
 			diff_press_pub.publish(differential_pressure_msg);
 		}


### PR DESCRIPTION
Sorry - converted units wrong on the differential and static pressure in #1001

PX4 also using new uorb for the static pressure which is in pa now (used to be millibar) https://github.com/PX4/Firmware/blob/master/msg/vehicle_air_data.msg#L4

