### PR TITLE
mavros_msgs/msg/LogData.msg: Define "offset" field to be of type uint32

### DIFF
--- a/mavros_msgs/msg/LogData.msg
+++ b/mavros_msgs/msg/LogData.msg
@@ -7,5 +7,5 @@
 std_msgs/Header header
 
 uint16 id
-uint16 offset
+uint32 offset
 uint8[] data


### PR DESCRIPTION
.. so that it matches the mavlink type, that is used for this message. Otherwise, the value for this field wraps around at 0xffffffff and confusion ensues.