### PR TITLE
Add support for log transfer related messages

### DIFF
--- a/libmavconn/CMakeLists.txt
+++ b/libmavconn/CMakeLists.txt
@@ -96,7 +96,7 @@ install(DIRECTORY cmake/Modules
 if(CATKIN_ENABLE_TESTING)
 
 catkin_add_gtest(mavconn-test test/test_mavconn.cpp)
-target_link_libraries(mavconn-test mavconn)
+target_link_libraries(mavconn-test mavconn pthread)
 
 endif()
 

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(mavros_extras
   src/plugins/distance_sensor.cpp
   src/plugins/fake_gps.cpp
   src/plugins/gps_rtk.cpp
+  src/plugins/log_transfer.cpp
   src/plugins/mocap_pose_estimate.cpp
   src/plugins/obstacle_distance.cpp
   src/plugins/odom.cpp

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -17,6 +17,9 @@
 	<class name="gps_rtk" type="mavros::extra_plugins::GpsRtkPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Sends the RTCM messages to the FCU for the RTK Fix.</description>
 	</class>
+	<class name="log_transfer" type="mavros::extra_plugins::LogTransferPlugin" base_class_type="mavros::plugin::PluginBase">
+		 <description>Expose firmware functionality, that is related to log transfer</description>
+	</class>
 	<class name="mocap_pose_estimate" type="mavros::extra_plugins::MocapPoseEstimatePlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Send motion capture pose estimate to FCU.</description>
 	</class>

--- a/mavros_extras/src/plugins/log_transfer.cpp
+++ b/mavros_extras/src/plugins/log_transfer.cpp
@@ -1,0 +1,125 @@
+#include <mavros/mavros_plugin.h>
+#include <mavros_msgs/LogData.h>
+#include <mavros_msgs/LogEntry.h>
+#include <mavros_msgs/LogRequestData.h>
+#include <mavros_msgs/LogRequestEnd.h>
+#include <mavros_msgs/LogRequestList.h>
+
+namespace mavros {
+namespace extra_plugins {
+class LogTransferPlugin : public plugin::PluginBase {
+public:
+	LogTransferPlugin() :
+		nh("~log_transfer") {}
+
+	void initialize(UAS& uas) override
+	{
+		PluginBase::initialize(uas);
+
+		log_entry_pub = nh.advertise<mavros_msgs::LogEntry>("raw/log_entry", 1000);
+		log_data_pub = nh.advertise<mavros_msgs::LogData>("raw/log_data", 1000);
+
+		log_request_list_srv = nh.advertiseService("raw/log_request_list",
+					&LogTransferPlugin::log_request_list_cb, this);
+		log_request_data_srv = nh.advertiseService("raw/log_request_data",
+					&LogTransferPlugin::log_request_data_cb, this);
+		log_request_end_srv = nh.advertiseService("raw/log_request_end",
+					&LogTransferPlugin::log_request_end_cb, this);
+	}
+
+	Subscriptions get_subscriptions() override
+	{
+		return {
+			       make_handler(&LogTransferPlugin::handle_log_entry),
+			       make_handler(&LogTransferPlugin::handle_log_data),
+		};
+	}
+
+private:
+	ros::NodeHandle nh;
+	ros::Publisher log_entry_pub, log_data_pub;
+	ros::ServiceServer log_request_list_srv, log_request_data_srv, log_request_end_srv;
+
+	void handle_log_entry(const mavlink::mavlink_message_t*, mavlink::common::msg::LOG_ENTRY& le)
+	{
+		mavros_msgs::LogEntry msg;
+		msg.id = le.id;
+		msg.num_logs = le.num_logs;
+		msg.last_log_num = le.last_log_num;
+		msg.time_utc = ros::Time(le.time_utc);
+		msg.size = le.size;
+		log_entry_pub.publish(msg);
+	}
+
+	void handle_log_data(const mavlink::mavlink_message_t*, mavlink::common::msg::LOG_DATA& ld)
+	{
+		mavros_msgs::LogData msg;
+		msg.id = ld.id;
+		msg.offset = ld.ofs;
+
+		decltype(ld.data) ::size_type count(ld.count);
+		if (count > ld.data.max_size()) {
+			count = ld.data.max_size();
+		}
+		msg.data.insert(msg.data.cbegin(), ld.data.cbegin(), ld.data.cbegin() + count);
+		log_data_pub.publish(msg);
+	}
+
+	bool log_request_list_cb(mavros_msgs::LogRequestList::Request &req,
+				mavros_msgs::LogRequestList::Response &res)
+	{
+		mavlink::common::msg::LOG_REQUEST_LIST msg;
+		msg.target_system = m_uas->get_tgt_system();
+		msg.target_component = m_uas->get_tgt_component();
+		msg.start = req.start;
+		msg.end = req.end;
+
+		res.success = true;
+		try {
+			UAS_FCU(m_uas)->send_message(msg);
+		} catch (std::length_error&) {
+			res.success = false;
+		}
+		return true;
+	}
+
+	bool log_request_data_cb(mavros_msgs::LogRequestData::Request &req,
+				mavros_msgs::LogRequestData::Response &res)
+	{
+		mavlink::common::msg::LOG_REQUEST_DATA msg;
+		msg.target_system = m_uas->get_tgt_system();
+		msg.target_component = m_uas->get_tgt_component();
+		msg.id = req.id;
+		msg.ofs = req.offset;
+		msg.count = req.count;
+
+		res.success = true;
+		try {
+			UAS_FCU(m_uas)->send_message(msg);
+		} catch (std::length_error&) {
+			res.success = false;
+		}
+		return true;
+	}
+
+	bool log_request_end_cb(mavros_msgs::LogRequestEnd::Request &,
+				mavros_msgs::LogRequestEnd::Response &res)
+	{
+		mavlink::common::msg::LOG_REQUEST_END msg;
+		msg.target_system = m_uas->get_tgt_system();
+		msg.target_component = m_uas->get_tgt_component();
+
+		res.success = true;
+		try {
+			UAS_FCU(m_uas)->send_message(msg);
+		} catch (std::length_error&) {
+			res.success = false;
+		}
+		return true;
+	}
+};
+}	// namespace extra_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::LogTransferPlugin, mavros::plugin::PluginBase)

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -25,6 +25,8 @@ add_message_files(
   HilSensor.msg
   HilStateQuaternion.msg
   HomePosition.msg
+  LogData.msg
+  LogEntry.msg
   ManualControl.msg
   Mavlink.msg
   OpticalFlowRad.msg
@@ -67,6 +69,9 @@ add_service_files(
   FileRename.srv
   FileTruncate.srv
   FileWrite.srv
+  LogRequestData.srv
+  LogRequestEnd.srv
+  LogRequestList.srv
   ParamGet.srv
   ParamPull.srv
   ParamPush.srv

--- a/mavros_msgs/msg/LogData.msg
+++ b/mavros_msgs/msg/LogData.msg
@@ -4,6 +4,8 @@
 #  :offset: - offset into the log
 #  :data: - chunk of data (if zero-sized, then there are no more chunks)
 
+std_msgs/Header header
+
 uint16 id
 uint16 offset
 uint8[] data

--- a/mavros_msgs/msg/LogData.msg
+++ b/mavros_msgs/msg/LogData.msg
@@ -1,0 +1,9 @@
+# Reply to LogRequestData, - a chunk of a log
+#
+#  :id: - log id
+#  :offset: - offset into the log
+#  :data: - chunk of data (if zero-sized, then there are no more chunks)
+
+uint16 id
+uint16 offset
+uint8[] data

--- a/mavros_msgs/msg/LogEntry.msg
+++ b/mavros_msgs/msg/LogEntry.msg
@@ -1,0 +1,13 @@
+# Information about a single log
+#
+#  :id: - log id
+#  :num_logs: - total number of logs
+#  :last_log_num: - id of last log
+#  :time_utc: - UTC timestamp of log (ros::Time(0) if not available)
+#  :size: - size of log in bytes (may be approximate)
+
+uint16 id
+uint16 num_logs
+uint16 last_log_num
+time time_utc
+uint32 size

--- a/mavros_msgs/msg/LogEntry.msg
+++ b/mavros_msgs/msg/LogEntry.msg
@@ -6,6 +6,8 @@
 #  :time_utc: - UTC timestamp of log (ros::Time(0) if not available)
 #  :size: - size of log in bytes (may be approximate)
 
+std_msgs/Header header
+
 uint16 id
 uint16 num_logs
 uint16 last_log_num

--- a/mavros_msgs/srv/LogRequestData.srv
+++ b/mavros_msgs/srv/LogRequestData.srv
@@ -1,0 +1,11 @@
+# Request a chunk of a log
+#
+#  :id: - log id from LogEntry message
+#  :offset: - offset into the log
+#  :count: - number of bytes to get
+
+uint16 id
+uint32 offset
+uint32 count
+---
+bool success

--- a/mavros_msgs/srv/LogRequestEnd.srv
+++ b/mavros_msgs/srv/LogRequestEnd.srv
@@ -1,0 +1,4 @@
+# Stop log transfer and resume normal logging
+
+---
+bool success

--- a/mavros_msgs/srv/LogRequestList.srv
+++ b/mavros_msgs/srv/LogRequestList.srv
@@ -1,0 +1,9 @@
+# Request a list of available logs
+#
+#  :start: - first log id (0 for first available)
+#  :end: - last log id (0xffff for last available)
+
+uint16 start
+uint16 end
+---
+bool success


### PR DESCRIPTION
This adds basic support for messages, that allow to implement efficient log transfer even for very large log files. These messages are used by QGroundControl to download log files, but there are times, when using QGC to download logs is inappropriate. For example, when one is conducting automated testing of UAVs (without human intervention).

The endpoints (services, topics) are called `raw/...`, because I intend to add "high-level" functionality, that will add convenient abstraction over this functionality. That abstraction, however, needs not be a part of this request.