### PR TITLE
VehicleInfo : add srv into sys_status plugin to request vehicule basic info

### DIFF
--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -39,6 +39,7 @@ add_message_files(
   Thrust.msg
   VFR_HUD.msg
   Vibration.msg
+  VehicleInfo.msg
   Waypoint.msg
   WaypointList.msg
   WaypointReached.msg
@@ -71,6 +72,7 @@ add_service_files(
   SetMavFrame.srv
   SetMode.srv
   StreamRate.srv
+  VehicleInfoGet.srv
   WaypointClear.srv
   WaypointPull.srv
   WaypointPush.srv

--- a/mavros_msgs/msg/VehicleInfo.msg
+++ b/mavros_msgs/msg/VehicleInfo.msg
@@ -1,0 +1,18 @@
+# Vehicle Info msg
+uint8 sysid                     #SYSTEM ID
+uint8 compid                    #COMPONENT ID
+uint8 autopilot                 #MAV_AUTOPILOT
+uint8 type                      #MAV_TYPE
+uint8 system_status             #MAV_STATE
+uint8 base_mode
+uint32 custom_mode
+string mode                     #MAV_MODE string
+uint32 mode_id                  #MAV_MODE number
+uint64 capabilities             #MAV_PROTOCOL_CAPABILITY
+uint32 flight_sw_version        #Firmware version number
+uint32 middleware_sw_version    #Middleware version number
+uint32 os_sw_version            #Operating system version number
+uint32 board_version            #HW / board version (last 8 bytes should be silicon ID, if any)
+uint16 vendor_id                #ID of the board vendor
+uint16 product_id               #ID of the product
+uint64 uid                      #UID if provided by hardware

--- a/mavros_msgs/srv/VehicleInfoGet.srv
+++ b/mavros_msgs/srv/VehicleInfoGet.srv
@@ -1,0 +1,14 @@
+# Request the Vehicle Info
+# use this to request the current target sysid / compid defined in mavros
+# set get_all = True to request all available vehicles
+
+uint8 GET_MY_SYSID = 0
+uint8 GET_MY_COMPID = 0
+
+uint8 sysid
+uint8 compid
+bool get_all
+---
+bool success
+mavros_msgs/VehicleInfo[] vehicles
+


### PR DESCRIPTION

Service allow to request : 
- my target vehicle
- a specific sysid/compid
- all vehicles seen by mavros

Took all comment from https://github.com/mavlink/mavros/pull/1147 and made a much more elegant solution. 

I used an unordered_map with key & mavros_msgs::VehicleInfo directly rather than defining a new class/struc VehicleInfo and a to_msg() function like in the waypoint plugin.

Thanks !

