### PR TITLE
udp: bind should be called after reuse_address is set

### DIFF
--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -101,12 +101,13 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 
 	try {
 		socket.open(udp::v4());
-		socket.bind(bind_ep);
 
 		// set buffer opt. size from QGC
 		socket.set_option(udps::reuse_address(true));
 		socket.set_option(udps::send_buffer_size(256_KiB));
 		socket.set_option(udps::receive_buffer_size(512_KiB));
+
+		socket.bind(bind_ep);
 
 		if (remote_host == BROADCAST_REMOTE_HOST) {
 			socket.set_option(udps::broadcast(true));


### PR DESCRIPTION
Fixes #1095 