### PR TITLE
gps_rtk: Fix wrong namespace (std->extras)

### DIFF
--- a/mavros_extras/src/plugins/gps_rtk.cpp
+++ b/mavros_extras/src/plugins/gps_rtk.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 
 namespace mavros {
-namespace std_plugins {
+namespace extra_plugins {
 /**
  * @brief GPS RTK plugin
  *
@@ -89,8 +89,8 @@ private:
 		}
 	}
 };
-}	// namespace std_plugins
+}	// namespace extra_plugins
 }	// namespace mavros
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::GpsRtkPlugin, mavros::plugin::PluginBase)
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::GpsRtkPlugin, mavros::plugin::PluginBase)


### PR DESCRIPTION
The namespace is wrong and has to be corrected to be loadable.