### PR TITLE
libmavconn: add the possibility to override the source component ID

### DIFF
--- a/libmavconn/include/mavconn/interface.h
+++ b/libmavconn/include/mavconn/interface.h
@@ -144,7 +144,22 @@ public:
 	 * @throws std::length_error  On exceeding Tx queue limit (MAX_TXQ_SIZE)
 	 * @param[in] &message  not changed
 	 */
-	virtual void send_message(const mavlink::Message &message) = 0;
+	virtual void send_message(const mavlink::Message &message) {
+		send_message(message, this->comp_id);
+	}
+
+	/**
+	 * @brief Send message (child of mavlink::Message)
+	 *
+	 * Does serialization inside.
+	 * System ID = from this object.
+	 * Component ID passed by argument.
+	 *
+	 * @throws std::length_error  On exceeding Tx queue limit (MAX_TXQ_SIZE)
+	 * @param[in] &message  not changed
+	 * @param[in] src_compid  sets the component ID of the message source
+	 */
+	virtual void send_message(const mavlink::Message &message, const uint8_t src_compid) = 0;
 
 	/**
 	 * @brief Send raw bytes (for some quirks)
@@ -159,8 +174,20 @@ public:
 
 	/**
 	 * @brief Send message and ignore possible drop due to Tx queue limit
+	 *
+	 * System and Component ID = from this object.
 	 */
-	void send_message_ignore_drop(const mavlink::Message &message);
+	void send_message_ignore_drop(const mavlink::Message &message) {
+		send_message_ignore_drop(message, this->comp_id);
+	}
+
+	/**
+	 * @brief Send message and ignore possible drop due to Tx queue limit
+	 *
+	 * System ID = from this object.
+	 * Component ID passed by argument.
+	 */
+	void send_message_ignore_drop(const mavlink::Message &message, const uint8_t src_compid);
 
 	//! Message receive callback
 	ReceivedCb message_received_cb;

--- a/libmavconn/include/mavconn/msgbuffer.h
+++ b/libmavconn/include/mavconn/msgbuffer.h
@@ -92,4 +92,3 @@ struct MsgBuffer {
 	}
 };
 }	// namespace mavconn
-

--- a/libmavconn/include/mavconn/serial.h
+++ b/libmavconn/include/mavconn/serial.h
@@ -45,7 +45,7 @@ public:
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;
-	void send_message(const mavlink::Message &message) override;
+	void send_message(const mavlink::Message &message, const uint8_t source_compid) override;
 	void send_bytes(const uint8_t *bytes, size_t length) override;
 
 	inline bool is_open() override {
@@ -66,4 +66,3 @@ private:
 	void do_write(bool check_tx_state);
 };
 }	// namespace mavconn
-

--- a/libmavconn/include/mavconn/tcp.h
+++ b/libmavconn/include/mavconn/tcp.h
@@ -54,7 +54,7 @@ public:
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;
-	void send_message(const mavlink::Message &message) override;
+	void send_message(const mavlink::Message &message, const uint8_t source_compid) override;
 	void send_bytes(const uint8_t *bytes, size_t length) override;
 
 	inline bool is_open() override {
@@ -108,7 +108,7 @@ public:
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;
-	void send_message(const mavlink::Message &message) override;
+	void send_message(const mavlink::Message &message, const uint8_t source_compid) override;
 	void send_bytes(const uint8_t *bytes, size_t length) override;
 
 	mavlink::mavlink_status_t get_status() override;
@@ -137,4 +137,3 @@ private:
 	void recv_message(const mavlink::mavlink_message_t *message, const Framing framing);
 };
 }	// namespace mavconn
-

--- a/libmavconn/include/mavconn/udp.h
+++ b/libmavconn/include/mavconn/udp.h
@@ -53,7 +53,7 @@ public:
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;
-	void send_message(const mavlink::Message &message) override;
+	void send_message(const mavlink::Message &message, const uint8_t source_compid) override;
 	void send_bytes(const uint8_t *bytes, size_t length) override;
 
 	inline bool is_open() override {
@@ -82,4 +82,3 @@ private:
 	void do_sendto(bool check_tx_state);
 };
 }	// namespace mavconn
-

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -168,10 +168,10 @@ void MAVConnInterface::send_message_ignore_drop(const mavlink::mavlink_message_t
 	}
 }
 
