### PR TITLE
Add permanent UDP broadcasting for GCS bridge

### DIFF
--- a/libmavconn/README.md
+++ b/libmavconn/README.md
@@ -18,7 +18,8 @@ Supported schemas:
   - Serial: `serial:///path/to/serial/device[:baudrate][?ids=sysid,compid]`
   - Serial with hardware flow control: `serial-hwfc:///path/to/serial/device[:baudrate][?ids=sysid,compid]`
   - UDP: `udp://[bind_host][:port]@[remote_host][:port][/?ids=sysid,compid]`
-  - UDP broadcast: `udp-b://[bind_host][:port]@[:port][/?ids=sysid,compid]`
+  - UDP broadcast until GCS discovery: `udp-b://[bind_host][:port]@[:port][/?ids=sysid,compid]`
+  - UDP broadcast (permanent): `udp-pb://[bind_host][:port]@[:port][/?ids=sysid,compid]
   - TCP client: `tcp://[server_host][:port][/?ids=sysid,compid]`
   - TCP server: `tcp-l://[bind_port][:port][/?ids=sysid,compid]`
 

--- a/libmavconn/include/mavconn/udp.h
+++ b/libmavconn/include/mavconn/udp.h
@@ -35,8 +35,9 @@ public:
 	static constexpr auto DEFAULT_BIND_PORT = 14555;
 	static constexpr auto DEFAULT_REMOTE_HOST = "";
 	static constexpr auto DEFAULT_REMOTE_PORT = 14550;
-	//! Marker for boardcast mode. Not valid domain name.
+	//! Markers for broadcast modes. Not valid domain names.
 	static constexpr auto BROADCAST_REMOTE_HOST = "***i want broadcast***";
