### PR TITLE
px4_config: set the thrust_scaling to one by default

### DIFF
--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -99,7 +99,9 @@ setpoint_attitude:
     rate_limit: 50.0
 
 setpoint_raw:
-  thrust_scaling: 0.0       # used in rpyt callback
+  thrust_scaling: 1.0       # used in setpoint_raw attitude callback.
+  # Note: PX4 expects normalized thrust values between 0 and 1, which means that
+  # the scaling needs to be unitary and the inputs should be 0..1 as well.
 
 # setpoint_position
 setpoint_position:


### PR DESCRIPTION
This should be set to unitary by default, as being 0 means there's no thrust.

@lamping7 FYI.

@vooon what's the possibility of having a 0.28.1 minor release to bring this? The reason is that this is currently breaking PX4 CI.