### PR TITLE
add wind estimation plugin

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -134,6 +134,7 @@ add_library(mavros_plugins
   src/plugins/altitude.cpp
   src/plugins/hil.cpp
   src/plugins/home_position.cpp
+  src/plugins/wind_estimation.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -71,4 +71,7 @@
 	<class name="home_position" type="mavros::std_plugins::HomePositionPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish home position</description>
 	</class>
+	<class name="wind_estimation" type="mavros::std_plugins::WindEstimationPlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>Publish wind estimates</description>
+	</class>
 </library>

--- a/mavros/src/plugins/wind_estimation.cpp
+++ b/mavros/src/plugins/wind_estimation.cpp
@@ -1,0 +1,96 @@
+/**
+ * @brief wind estimation plugin
+ * @file wind_estimation.cpp
+ * @author Thomas Stastny <thomas.stastny@mavt.ethz.ch>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2018 Thomas Stastny <thomas.stastny@mavt.ethz.ch>
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <angles/angles.h>
+#include <mavros/mavros_plugin.h>
+
+#include <geometry_msgs/TwistWithCovarianceStamped.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief Wind estimation plugin.
+ */
+class WindEstimationPlugin : public plugin::PluginBase {
+public:
+	WindEstimationPlugin() : PluginBase(),
+		nh("~")
+	{ }
+
+	/**
+	 * Plugin initializer. Constructor should not do this.
+	 */
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		wind_pub = nh.advertise<geometry_msgs::TwistWithCovarianceStamped>("wind_estimation", 10);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return {
+			make_handler(&WindEstimationPlugin::handle_APM_wind),
+			make_handler(&WindEstimationPlugin::handle_PX4_wind),
+		};
+	}
+
+private:
+	ros::NodeHandle nh;
+
+	ros::Publisher wind_pub;
+
+	/**
+	 * Handle APM specific wind direction estimation message
+	 */
+	void handle_APM_wind(const mavlink::mavlink_message_t *msg, mavlink::ardupilotmega::msg::WIND &wind)
+	{
+		const double speed = wind.speed;
+		const double course = angles::from_degrees(wind.direction);
+
+		auto twist_cov = boost::make_shared<geometry_msgs::TwistWithCovarianceStamped>();
+		twist_cov->header.stamp = ros::Time::now();
+		// TODO: check math's
+		twist_cov->twist.twist.linear.x = speed * std::sin(course);
+		twist_cov->twist.twist.linear.y = speed * std::cos(course);
+		twist_cov->twist.twist.linear.z = wind.speed_z;
+
+		wind_pub.publish(twist_cov);
+	}
+
+	/**
+	 * Handle APM specific wind direction estimation message
+	 */
+	void handle_PX4_wind(const mavlink::mavlink_message_t *msg, mavlink::common::msg::WIND_COV &wind)
+	{
+		auto twist_cov = boost::make_shared<geometry_msgs::TwistWithCovarianceStamped>();
+		twist_cov->header.stamp = ros::Time::now();
+
+		twist_cov->twist.twist.linear.x = wind.wind_x;
+		twist_cov->twist.twist.linear.y = wind.wind_y;
+		twist_cov->twist.twist.linear.z = wind.wind_z;
+
+		twist_cov->twist.covariance[0] = wind.var_horiz; // NOTE: this is a summed covariance for both x and y horizontal wind components
+		twist_cov->twist.covariance[2] = wind.var_vert;
+
+		wind_pub.publish(twist_cov);
+	}
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::WindEstimationPlugin, mavros::plugin::PluginBase)

--- a/mavros/src/plugins/wind_estimation.cpp
+++ b/mavros/src/plugins/wind_estimation.cpp
@@ -45,8 +45,8 @@ public:
 	Subscriptions get_subscriptions()
 	{
 		return {
-			make_handler(&WindEstimationPlugin::handle_apm_wind),
-			make_handler(&WindEstimationPlugin::handle_px4_wind),
+			       make_handler(&WindEstimationPlugin::handle_apm_wind),
+			       make_handler(&WindEstimationPlugin::handle_px4_wind),
 		};
 	}
 
@@ -61,14 +61,14 @@ private:
 	void handle_apm_wind(const mavlink::mavlink_message_t *msg, mavlink::ardupilotmega::msg::WIND &wind)
 	{
 		const double speed = wind.speed;
-		const double course = -angles::from_degrees(wind.direction); // direction "from" -> direction "to"
+		const double course = -angles::from_degrees(wind.direction);	// direction "from" -> direction "to"
 
 		auto twist_cov = boost::make_shared<geometry_msgs::TwistWithCovarianceStamped>();
 		twist_cov->header.stamp = ros::Time::now();
 		// TODO: check math's
-		twist_cov->twist.twist.linear.x = speed * std::sin(course); // E
-		twist_cov->twist.twist.linear.y = speed * std::cos(course); // N
-		twist_cov->twist.twist.linear.z = -wind.speed_z; // D -> U
+		twist_cov->twist.twist.linear.x = speed * std::sin(course);	// E
+		twist_cov->twist.twist.linear.y = speed * std::cos(course);	// N
+		twist_cov->twist.twist.linear.z = -wind.speed_z;// D -> U
 
 		// covariance matrix unknown in APM msg
 		ftf::EigenMapCovariance6d cov_map(twist_cov->twist.covariance.data());
@@ -92,7 +92,7 @@ private:
 		// fill available covariance elements
 		ftf::EigenMapCovariance6d cov_map(twist_cov->twist.covariance.data());
 		cov_map.setZero();
-		cov_map(0, 0) = wind.var_horiz; // NOTE: this is a summed covariance for both x and y horizontal wind components
+		cov_map(0, 0) = wind.var_horiz;	// NOTE: this is a summed covariance for both x and y horizontal wind components
 		cov_map(2, 2) = wind.var_vert;
 
 		wind_pub.publish(twist_cov);


### PR DESCRIPTION
Makes a new wind estimation plugin handling both APM and PX4 specific wind messages.
- moves old APM wind publisher from vfr_hud to the new wind plugin
- the PX4 message contains a *summed* horizontal wind speed convariance (i.e. x cov + y cov). This value is placed in the first covariance array slot for now, and the vertical in the 3rd.

resolves #1008