+	static constexpr auto PERMANENT_BROADCAST_REMOTE_HOST = "***permanent broadcast***";
 
 	/**
 	 * @param[id] bind_host    bind host
@@ -63,10 +64,12 @@ private:
 	boost::asio::io_service io_service;
 	std::unique_ptr<boost::asio::io_service::work> io_work;
 	std::thread io_thread;
+	bool permanent_broadcast;
 
 	std::atomic<bool> remote_exists;
 	boost::asio::ip::udp::socket socket;
 	boost::asio::ip::udp::endpoint remote_ep;
+	boost::asio::ip::udp::endpoint recv_ep;
 	boost::asio::ip::udp::endpoint last_remote_ep;
 	boost::asio::ip::udp::endpoint bind_ep;
 

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -284,7 +284,7 @@ static MAVConnInterface::Ptr url_parse_serial(
 
 static MAVConnInterface::Ptr url_parse_udp(
 		std::string hosts, std::string query,
-		uint8_t system_id, uint8_t component_id, bool is_udpb)
+		uint8_t system_id, uint8_t component_id, bool is_udpb, bool permanent_broadcast)
 {
 	std::string bind_pair, remote_pair;
 	std::string bind_host, remote_host;
@@ -305,7 +305,7 @@ static MAVConnInterface::Ptr url_parse_udp(
 	url_parse_query(query, system_id, component_id);
 
 	if (is_udpb)
-		remote_host = MAVConnUDP::BROADCAST_REMOTE_HOST;
+		remote_host = permanent_broadcast ? MAVConnUDP::PERMANENT_BROADCAST_REMOTE_HOST : MAVConnUDP::BROADCAST_REMOTE_HOST;
 
 	return std::make_shared<MAVConnUDP>(system_id, component_id,
 			bind_host, bind_port,
@@ -389,9 +389,11 @@ MAVConnInterface::Ptr MAVConnInterface::open_url(std::string url,
 			path.c_str(), query.c_str());
 
 	if (proto == "udp")
-		return url_parse_udp(host, query, system_id, component_id, false);
+		return url_parse_udp(host, query, system_id, component_id, false, false);
 	else if (proto == "udp-b")
-		return url_parse_udp(host, query, system_id, component_id, true);
+		return url_parse_udp(host, query, system_id, component_id, true, false);
+	else if (proto == "udp-pb")
+		return url_parse_udp(host, query, system_id, component_id, true, true);
 	else if (proto == "tcp")
 		return url_parse_tcp_client(host, query, system_id, component_id);
 	else if (proto == "tcp-l")

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -42,7 +42,7 @@ static bool resolve_address_udp(io_service &io, size_t chan, std::string host, u
 	error_code ec;
 
 	udp::resolver::query query(host, "");
-	
+
 	auto fn = [&](const udp::endpoint & q_ep) {
 		ep = q_ep;
 		ep.port(port);
@@ -75,7 +75,8 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 	rx_buf {},
 	io_service(),
 	io_work(new io_service::work(io_service)),
-	socket(io_service)
+	socket(io_service),
+	permanent_broadcast(false)
 {
 	using udps = boost::asio::ip::udp::socket;
 
@@ -85,7 +86,7 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 	CONSOLE_BRIDGE_logInform(PFXd "Bind address: %s", conn_id, to_string_ss(bind_ep).c_str());
 
 	if (remote_host != "") {
-		if (remote_host != BROADCAST_REMOTE_HOST)
+		if (remote_host != BROADCAST_REMOTE_HOST && remote_host != PERMANENT_BROADCAST_REMOTE_HOST)
 			remote_exists = resolve_address_udp(io_service, conn_id, remote_host, remote_port, remote_ep);
 		else {
 			remote_exists = true;
@@ -107,8 +108,12 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 		socket.set_option(udps::send_buffer_size(256_KiB));
 		socket.set_option(udps::receive_buffer_size(512_KiB));
 
-		if (remote_host == BROADCAST_REMOTE_HOST)
+		if (remote_host == BROADCAST_REMOTE_HOST) {
 			socket.set_option(udps::broadcast(true));
+		} else if (remote_host == PERMANENT_BROADCAST_REMOTE_HOST) {
+			socket.set_option(udps::broadcast(true));
+			permanent_broadcast = true;
+		}
 	}
 	catch (boost::system::system_error &err) {
 		throw DeviceError("udp", err);
@@ -232,7 +237,7 @@ void MAVConnUDP::do_recvfrom()
 	auto sthis = shared_from_this();
 	socket.async_receive_from(
 			buffer(rx_buf),
-			remote_ep,
+			permanent_broadcast ? recv_ep : remote_ep,
 			[sthis] (error_code error, size_t bytes_transferred) {
 				if (error) {
 					CONSOLE_BRIDGE_logError(PFXd "receive: %s", sthis->conn_id, error.message().c_str());
@@ -240,7 +245,7 @@ void MAVConnUDP::do_recvfrom()
 					return;
 				}
 
-				if (sthis->remote_ep != sthis->last_remote_ep) {
+				if (!sthis->permanent_broadcast && sthis->remote_ep != sthis->last_remote_ep) {
 					CONSOLE_BRIDGE_logInform(PFXd "Remote address: %s", sthis->conn_id, to_string_ss(sthis->remote_ep).c_str());
 					sthis->remote_exists = true;
 					sthis->last_remote_ep = sthis->remote_ep;

--- a/mavros/README.md
+++ b/mavros/README.md
@@ -40,7 +40,8 @@ Supported schemas:
   - Serial: `serial:///path/to/serial/device[:baudrate][?ids=sysid,compid]`
   - Serial with hardware flow control: `serial-hwfc:///path/to/serial/device[:baudrate][?ids=sysid,compid]`
   - UDP: `udp://[bind_host][:port]@[remote_host[:port]][/?ids=sysid,compid]`
-  - UDP boroadcast: `udp-b://[bind_host][:port]@[:port][/?ids=sysid,compid]`
+  - UDP broadcast until GCS discovery: `udp-b://[bind_host][:port]@[:port][/?ids=sysid,compid]`
+  - UDP broadcast (permanent): `udp-pb://[bind_host][:port]@[:port][/?ids=sysid,compid]
   - TCP client: `tcp://[server_host][:port][/?ids=sysid,compid]`
   - TCP server: `tcp-l://[bind_host][:port][/?ids=sysid,compid]`
 


### PR DESCRIPTION
For now, the GCS bridge has a «UDP broadcast» mode, but this name is quite confusing, because it’s not real broadcasting. In fact, it’s just an automatic GCS discovery. 

But, for some environments, simple UDP broadcasting is preferable. For example:

1. It allows viewing and controlling the vehicle from multiple GCS simultaneously (tested)
2. Sometimes, it better fits multiple vehicles communications purposes (e. g. drone - charging station - GCS, drones swarms, etc)
3. It can be faster over Wi-Fi connections, because broadcasting doesn’t have Wi-Fi level acks (unlike of unicasting).

The protocol name (udp-bb) is quite random, can be discussed.