### PR TITLE
[WIP] extras: odom: adapt the transform according to the frames

### DIFF
--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -25,6 +25,7 @@
 namespace mavros {
 namespace extra_plugins {
 using mavlink::common::MAV_FRAME;
+using Matrix6d = Eigen::Matrix<double, 6, 6>;
 
 /**
  * @brief Odometry plugin
@@ -157,10 +158,8 @@ private:
 		Eigen::Quaterniond orientation {};	//!< Attitude quaternion. WRT frame_id
 		Eigen::Vector3d lin_vel {};		//!< Linear velocity vector. WRT child_frame_id
 		Eigen::Vector3d ang_vel {};		//!< Angular velocity vector. WRT child_frame_id
-		Eigen::Matrix<double, 6, 6> r_pose {};	//!< Pose 6-D Covariance matrix. WRT frame_id
-		Eigen::Matrix<double, 6, 6> r_vel {};	//!< Velocity 6-D Covariance matrix. WRT child_frame_id
-		r_pose.setZero();			// make sure to initialize with zeros
-		r_vel.setZero();			// make sure to initialize with zeros
+		Matrix6d r_pose = Matrix6d::Zero();	//!< Zero initialized pose 6-D Covariance matrix. WRT frame_id
+		Matrix6d r_vel = Matrix6d::Zero();	//!< Zero initialized velocity 6-D Covariance matrix. WRT child_frame_id
 
 		mavlink::common::msg::ODOMETRY msg {};
 

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -184,21 +184,21 @@ private:
 		 * Linear and angular velocities are in the same frame as child_frame_id.
 		 * Same logic here applies as above.
 		 */
-		auto set_tf = [&](auto affineTf, auto frame_id) {
+		auto set_tf = [&](Eigen::Affine3d affineTf, MAV_FRAME frame_id) {
 			lin_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.linear));
 			ang_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.angular));
 			r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = affineTf.linear();
 
-			msg.child_frame_id = frame_id;
+			msg.child_frame_id = utils::enum_value(frame_id);
 		};
 
 		if (odom->child_frame_id == "world" || odom->child_frame_id == "odom") {
 			// the child_frame_id would be the same reference frame as frame_id
-			set_tf(tf_child2local, msg.frame_id);
+			set_tf(tf_child2local, lf_id);
 		}
 		else {
 			// the child_frame_id would be the WRT a body frame reference
-			set_tf(tf_child2body, utils::enum_value(bf_id));
+			set_tf(tf_child2body, bf_id);
 		}
 
 		/** Apply covariance transforms */


### PR DESCRIPTION
The msgs spec states that the position and orientation should be on the local frame, while the twist data should be on the body frame.

**UPDATE:** this is not actually right -> it depends on the frames where the data is sent on. *example:* If a VIO app sends the velocity of a vehicle (the `child_frame_id` that navigates in an `odom` `frame_id`), then the velocity of the vehicle needs to be parsed on the the same frame of the `child_frame_id`, which means the vehicle body frame. The orientation should though be rotated from the FLU to the FRD orientation.