### PR TITLE
odom: add ODOMETRY handler and ROS publisher

### DIFF
--- a/mavros/include/mavros/frame_tf.h
+++ b/mavros/include/mavros/frame_tf.h
@@ -380,9 +380,10 @@ inline void covariance_urt_to_mavlink(const T &covmap, std::array<float, ARR_SIZ
 
 	auto out = covmsg.begin();
 
-	for (size_t x = 0; x < m.cols(); x++)
+	for (size_t x = 0; x < m.cols(); x++) {
 		for (size_t y = x; y < m.rows(); y++)
 			*out++ = m(y, x);
+	}
 }
 
 /**
@@ -399,11 +400,12 @@ inline void mavlink_urt_to_covariance_matrix(const std::array<float, ARR_SIZE> &
 
 	auto in = covmsg.begin();
 
-	for (size_t x = 0; x < covmat.cols(); x++)
-		for (size_t y = x; y < covmat.rows(); y++)
-			covmat(y, x) = static_cast<double>(*in++);
-
-	//TODO: make the matrix symmetric
+	for (size_t x = 0; x < covmat.cols(); x++) {
+		for (size_t y = x; y < covmat.rows(); y++) {
+			covmat(x, y) = static_cast<double>(*in++);
+			covmat(y, x) = covmat(x, y);
+		}
+	}
 }
 
 // [[[cog:

--- a/mavros/include/mavros/frame_tf.h
+++ b/mavros/include/mavros/frame_tf.h
@@ -385,6 +385,27 @@ inline void covariance_urt_to_mavlink(const T &covmap, std::array<float, ARR_SIZ
 			*out++ = m(y, x);
 }
 
+/**
+ * @brief Convert MAVLink float[n] format (upper right triangular of a covariance matrix)
+ * to Eigen::MatrixXd<n,n> full covariance matrix
+ */
+template<class T, std::size_t ARR_SIZE>
+inline void mavlink_urt_to_covariance_matrix(const std::array<float, ARR_SIZE> &covmsg, T &covmat)
+{
+	std::size_t COV_SIZE = covmat.rows() * (covmat.rows() + 1) / 2;
+	ROS_ASSERT_MSG(COV_SIZE == ARR_SIZE,
+				"frame_tf: covariance matrix URT size (%lu) is different from Mavlink msg covariance field size (%lu)",
+				COV_SIZE, ARR_SIZE);
+
+	auto in = covmsg.begin();
+
+	for (size_t x = 0; x < covmat.cols(); x++)
+		for (size_t y = x; y < covmat.rows(); y++)
+			covmat(y, x) = static_cast<double>(*in++);
+
+	//TODO: make the matrix symmetric
+}
+
 // [[[cog:
 // def make_to_eigen(te, tr, fields):
 //     cog.outl("""//! @brief Helper to convert common ROS geometry_msgs::{tr} to Eigen::{te}""".format(**locals()))

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -192,12 +192,19 @@ mocap:
 
 # odom
 odometry:
-  frame_tf:
-    # available: check MAV_FRAME odometry local frames in
-    # http://mavlink.org/messages/common
-    local_frame: "vision_ned"
-    # available: ned, frd or flu (though only the tf to frd is supported)
-    body_frame_orientation: "frd"
+  in:
+    frame_id: "odom"
+    child_frame_id: "base_link"
+    frame_tf:
+      local_frame: "local_origin_ned"
+      body_frame_orientation: "flu"
+  out:
+    frame_tf:
+      # available: check MAV_FRAME odometry local frames in
+      # http://mavlink.org/messages/common
+      local_frame: "vision_ned"
+      # available: ned, frd or flu (though only the tf to frd is supported)
+      body_frame_orientation: "frd"
 
 # px4flow
 px4flow:

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -54,7 +54,8 @@ UAS::UAS() :
 	// send static transform from "local_origin" (ENU) to "local_origin_ned" (NED)
 	publish_static_transform("local_origin", "local_origin_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)));
 	publish_static_transform("fcu", "fcu_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)));
-	publish_static_transform("fcu_frd", "fcu", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)));
+	// for being able to apply the transforms at the data coming from the FCU, the opposite transform is also required
+	publish_static_transform("fcu_frd", "fcu", Eigen::Affine3d(ftf::quaternion_from_rpy(-M_PI, 0, 0)));
 }
 
 /* -*- heartbeat handlers -*- */

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -54,6 +54,7 @@ UAS::UAS() :
 	// send static transform from "local_origin" (ENU) to "local_origin_ned" (NED)
 	publish_static_transform("local_origin", "local_origin_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)));
 	publish_static_transform("fcu", "fcu_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)));
+	publish_static_transform("fcu_frd", "fcu", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)));
 }
 
 /* -*- heartbeat handlers -*- */

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -21,11 +21,12 @@
 #include <boost/algorithm/string.hpp>
 
 #include <nav_msgs/Odometry.h>
