### PR TITLE
setpoint_attitude: rename topic from target_attitude to attitude

### DIFF
--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -79,7 +79,7 @@ public:
 			/**
 			 * @brief Use message_filters to sync attitude and thrust msg coming from different topics
 			 */
-			pose_sub.subscribe(sp_nh, "target_attitude", 1);
+			pose_sub.subscribe(sp_nh, "attitude", 1);
 
 			/**
 			 * @brief Matches messages, even if they have different time stamps,


### PR DESCRIPTION
Discussed with @TSC21 

Topic list:
```
/mavros/setpoint_accel/accel
/mavros/setpoint_attitude/target_attitude
/mavros/setpoint_attitude/thrust
/mavros/setpoint_position/global
/mavros/setpoint_position/local
/mavros/setpoint_raw/attitude
/mavros/setpoint_raw/global
/mavros/setpoint_raw/local
/mavros/setpoint_raw/target_attitude
/mavros/setpoint_raw/target_global
/mavros/setpoint_raw/target_local
/mavros/setpoint_velocity/cmd_vel
/mavros/setpoint_velocity/cmd_vel_unstamped
```

Basically, while going over the documentation it seemed fitting to change the topic name back to `attitude` as documentation states and because the `target_*` topics used by setpoint_raw are loopback publishers.

I doubt the topic is currently widely used as the parameter to enable it wasn't documented till today,