### PR TITLE
Fix std::bad_weak_ptr in mavconn-test

### DIFF
--- a/libmavconn/include/mavconn/tcp.h
+++ b/libmavconn/include/mavconn/tcp.h
@@ -70,6 +70,8 @@ private:
 	boost::asio::ip::tcp::socket socket;
 	boost::asio::ip::tcp::endpoint server_ep;
 
+	std::atomic<bool> is_destroying;
+
 	std::atomic<bool> tx_in_progress;
 	std::deque<MsgBuffer> tx_q;
 	std::array<uint8_t, MsgBuffer::MAX_SIZE> rx_buf;
@@ -122,6 +124,8 @@ private:
 
 	boost::asio::ip::tcp::acceptor acceptor;
 	boost::asio::ip::tcp::endpoint bind_ep;
+
+	std::atomic<bool> is_destroying;
 
 	std::list<std::shared_ptr<MAVConnTCPClient> > client_list;
 	std::recursive_mutex mutex;


### PR DESCRIPTION
When attempting to run mavros tests on my machine (Ubuntu 16.04.10, GCC 5.4.0, ROS kinetic), I see mavconn-test failing like this:

```
Error:   mavconn: tcp18: receive: End of fileterminate called after throwing an instance of '
         at line std::bad_weak_ptr'
219 in /home/mlvov/ros/ws/src/libmavconn/src/tcp.cpp
  what():  bad_weak_ptr
Aborted (core dumped)
```

When I examined it with gdb, I've learned, that bad_weak_ptr is thrown from `shared_from_this`

```
(gdb) run
Starting program: /home/mlvov/ros/ws/devel/lib/libmavconn/mavconn-test --gtest_filter=TCP.client_reconnect
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Note: Google Test filter = TCP.client_reconnect
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TCP
[ RUN      ] TCP.client_reconnect
[New Thread 0x7ffff6825700 (LWP 15147)]
[New Thread 0x7ffff5e12700 (LWP 15148)]
[New Thread 0x7ffff5611700 (LWP 15149)]
[Switching to Thread 0x7ffff5e12700 (LWP 15148)]

Thread 3 "mtcp1" hit Catchpoint 1 (exception thrown), 0x00007ffff73a18bd in __cxa_throw ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
(gdb) bt
#0  0x00007ffff73a18bd in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x00007ffff7b5fab6 in std::__throw_bad_weak_ptr() () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#2  0x00007ffff7b6bbc0 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count(std::__weak_count<(__gnu_cxx::_Lock_policy)2> const&) () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#3  0x00007ffff7b8a8bb in std::__shared_ptr<mavconn::MAVConnTCPClient, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<mavconn::MAVConnTCPClient>(std::__weak_ptr<mavconn::MAVConnTCPClient, (__gnu_cxx::_Lock_policy)2> const&) () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#4  0x00007ffff7b88765 in std::shared_ptr<mavconn::MAVConnTCPClient>::shared_ptr<mavconn::MAVConnTCPClient>(std::weak_ptr<mavconn::MAVConnTCPClient> const&) () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#5  0x00007ffff7b86d55 in std::enable_shared_from_this<mavconn::MAVConnTCPClient>::shared_from_this() ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#6  0x00007ffff7b7f3ac in mavconn::MAVConnTCPClient::do_recv() ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#7  0x00007ffff7b8f117 in void std::_Mem_fn_base<void (mavconn::MAVConnTCPClient::*)(), true>::operator()<, void>(mavconn::MAVConnTCPClient*) const () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#8  0x00007ffff7b8ebf9 in void std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#9  0x00007ffff7b8e4c3 in void std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)>::operator()<, void>() () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#10 0x00007ffff7b8d80c in void boost::asio::asio_handler_invoke<std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)> >(std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)>&, ...) () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#11 0x00007ffff7b8cb30 in void boost_asio_handler_invoke_helpers::invoke<std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)>, std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)> >(std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)>&, std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)>&) () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#12 0x00007ffff7b8bbdf in boost::asio::detail::completion_handler<std::_Bind<std::_Mem_fn<void (mavconn::MAVConnTCPClient::*)()> (mavconn::MAVConnTCPClient*)> >::do_complete(boost::asio::detail::task_io_service*, boost::asio::detail::task_io_service_operation*, boost::system::error_code const&, unsigned long) ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#13 0x00007ffff7b60b80 in boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#14 0x00007ffff7b6370d in boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code const&) () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#15 0x00007ffff7b63131 in boost::asio::detail::task_io_service::run(boost::system::error_code&) ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#16 0x00007ffff7b639d4 in boost::asio::io_service::run() ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#17 0x00007ffff7b7df7a in mavconn::MAVConnTCPClient::MAVConnTCPClient(unsigned char, unsigned char, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned short)::{lambda()#1}::operator()() const () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#18 0x00007ffff7b84cee in void std::_Bind_simple<mavconn::MAVConnTCPClient::MAVConnTCPClient(unsigned char, unsigned char, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned short)::{lambda()#1} ()>::_M_invoke<>(std::_Index_tuple<>) ()
   from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#19 0x00007ffff7b84bb2 in std::_Bind_simple<mavconn::MAVConnTCPClient::MAVConnTCPClient(unsigned char, unsigned char, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned short)::{lambda()#1} ()>::operator()() () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#20 0x00007ffff7b84abc in std::thread::_Impl<std::_Bind_simple<mavconn::MAVConnTCPClient::MAVConnTCPClient(unsigned char, unsigned char, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned short)::{lambda()#1} ()> >::_M_run() () from /home/mlvov/ros/ws/devel/lib/libmavconn.so
#21 0x00007ffff73ccc80 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
---Type <return> to continue, or q <return> to quit---
#22 0x00007ffff78a16ba in start_thread (arg=0x7ffff5e12700) at pthread_create.c:333
#23 0x00007ffff6e3b41d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

Further examination revealed that this particular case happens when an instance of MAVConnTCPClient's destructor is called before MAVConnTCPClient::do_recv gets the chance to run at least once. When do_recv _does get_ the chance to run, there's no more std::shared_ptr pointing to `this`, so `shared_from_this` throws std::bad_weak_ptr (as per the standard).

This PR fixes this particular problem, but I feel, that the problem might resurface in some other way, since the destructors for TCP server and TCP client are extremely non-trivial and there might still be a case, when `shared_from_this` is called after the call to the destructor is made. 

It is quite possible, that the problem described in https://github.com/mavlink/mavros/issues/937# are also related to usage of shared_from_this at an inappropriate time.