-void MAVConnInterface::send_message_ignore_drop(const mavlink::Message &msg)
+void MAVConnInterface::send_message_ignore_drop(const mavlink::Message &msg, uint8_t source_compid)
 {
 	try {
-		send_message(msg);
+		send_message(msg, source_compid);
 	}
 	catch (std::length_error &e) {
 		CONSOLE_BRIDGE_logError(PFX "%zu: DROPPED Message %s: %s",

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -184,7 +184,7 @@ void MAVConnSerial::send_message(const mavlink_message_t *message)
 	io_service.post(std::bind(&MAVConnSerial::do_write, shared_from_this(), true));
 }
 
-void MAVConnSerial::send_message(const mavlink::Message &message)
+void MAVConnSerial::send_message(const mavlink::Message &message, const uint8_t source_compid)
 {
 	if (!is_open()) {
 		CONSOLE_BRIDGE_logError(PFXd "send: channel closed!", conn_id);
@@ -199,7 +199,7 @@ void MAVConnSerial::send_message(const mavlink::Message &message)
 		if (tx_q.size() >= MAX_TXQ_SIZE)
 			throw std::length_error("MAVConnSerial::send_message: TX queue overflow");
 
-		tx_q.emplace_back(message, get_status_p(), sys_id, comp_id);
+		tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
 	}
 	io_service.post(std::bind(&MAVConnSerial::do_write, shared_from_this(), true));
 }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -191,7 +191,7 @@ void MAVConnTCPClient::send_message(const mavlink_message_t *message)
 	socket.get_io_service().post(std::bind(&MAVConnTCPClient::do_send, shared_from_this(), true));
 }
 
-void MAVConnTCPClient::send_message(const mavlink::Message &message)
+void MAVConnTCPClient::send_message(const mavlink::Message &message, const uint8_t source_compid)
 {
 	if (!is_open()) {
 		CONSOLE_BRIDGE_logError(PFXd "send: channel closed!", conn_id);
@@ -206,7 +206,7 @@ void MAVConnTCPClient::send_message(const mavlink::Message &message)
 		if (tx_q.size() >= MAX_TXQ_SIZE)
 			throw std::length_error("MAVConnTCPClient::send_message: TX queue overflow");
 
-		tx_q.emplace_back(message, get_status_p(), sys_id, comp_id);
+		tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
 	}
 	socket.get_io_service().post(std::bind(&MAVConnTCPClient::do_send, shared_from_this(), true));
 }
@@ -397,11 +397,11 @@ void MAVConnTCPServer::send_message(const mavlink_message_t *message)
 	}
 }
 
-void MAVConnTCPServer::send_message(const mavlink::Message &message)
+void MAVConnTCPServer::send_message(const mavlink::Message &message, const uint8_t source_compid)
 {
 	lock_guard lock(mutex);
 	for (auto &instp : client_list) {
-		instp->send_message(message);
+		instp->send_message(message, source_compid);
 	}
 }
 

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -208,7 +208,7 @@ void MAVConnUDP::send_message(const mavlink_message_t *message)
 	io_service.post(std::bind(&MAVConnUDP::do_sendto, shared_from_this(), true));
 }
 
-void MAVConnUDP::send_message(const mavlink::Message &message)
+void MAVConnUDP::send_message(const mavlink::Message &message, const uint8_t source_compid)
 {
 	if (!is_open()) {
 		CONSOLE_BRIDGE_logError(PFXd "send: channel closed!", conn_id);
@@ -228,7 +228,7 @@ void MAVConnUDP::send_message(const mavlink::Message &message)
 		if (tx_q.size() >= MAX_TXQ_SIZE)
 			throw std::length_error("MAVConnUDP::send_message: TX queue overflow");
 
-		tx_q.emplace_back(message, get_status_p(), sys_id, comp_id);
+		tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
 	}
 	io_service.post(std::bind(&MAVConnUDP::do_sendto, shared_from_this(), true));
 }


### PR DESCRIPTION
This PR adds the possibility to override the source component ID through the `send_message()` and `send_message_ignore_drop()` methods. This allows one to set the specific component ID for each message being sent, which is useful for use cases as https://github.com/mavlink/mavros/pull/1118, where one wants to check the status of certain processes on a companion computer.

@baumanta @thomasgubler this should address what you are looking for. The way you can set this is by adding the respective ID to https://github.com/mavlink/mavros/pull/1118/files#diff-8aa5199f38db01aa1a7258093d338c99R78,
```c++
UAS_FCU(m_uas)->send_message_ignore_drop(heartbeat, proc_id);
```
where the `proc_id` matches the ID you set for a certain process running on the companion computer. Note that this ID should be higher than 1 (and lower than 255).