### PR TITLE
setpoint_velocity: fix yaw rate setpoint rotation

### DIFF
--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -94,7 +94,13 @@ private:
 			}
 		} ();
 
-		auto yr = ftf::transform_frame_baselink_aircraft(Eigen::Vector3d(0.0, 0.0, yaw_rate));
+		auto yr = [&] () {
+			if (mav_frame == MAV_FRAME::BODY_NED || mav_frame == MAV_FRAME::BODY_OFFSET_NED) {
+				return ftf::transform_frame_baselink_aircraft(Eigen::Vector3d(0.0, 0.0, yaw_rate));
+			} else {
+				return ftf::transform_frame_ned_enu(Eigen::Vector3d(0.0, 0.0, yaw_rate));
+			}
+		} ();
 
 		set_position_target_local_ned(stamp.toNSec() / 1000000,
 					utils::enum_value(mav_frame),


### PR DESCRIPTION
Similar to what is done with the linear velocity, this patch allows to apply the proper rotation to the yaw rate according to the frame of reference. *note:* PX4 only processes the yaw rate wrt to the local frame. This is already done properly in `setpoint_raw` plugin. 