### PR TITLE
Fix mavros/param.py to work in python2 and python3, #940

### DIFF
--- a/mavros/src/mavros/param.py
+++ b/mavros/src/mavros/param.py
@@ -11,7 +11,6 @@ import csv
 import time
 import rospy
 import mavros
-import functools
 
 from mavros_msgs.msg import ParamValue
 from mavros_msgs.srv import ParamPull, ParamPush, ParamGet, ParamSet

--- a/mavros/src/mavros/param.py
+++ b/mavros/src/mavros/param.py
@@ -7,10 +7,14 @@
 # in the top-level LICENSE file of the mavros repository.
 # https://github.com/mavlink/mavros/tree/master/LICENSE.md
 
+from future.utils import viewitems
+from past.builtins import cmp
+
 import csv
 import time
 import rospy
 import mavros
+import functools
 
 from mavros_msgs.msg import ParamValue
 from mavros_msgs.srv import ParamPull, ParamPush, ParamGet, ParamSet
@@ -164,8 +168,8 @@ def param_get_all(force_pull=False):
     params = rospy.get_param(mavros.get_topic('param'))
 
     return (ret.param_received,
-            sorted((Parameter(k, v) for k, v in params.iteritems()),
-                   cmp=lambda x, y: cmp(x.param_id, y.param_id))
+            sorted((Parameter(k, v) for k, v in viewitems(params)),
+                   key=functools.cmp_to_key(lambda x, y: cmp(x.param_id, y.param_id)))
             )
 
 

--- a/mavros/src/mavros/param.py
+++ b/mavros/src/mavros/param.py
@@ -7,9 +7,6 @@
 # in the top-level LICENSE file of the mavros repository.
 # https://github.com/mavlink/mavros/tree/master/LICENSE.md
 
-from future.utils import viewitems
-from past.builtins import cmp
-
 import csv
 import time
 import rospy
@@ -168,8 +165,8 @@ def param_get_all(force_pull=False):
     params = rospy.get_param(mavros.get_topic('param'))
 
     return (ret.param_received,
-            sorted((Parameter(k, v) for k, v in viewitems(params)),
-                   key=functools.cmp_to_key(lambda x, y: cmp(x.param_id, y.param_id)))
+            sorted((Parameter(k, v) for k, v in params.items()),
+                   key=lambda p: p.param_id)
             )
 
 


### PR DESCRIPTION
Small fixes to param.py to allow mavros to be called from python2 and python3 scripts