### PR TITLE
setpoint_raw/target_attitude bodyrate commands should be converted to NED from ENU

### DIFF
--- a/mavros/src/plugins/setpoint_raw.cpp
+++ b/mavros/src/plugins/setpoint_raw.cpp
@@ -217,18 +217,18 @@ private:
 	void attitude_cb(const mavros_msgs::AttitudeTarget::ConstPtr &req)
 	{
 		Eigen::Quaterniond desired_orientation;
-		Eigen::Vector3d baselink_angular_rate;
+		Eigen::Vector3d desired_angular_rate;
 
 		tf::quaternionMsgToEigen(req->orientation, desired_orientation);
+
+		tf::vectorMsgToEigen(req->body_rate, desired_angular_rate);
 
 		// Transform desired orientation to represent aircraft->NED,
 		// MAVROS operates on orientation of base_link->ENU
 		auto ned_desired_orientation = ftf::transform_orientation_enu_ned(
 					ftf::transform_orientation_baselink_aircraft(desired_orientation));
 
-		auto body_rate = ftf::transform_frame_baselink_aircraft(baselink_angular_rate);
-
-		tf::vectorMsgToEigen(req->body_rate, body_rate);
+		auto body_rate = ftf::transform_frame_ned_enu(ftf::transform_frame_baselink_aircraft(desired_angular_rate));
 
 		set_attitude_target(
 					req->header.stamp.toNSec() / 1000000,


### PR DESCRIPTION
This PR fixes a coordinate frame mismatch of the setpoint_raw/target_attitude.

The current setpoint_raw/target_attitude body_rate commands directly sends the bodyrate commands from the ROS coordinate system(ENU) without converting it to NED->roll pitch yaw rate commands.