### PR TITLE
with this fix ,it will avoid eigen error on 32 bits system

### DIFF
--- a/mavros/src/plugins/hil.cpp
+++ b/mavros/src/plugins/hil.cpp
@@ -42,7 +42,7 @@ public:
 	HilPlugin() : PluginBase(),
 		hil_nh("~hil")
 	{ }
-
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 	void initialize(UAS &uas_)
 	{
 		PluginBase::initialize(uas_);


### PR DESCRIPTION
The issue and the solution I have reported here#1110 .
Here is the flexible way to avoid the eigen not perfectly aligned issue on 32 bits system.If you libeigen support SSE packet, you will need this fix on your board.

[http://eigen.tuxfamily.org/dox-devel/group__TopicStructHavingEigenMembers.html](url)here explain why this fix is needed, and why it can also fit X86-X64system.

In addition,the version is pasted here :ROS distro is above Lunar ,and GCC is above 5.4 and libeigen3 is above 3.3.4-4