### PR TITLE
launch: remove mocap_pose_estimate from apm blacklist

### DIFF
--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -8,7 +8,6 @@ plugin_blacklist:
 - altitude
 - debug_value
 - image_pub
-- mocap_pose_estimate
 - px4flow
 - vibration
 - vision_speed_estimate


### PR DESCRIPTION
This resolves [this issue](https://github.com/mavlink/mavros/issues/1080) by enabling the mocap_pose_estimate plugin.

The mocap_pose_estimate has been tested ([video](https://www.youtube.com/watch?v=P3qllsrt-_M), [blog](https://discuss.ardupilot.org/t/indoor-flight-with-external-navigation-data/29980)) and shown to work well.