### PR TITLE
Fixed NavSatFix bug in mavcmd takeoffcur and landcur

### DIFF
--- a/mavros/src/mavros/__init__.py
+++ b/mavros/src/mavros/__init__.py
@@ -50,4 +50,4 @@ def get_topic(*args):
     """
     Create topic name for mavros node
     """
-    return '/'.join((get_namespace(), ) + args)
+    return '/'+'/'.join((get_namespace(), ) + args)


### PR DESCRIPTION
Found the bug when getting "NavSatFix topic not exist" when calling mavcmd takeoffcur and landcur. In mavcmd there are calls to `_find_gps_topic(args, op_name)`. The function starts by calling:
`global_fix = mavros.get_topic('global_position', 'global')
gps_fix = mavros.get_topic('global_position', 'raw', 'fix')`
and then does a string compare using `==`. The mavros function returns topics without preceding `/` but the topics listed by `rospy.get_published_topics()` all have a preceding `/` so the string compare fails. I prepended the `/` in mavros/__init__.py's get_topic and the functions seem to work now.