+#include <geometry_msgs/TransformStamped.h>
 
 namespace mavros {
 namespace extra_plugins {
 using mavlink::common::MAV_FRAME;
-using Matrix6d = Eigen::Matrix<double, 6, 6>;
+using Matrix6d = Eigen::Matrix<double, 6, 6, Eigen::RowMajor>;
 
 /**
  * @brief Odometry plugin
@@ -37,23 +38,35 @@ class OdometryPlugin : public plugin::PluginBase {
 public:
 	OdometryPlugin() : PluginBase(),
 		odom_nh("~odometry"),
-		local_frame("vision_ned"),
-		body_frame_orientation("frd")
+		body_frame_orientation_in_desired("flu"),
+		body_frame_orientation_out_desired("frd"),
+		child_frame_id("base_link"),
+		frame_id("odom"),
+		local_frame_in("local_origin_ned"),
+		local_frame_out("vision_ned")
 	{ }
 
 	void initialize(UAS &uas_)
 	{
 		PluginBase::initialize(uas_);
 
-		// frame tf params
-		odom_nh.param<std::string>("frame_tf/local_frame", local_frame, "vision_ned");
-		odom_nh.param<std::string>("frame_tf/body_frame_orientation", body_frame_orientation, "frd");
+		odom_nh.param<std::string>("frame_id", frame_id, "odom");
+		odom_nh.param<std::string>("child_frame_id", child_frame_id, "base_link");
 
-		boost::algorithm::to_lower(local_frame);
-		boost::algorithm::to_lower(body_frame_orientation);
+		// frame tf params:
+		odom_nh.param<std::string>("in/frame_tf/local_frame", local_frame_in, "local_origin_ned");
+		odom_nh.param<std::string>("out/frame_tf/local_frame", local_frame_out, "vision_ned");
+		odom_nh.param<std::string>("in/frame_tf/body_frame_orientation", body_frame_orientation_in_desired, "flu");
+		odom_nh.param<std::string>("out/frame_tf/body_frame_orientation", body_frame_orientation_out_desired, "frd");
+
+		boost::algorithm::to_lower(local_frame_out);
+		boost::algorithm::to_lower(body_frame_orientation_out_desired);
+
+		// publishers
+		odom_pub = odom_nh.advertise<nav_msgs::Odometry>("in", 10);
 
 		// subscribers
-		odom_sub = odom_nh.subscribe("odom", 10, &OdometryPlugin::odom_cb, this);
+		odom_sub = odom_nh.subscribe("out", 10, &OdometryPlugin::odom_cb, this);
 
 		//! Map from param string to local MAV_FRAME
 		const std::unordered_map<std::string, MAV_FRAME> lf_map {
@@ -69,41 +82,222 @@ public:
 			{ "frd", MAV_FRAME::BODY_FRD },
 			{ "flu", MAV_FRAME::BODY_FLU }
 		};
-		// Determine frame_id naming - considering the ROS msg frame_id
+
+		// Determine input frame_id naming
+		if (local_frame_in == "local_origin_ned")
+			local_frame_orientation_in = local_frame_in;
+		else
+			ROS_FATAL_NAMED("odom", "ODOM: invalid input local frame \"%s\"", local_frame_in.c_str());
+
+		// Determine output frame_id naming - considering the ROS msg frame_id
 		// as "odom" by default
-		auto lf_it = lf_map.find(local_frame);
+		auto lf_it = lf_map.find(local_frame_out);
 		if (lf_it != lf_map.end()) {
 			lf_id = lf_it->second;
-			local_frame_orientation = "local_origin_" + local_frame.substr(local_frame.length() - 3);
+			auto orient = local_frame_out.substr(local_frame_out.length() - 3);
+			if (orient != "enu") {
+				local_frame_orientation_out = "local_origin_" + orient;
+			} else {
+				local_frame_orientation_out = "local_origin";
+			}
 		}
 		else
-			ROS_FATAL_NAMED("odom", "ODOM: invalid local frame \"%s\"", local_frame.c_str());
+			ROS_FATAL_NAMED("odom", "ODOM: invalid ouput local frame \"%s\"", local_frame_out.c_str());
 
-		// Determine child_frame_id naming
-		auto bf_it = bf_map.find(body_frame_orientation);
+		// Determine input child_frame_id naming
+		auto bf_it_in = bf_map.find(body_frame_orientation_in_desired);
+		if (bf_it_in != bf_map.end()) {
+			if (body_frame_orientation_in_desired != "flu")
+				body_frame_orientation_in_desired = "fcu_" + body_frame_orientation_in_desired;
+			else
+				body_frame_orientation_in_desired = "fcu";
+		}
+		else
+			ROS_FATAL_NAMED("odom", "ODOM: invalid input body frame orientation \"%s\"", body_frame_orientation_in_desired.c_str());
+
+		// Determine output child_frame_id naming
+		auto bf_it = bf_map.find(body_frame_orientation_out_desired);
 		if (bf_it != bf_map.end()) {
 			bf_id = bf_it->second;
-			body_frame_orientation = "fcu_" + body_frame_orientation;
+			if (body_frame_orientation_out_desired != "flu")
+				body_frame_orientation_out_desired = "fcu_" + body_frame_orientation_out_desired;
+			else
+				body_frame_orientation_in_desired = "fcu";
 		}
 		else
-			ROS_FATAL_NAMED("odom", "ODOM: invalid body frame orientation \"%s\"", body_frame_orientation.c_str());
+			ROS_FATAL_NAMED("odom", "ODOM: invalid output body frame orientation \"%s\"", body_frame_orientation_out_desired.c_str());
 	}
 
 	Subscriptions get_subscriptions()
 	{
-		return { /* Rx disabled */ };
+		return {
+			       make_handler(&OdometryPlugin::handle_odom)
+		};
 	}
 
 private:
