### PR TITLE
apm_config: enable timesync and system for ardupilot

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -9,8 +9,8 @@ startup_px4_usb_quirk: false
 conn:
   heartbeat_rate: 1.0    # send hertbeat rate in Hertz
   timeout: 10.0          # hertbeat timeout in seconds
-  timesync_rate: 0.0     # TIMESYNC rate in Hertz (feature disabled if 0.0)
-  system_time_rate: 0.0  # send system time to FCU rate in Hertz (disabled if 0.0)
+  timesync_rate: 10.0    # TIMESYNC rate in Hertz (feature disabled if 0.0)
+  system_time_rate: 1.0  # send system time to FCU rate in Hertz (disabled if 0.0)
 
 # sys_status
 sys:
@@ -20,7 +20,7 @@ sys:
 # sys_time
 time:
   time_ref_source: "fcu"  # time_reference source
-  timesync_mode: NONE
+  timesync_mode: MAVLINK
   timesync_avg_alpha: 0.6 # timesync averaging factor
 
 # --- mavros plugins (alphabetical order) ---


### PR DESCRIPTION
ArduPilot has added support for handling of the TIMESYNC and SYSTEM_TIME messages and it seems to be working.

- documentation on the setup is [here on the AP developer wiki](ardupilot.org/dev/docs/ros-timesync.html) (should be visible about 10min after this PR was submitted)
- below is an image of the clocks syncronised between a TX2 companion computer and a Cube flight controller.

![ros-time-sync-testing](https://user-images.githubusercontent.com/1498098/48745653-96e7b680-ecaf-11e8-8a27-13c3f3fdb928.png)
