### PR TITLE
Fix of trigger setup and control via mavlink cmd interface 

### DIFF
--- a/mavros/src/mavros/command.py
+++ b/mavros/src/mavros/command.py
@@ -20,7 +20,7 @@ __all__ = (
 import rospy
 import mavros
 
-from mavros_msgs.srv import CommandLong, CommandInt, CommandBool, CommandHome, CommandTOL, CommandTriggerControl
+from mavros_msgs.srv import CommandLong, CommandInt, CommandBool, CommandHome, CommandTOL, CommandTriggerControl, CommandTriggerInterval
 
 
 def _get_proxy(service, type):
@@ -45,6 +45,7 @@ def _setup_services():
     takeoff = _get_proxy('takeoff', CommandTOL)
     land = _get_proxy('land', CommandTOL)
     trigger_control = _get_proxy('trigger_control', CommandTriggerControl)
+    trigger_interval = _get_proxy('trigger_interval', CommandTriggerInterval)
 
 
 # register updater

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -58,6 +58,7 @@ add_service_files(
   CommandLong.srv
   CommandTOL.srv
   CommandTriggerControl.srv
+  CommandTriggerInterval.srv
   FileChecksum.srv
   FileClose.srv
   FileList.srv

--- a/mavros_msgs/srv/CommandTriggerControl.srv
+++ b/mavros_msgs/srv/CommandTriggerControl.srv
@@ -1,7 +1,8 @@
-# Type for controlling onboard camera trigerring system
+# Type for controlling onboard camera triggering system
 
-bool    trigger_enable		# Trigger on/off control
-float32 cycle_time		# Camera trigger cycle time. Zero to use current onboard value.
+bool    trigger_enable		# Trigger enable/disable
+bool    sequence_reset		# Reset the trigger sequence
+bool    trigger_pause		# Pause triggering, but without switching the camera off or retracting it.
 ---
 bool success
 uint8 result

--- a/mavros_msgs/srv/CommandTriggerInterval.srv
+++ b/mavros_msgs/srv/CommandTriggerInterval.srv
@@ -1,0 +1,7 @@
+# Type for controlling camera trigger interval and integration time
+
+float32   cycle_time			# Trigger cycle_time (interval between to triggers) - set to 0 to ignore command
+float32   integration_time	# Camera shutter integration_time - set to 0 to ignore command
+---
+bool success
+uint8 result


### PR DESCRIPTION
Adapt trigger_control service to current mavlink cmd spec. Add a new service to change trigger interval and integration time.

Fixes #987
@mhkabir 