-	ros::NodeHandle odom_nh;
-	ros::Subscriber odom_sub;
+	ros::NodeHandle odom_nh;			//!< node handler
+	ros::Publisher odom_pub;			//!< nav_msgs/Odometry publisher
+	ros::Subscriber odom_sub;			//!< nav_msgs/Odometry subscriber
 
-	std::string local_frame;		//!< orientation and source of the local frame
-	std::string local_frame_orientation;	//!< orientation of the local fram
-	std::string body_frame_orientation;	//!< orientation of the body frame
+	std::string local_frame_in;			//!< orientation and source of the input local frame
+	std::string local_frame_out;			//!< orientation and source of the output local frame
+	std::string local_frame_orientation_in;		//!< orientation of the local frame (input data)
+	std::string local_frame_orientation_out;	//!< orientation of the local frame (output data)
+	std::string body_frame_orientation_in_desired;	//!< orientation of the body frame (input data)
+	std::string body_frame_orientation_out_desired;	//!< orientation of the body frame (output data)
+	std::string frame_id;				//!< parent frame identifier
+	std::string child_frame_id;			//!< child frame identifier
 
-	MAV_FRAME lf_id;			//!< local frame (pose) ID
-	MAV_FRAME bf_id;			//!< body frame (pose) ID
+	MAV_FRAME lf_id;				//!< local frame (pose) ID
+	MAV_FRAME bf_id;				//!< body frame (pose) ID
+
+	/**
+	 * @brief Lookup transforms
+	 * @todo Implement in a more general fashion in the API IOT apply frame transforms
+	 * This should also run in parallel on a thread
+	 * @param[in] &frame_id The parent frame of reference
+	 * @param[in] &child_frame_id The child frame of reference
+	 * @param[in] &local_frame_orientation The desired local frame orientation
+	 * @param[in] &body_frame_orientation The desired body frame orientation
+	 * @param[in,out] &tf_parent2local The affine transform from the parent frame to the local frame
+	 * @param[in,out] &tf_child2local The affine transform from the child frame to the local frame
+	 * @param[in,out] &tf_parent2body The affine transform from the parent frame to the body frame
+	 * @param[in,out] &tf_child2body The affine transform from the child frame to the body frame
+	 */
+	void transform_lookup(const std::string &frame_id, const std::string &child_frame_id,
+		const std::string &local_frame_orientation, const std::string &body_frame_orientation,
+		Eigen::Affine3d &tf_parent2local, Eigen::Affine3d &tf_child2local,
+		Eigen::Affine3d &tf_parent2body, Eigen::Affine3d &tf_child2body)
+	{
+		try {
+			// transform lookup WRT local frame
+			tf_parent2local = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
+				frame_id, local_frame_orientation,
+				ros::Time(0)));
+			tf_child2local = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
+				child_frame_id, local_frame_orientation,
+				ros::Time(0)));
+
+			// transform lookup WRT body frame
+			tf_parent2body = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
+				frame_id, body_frame_orientation,
+				ros::Time(0)));
+			tf_child2body = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
+				child_frame_id, body_frame_orientation,
+				ros::Time(0)));
+		} catch (tf2::TransformException &ex) {
+			ROS_ERROR_THROTTLE_NAMED(1, "odom", "ODOM: Ex: %s", ex.what());
+			return;
+		}
+	}
+
+	/**
+	 * @brief Handle ODOMETRY MAVlink message.
+	 *
+	 * Message specification: https://mavlink.io/en/messages/common.html#ODOMETRY
+	 * @param msg	Received Mavlink msg
+	 * @param att	ATTITUDE msg
+	 */
+	void handle_odom(const mavlink::mavlink_message_t *msg, mavlink::common::msg::ODOMETRY &odom_msg)
+	{
+		/*** Send fcu_frd <-> local_origin_ned transform ***/
+		geometry_msgs::TransformStamped transform;
+		transform.header.stamp = m_uas->synchronise_stamp(odom_msg.time_usec);
+		transform.header.frame_id = "local_origin_ned";
+		transform.child_frame_id = "fcu_frd";
+
+		tf::vectorEigenToMsg(Eigen::Vector3d(odom_msg.x, odom_msg.y, odom_msg.z), transform.transform.translation);
+		tf::quaternionEigenToMsg(ftf::mavlink_to_quaternion(odom_msg.q), transform.transform.rotation);
+
+		m_uas->tf2_broadcaster.sendTransform(transform);
+		/***************************************************/
+
+		/**
+		 * Required affine rotations to apply transforms
+		 */
+		Eigen::Affine3d tf_parent2local;
+		Eigen::Affine3d tf_child2local;
+		Eigen::Affine3d tf_parent2body;
+		Eigen::Affine3d tf_child2body;
+
+		//! Lookup to the required trans
+		transform_lookup("local_origin_ned", "fcu_frd",
+			local_frame_orientation_in, body_frame_orientation_in_desired,
+			tf_parent2local, tf_child2local, tf_parent2body, tf_child2body);
+
+		//! Build 6x6 pose covariance matrix to be transformed and sent
+		Matrix6d cov_pose = Matrix6d::Zero();
+		ftf::mavlink_urt_to_covariance_matrix(odom_msg.pose_covariance, cov_pose);
+
+		//! Build 6x6 velocity covariance matrix to be transformed and sent
+		Matrix6d cov_vel = Matrix6d::Zero();
+		ftf::mavlink_urt_to_covariance_matrix(odom_msg.twist_covariance, cov_vel);
+
+		Eigen::Vector3d position {};		//!< Position vector. WRT frame_id
+		Eigen::Quaterniond orientation {};	//!< Attitude quaternion. WRT frame_id
+		Eigen::Vector3d lin_vel {};		//!< Linear velocity vector. WRT child_frame_id
+		Eigen::Vector3d ang_vel {};		//!< Angular velocity vector. WRT child_frame_id
+		Matrix6d r_pose = Matrix6d::Zero();	//!< Zero initialized pose 6-D Covariance matrix. WRT frame_id
+		Matrix6d r_vel = Matrix6d::Zero();	//!< Zero initialized velocity 6-D Covariance matrix. WRT child_frame_id
+
+		auto odom = boost::make_shared<nav_msgs::Odometry>();
+
+		odom->header = m_uas->synchronized_header(frame_id, odom_msg.time_usec);
+		odom->child_frame_id = child_frame_id;
+
+		/**
+		 * Position parsing
+		 */
+		position = Eigen::Vector3d(tf_parent2local.linear() * Eigen::Vector3d(odom_msg.x, odom_msg.y, odom_msg.z));
+		tf::pointEigenToMsg(position, odom->pose.pose.position);
+
+		/**
+		 * Orientation parsing
+		 */
+		Eigen::Quaterniond q_parent2child(ftf::mavlink_to_quaternion(odom_msg.q));
+		Eigen::Affine3d tf_local2body = tf_parent2local * q_parent2child * tf_child2body.inverse();
+		orientation = Eigen::Quaterniond(tf_local2body.linear());
+		tf::quaternionEigenToMsg(orientation, odom->pose.pose.orientation);
+
+		r_pose.block<3, 3>(0, 0) = r_pose.block<3, 3>(3, 3) = tf_parent2local.linear();
+
+		/**
+		 * Velocities parsing
+		 * Linear and angular velocities are in the same frame as child_frame_id.
+		 */
+		auto set_tf = [&](Eigen::Affine3d affineTf) {
+				lin_vel = Eigen::Vector3d(affineTf.linear() * Eigen::Vector3d(odom_msg.vx, odom_msg.vy, odom_msg.vz));
+				ang_vel = Eigen::Vector3d(affineTf.linear() * Eigen::Vector3d(odom_msg.rollspeed, odom_msg.pitchspeed, odom_msg.yawspeed));
+				r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = affineTf.linear();
+			};
+
+		if (odom_msg.child_frame_id == odom_msg.frame_id) {
+			// the child_frame_id would be the same reference frame as frame_id
+			set_tf(tf_child2local);
+		}
+		else {
+			// the child_frame_id would be the WRT a body frame reference
+			set_tf(tf_child2body);
+		}
+
+		tf::vectorEigenToMsg(lin_vel, odom->twist.twist.linear);
+		tf::vectorEigenToMsg(ang_vel, odom->twist.twist.angular);
+
+		/**
+		 * Covariances parsing
+		 */
+		//! Transform pose covariance matrix
+		cov_pose = r_pose * cov_pose * r_pose.transpose();
+		Eigen::Map<Matrix6d>(odom->pose.covariance.data(), cov_pose.rows(), cov_pose.cols()) = cov_pose;
+
+		//! Transform twist covariance matrix
+		cov_vel = r_vel * cov_vel * r_vel.transpose();
+		Eigen::Map<Matrix6d>(odom->twist.covariance.data(), cov_vel.rows(), cov_vel.cols()) = cov_vel;
+
+		//! Publish the data
+		odom_pub.publish(odom);
+	}
 
 	/**
 	 * @brief Sends odometry data msgs to the FCU.
@@ -113,35 +307,18 @@ private:
 	 */
 	void odom_cb(const nav_msgs::Odometry::ConstPtr &odom)
 	{
-		/** Lookup transforms
-		 *  @todo Implement in a more general fashion in the API IOT apply frame transforms
-		 *  This should also run in parallel on a thread
+		/**
+		 * Required affine rotations to apply transforms
 		 */
 		Eigen::Affine3d tf_parent2local;
 		Eigen::Affine3d tf_child2local;
 		Eigen::Affine3d tf_parent2body;
 		Eigen::Affine3d tf_child2body;
 
-		try {
-			// transform lookup WRT local frame
-			tf_parent2local = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-							odom->header.frame_id, local_frame_orientation,
-							ros::Time(0)));
-			tf_child2local = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-							odom->child_frame_id, local_frame_orientation,
-							ros::Time(0)));
-
-			// transform lookup WRT body frame
-			tf_parent2body = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-							odom->header.frame_id, body_frame_orientation,
-							ros::Time(0)));
-			tf_child2body = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-							odom->child_frame_id, body_frame_orientation,
-							ros::Time(0)));
-		} catch (tf2::TransformException &ex) {
-			ROS_ERROR_THROTTLE_NAMED(1, "odom", "ODOM: Ex: %s", ex.what());
-			return;
-		}
+		//! Build 6x6 pose covariance matrix to be transformed and sent
+		transform_lookup(odom->header.frame_id, odom->child_frame_id,
+			local_frame_orientation_out, body_frame_orientation_out_desired,
+			tf_parent2local, tf_child2local, tf_parent2body, tf_child2body);
 
 		//! Build 6x6 pose covariance matrix to be transformed and sent
 		ftf::Covariance6d cov_pose = odom->pose.covariance;
