### PR TITLE
Add support for set message interval

### DIFF
--- a/mavros/scripts/mavsys
+++ b/mavros/scripts/mavsys
@@ -16,7 +16,7 @@ import rospy
 import mavros
 from mavros.utils import *
 from mavros_msgs.msg import State
-from mavros_msgs.srv import SetMode, StreamRate, StreamRateRequest
+from mavros_msgs.srv import SetMode, StreamRate, StreamRateRequest, MessageInterval
 
 def do_mode(args):
     base_mode = 0
@@ -78,6 +78,24 @@ def do_rate(args):
 
 
 
+def do_message_interval(args):
+
+    if args.id is None:
+        fault("id not specified")
+        return
+
+    if args.rate is None:
+        fault("rate not specified")
+        return
+
+    try:
+        set_message_interval = rospy.ServiceProxy(mavros.get_topic('set_message_interval'), MessageInterval)
+        set_message_interval(message_id=args.id, message_rate=args.rate)
+    except rospy.ServiceException as ex:
+        fault(ex)
+
+
+
 def main():
     parser = argparse.ArgumentParser(description="Change mode and rate on MAVLink device.")
     parser.add_argument('-n', '--mavros-ns', help="ROS node namespace", default=mavros.DEFAULT_NAMESPACE)
@@ -104,6 +122,11 @@ def main():
     rate_args.add_argument('--extra2', type=int, metavar='rate', help="Extra 2 stream")
     rate_args.add_argument('--extra3', type=int, metavar='rate', help="Extra 3 stream")
     rate_args.add_argument('--stream-id', type=int, nargs=2, metavar=('id', 'rate'), help="any stream")
+
+    message_interval_args = subarg.add_parser('message_interval', help="Set message interval")
+    message_interval_args.set_defaults(func=do_message_interval)
+    message_interval_args.add_argument('--id', type=int, metavar='id', help="message id")
+    message_interval_args.add_argument('--rate', type=float, metavar='rate', help="message rate")
 
     args = parser.parse_args(rospy.myargv(argv=sys.argv)[1:])
 

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -76,6 +76,7 @@ add_service_files(
   LogRequestData.srv
   LogRequestEnd.srv
   LogRequestList.srv
+  MessageInterval.srv
   ParamGet.srv
   ParamPull.srv
   ParamPush.srv

--- a/mavros_msgs/srv/MessageInterval.srv
+++ b/mavros_msgs/srv/MessageInterval.srv
@@ -1,0 +1,7 @@
+# sets message interval
+# See MAV_CMD_SET_MESSAGE_INTERVAL
+
+uint16 message_id
+float32 message_rate
+---
+bool success


### PR DESCRIPTION
This PR attempts to close this issue: https://github.com/mavlink/mavros/issues/370

- new set_message_interval service added which accepts MessageInterval requests which provide a desired message id and rate (in hz) and then sends a COMMAND_LONG (using the CommandLong service) containing a MAV_CMD_SET_MESSAGE_INTERVAL.

   - The only slight complexity is that the request specifies a rate while the mavlink message provides an interval in us (I figured a rate was easier to use but it's possible this logic should have been put in mavsys instead of within the service).
   - If the rate is set to 0 or -1 set the outgoing message-interval is also set to 0 or -1 which sets the rate to the default or turns off the message.  Perhaps it would be more logical to have the caller specify "rate=0" to turning off the message and "rate=-1" for default rate.

- mavsys python script enhanced to allow using the above service from the command line

I've tested this on an AION robotics rover with an Nvidia tx2 running ROS and a Cube running ArduPilot Rover-3.5.0-dev and it worked correctly.  Some of the tests performed:

- set the RAW_IMU rate to 5hz and confirmed the update rate to the ground station (MP) changed correctly
- set the RAW_IMU rate to 0 to confirm the rate changed to the default (which was 3hz)
- set the RAW_IMU rate to -1 to confirm the message stopped being sent by the flight controller

Below are some screen shots of it in action.

![mavros-rawimu-update-cmdline](https://user-images.githubusercontent.com/1498098/51069954-589dc080-167c-11e9-968d-cdac2bddb484.png)
![mavros-mp-rawimu-update-rate](https://user-images.githubusercontent.com/1498098/51069955-5a678400-167c-11e9-8c44-c0c066863e67.png)

