### PR TITLE
GPS accuracy wo approximations

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -47,6 +47,7 @@ global_position:
   frame_id: "map"             # origin frame
   child_frame_id: "base_link" # body-fixed frame
   rot_covariance: 99999.0   # covariance for attitude?
+  gps_uere: 1.0             # User Equivalent Range Error (UERE) of GPS sensor (m)
   use_relative_alt: true    # use relative altitude for local coordinates
   tf:
     send: false               # send TF?

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -47,6 +47,7 @@ global_position:
   frame_id: "map"             # origin frame
   child_frame_id: "base_link" # body-fixed frame
   rot_covariance: 99999.0   # covariance for attitude?
+  gps_uere: 1.0             # User Equivalent Range Error (UERE) of GPS sensor (m)
   use_relative_alt: true    # use relative altitude for local coordinates
   tf:
     send: false               # send TF?

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -59,6 +59,7 @@ public:
 		gp_nh.param<std::string>("frame_id", frame_id, "map");
 		gp_nh.param<std::string>("child_frame_id", child_frame_id, "base_link");
 		gp_nh.param("rot_covariance", rot_cov, 99999.0);
+		gp_nh.param("gps_uere", gps_uere, 1.0);
 		gp_nh.param("use_relative_alt", use_relative_alt, true);
 		// tf subsection
 		gp_nh.param("tf/send", tf_send, false);
@@ -127,6 +128,7 @@ private:
 	bool is_map_init;
 
 	double rot_cov;
+	double gps_uere;
 
 	Eigen::Vector3d map_origin {};	//!< geodetic origin of map frame [lla]
 	Eigen::Vector3d ecef_origin {};	//!< geocentric origin of map frame [m]
@@ -168,13 +170,18 @@ private:
 		float eph = (raw_gps.eph != UINT16_MAX) ? raw_gps.eph / 1E2F : NAN;
 		float epv = (raw_gps.epv != UINT16_MAX) ? raw_gps.epv / 1E2F : NAN;
 
-		if (!std::isnan(eph)) {
-			const double hdop = eph;
-
-			// From nmea_navsat_driver
-			fix->position_covariance[0 + 0] = fix->position_covariance[3 + 1] = std::pow(raw_gps.h_acc/1e3, 2);
-			fix->position_covariance[6 + 2] = std::pow(raw_gps.v_acc/1e3, 2);
+		// With FCU protocol v2.0 use accuracies reported by sensor
+		if (UAS_FCU(m_uas)->get_protocol_version() == mavconn::Protocol::V20 &&
+				raw_gps.h_acc > 0 && raw_gps.v_acc > 0) {
+			fix->position_covariance[0 + 0] = fix->position_covariance[3 + 1] = std::pow(raw_gps.h_acc / 1E3, 2);
+			fix->position_covariance[6 + 2] = std::pow(raw_gps.v_acc / 1E3, 2);
 			fix->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+		}
+		// With FCU protocol v1.0 approximate accuracies by DOP
+		else if (!std::isnan(eph) && !std::isnan(epv)) {
+			fix->position_covariance[0 + 0] = fix->position_covariance[3 + 1] = std::pow(eph * gps_uere, 2);
+			fix->position_covariance[6 + 2] = std::pow(epv * gps_uere, 2);
+			fix->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_APPROXIMATED;
 		}
 		else {
 			fill_unknown_cov(fix);

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -172,9 +172,9 @@ private:
 			const double hdop = eph;
 
 			// From nmea_navsat_driver
-			fix->position_covariance[0 + 0] = fix->position_covariance[3 + 1] = std::pow(hdop, 2);
-			fix->position_covariance[6 + 2] = std::pow(2 * hdop, 2);
-			fix->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_APPROXIMATED;
+			fix->position_covariance[0 + 0] = fix->position_covariance[3 + 1] = std::pow(raw_gps.h_acc/1e3, 2);
+			fix->position_covariance[6 + 2] = std::pow(raw_gps.v_acc/1e3, 2);
+			fix->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
 		}
 		else {
 			fill_unknown_cov(fix);


### PR DESCRIPTION
GPS accuracy published by mavros is now based on accuracies reported by FCU in `GPS_RAW_INT` message if using mavlink v2.0. Otherwise they are approximated by HDOP & VDOP values, scaled by GPS User Equivalent Range Error (UERE) measured in meters.
According to #1020.