@@ -185,12 +362,12 @@ private:
 		 * Same logic here applies as above.
 		 */
 		auto set_tf = [&](Eigen::Affine3d affineTf, MAV_FRAME frame_id) {
-			lin_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.linear));
-			ang_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.angular));
-			r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = affineTf.linear();
+				lin_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.linear));
+				ang_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.angular));
+				r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = affineTf.linear();
 
-			msg.child_frame_id = utils::enum_value(frame_id);
-		};
+				msg.child_frame_id = utils::enum_value(frame_id);
+			};
 
 		if (odom->child_frame_id == "world" || odom->child_frame_id == "odom") {
 			// the child_frame_id would be the same reference frame as frame_id
@@ -205,8 +382,8 @@ private:
 		cov_pose_map = r_pose * cov_pose_map * r_pose.transpose();
 		cov_vel_map  = r_vel  * cov_vel_map  * r_vel.transpose();
 
-		ROS_DEBUG_STREAM_NAMED("odom", "ODOM: pose covariance matrix:" << std::endl << cov_pose_map);
-		ROS_DEBUG_STREAM_NAMED("odom", "ODOM: velocity covariance matrix:" << std::endl << cov_vel_map);
+		ROS_DEBUG_STREAM_NAMED("odom", "ODOM: output: pose covariance matrix:" << std::endl << cov_pose_map);
+		ROS_DEBUG_STREAM_NAMED("odom", "ODOM: output: velocity covariance matrix:" << std::endl << cov_vel_map);
 
 		/* -*- ODOMETRY msg parser -*- */
 		msg.time_usec = odom->header.stamp.toNSec() / 1e3;


### PR DESCRIPTION
This pull request is part of the effort to have a full odometry pipeline that allows sending and receiving odometry data. This implements the [`ODOMETRY`](https://mavlink.io/en/messages/common.html#ODOMETRY) handler in the `odom` plugin.

So to keep the consistency regarding the usage of `tf2` and tf lookups to apply the transforms, the `local_origin_ned`<->`fcu_frd` is published, in order to allow the following tf tree.

![tf_tree](https://user-images.githubusercontent.com/5048656/50378602-e7935c00-062d-11e9-870e-709acd7866c3.png)

Soon enough the above transform implementation should be brought to the frame transform API and replace the static Eigen math being applied.

Here's a [demo video](https://drive.google.com/open?id=1gUFYf4k2TBTApRXXH6QAzUDJwk-QHvQX), which allows to see the Odometry data in both Rviz, `rostopic echo` and also with the comparison with QGC Mavlink Inspector.