### PR TITLE
obstacle_distance: combine sensor distances to fit within distances array

### DIFF
--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -88,9 +88,9 @@ private:
 		}
 
 		obstacle.time_usec = req->header.stamp.toNSec() / 1000;					//!< [microsecs]
-		obstacle.sensor_type = utils::enum_value(MAV_DISTANCE_SENSOR::LASER);			//!< defaults is laser type (depth sensor, Lidar)
-		obstacle.min_distance = req->range_min * 1e2;						//!< [centimeters]
-		obstacle.max_distance = req->range_max * 1e2;						//!< [centimeters]
+		obstacle.sensor_type = utils::enum_value(MAV_DISTANCE_SENSOR::LASER);	//!< defaults is laser type (depth sensor, Lidar)
+		obstacle.min_distance = req->range_min * 1e2;							//!< [centimeters]
+		obstacle.max_distance = req->range_max * 1e2;							//!< [centimeters]
 
 		ROS_DEBUG_STREAM_NAMED("obstacle_distance", "OBSDIST: sensor type: " << utils::to_string_enum<MAV_DISTANCE_SENSOR>(obstacle.sensor_type)
 				<< std::endl << obstacle.to_yaml());

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -64,15 +64,32 @@ private:
 	{
 		mavlink::common::msg::OBSTACLE_DISTANCE obstacle {};
 
-		auto n = std::min(req->ranges.size(), obstacle.distances.size());
-		auto cm_ranges = Eigen::Map<const Eigen::VectorXf>(req->ranges.data(), n) * 1e2;
-		Eigen::Map<Eigen::Matrix<uint16_t, Eigen::Dynamic, 1> > map_distances(obstacle.distances.data(), n);
+		if (req->ranges.size() <= obstacle.distances.size()) {
+			// all distances from sensor will fit in obstacle distance message
+			auto n = std::min(req->ranges.size(), obstacle.distances.size());
+			Eigen::Map<Eigen::Matrix<uint16_t, Eigen::Dynamic, 1> > map_distances(obstacle.distances.data(), n);
+			auto cm_ranges = Eigen::Map<const Eigen::VectorXf>(req->ranges.data(), n) * 1e2;
+			map_distances = cm_ranges.cast<uint16_t>();							//!< [centimeters]
+			std::fill(obstacle.distances.begin() + n, obstacle.distances.end(), UINT16_MAX);    //!< fill the rest of the array values as "Unknown"
+			obstacle.increment = req->angle_increment * RAD_TO_DEG;				//!< [degrees]
+		} else {
+			// all distances from sensor will not fit so we combine adjacent distances always taking the shortest distance
+			int scale_factor = ceil(req->ranges.size() / obstacle.distances.size());
+			for (int i = 0; i < obstacle.distances.size(); i++) {
+				obstacle.distances[i] = UINT16_MAX;
+				for (int j = 0; j < scale_factor; j++) {
+					int req_index = i * scale_factor + j;
+					if (req_index < req->ranges.size()) {
+						uint16_t dist_cm = req->ranges[req_index] * 1e2;
+						obstacle.distances[i] = std::min(obstacle.distances[i], dist_cm);
+					}
+				}
+			}
+			obstacle.increment = ceil(req->angle_increment * RAD_TO_DEG * scale_factor);   //!< [degrees]
+		}
 
-		obstacle.time_usec = req->header.stamp.toNSec() / 1000;					//!< [milisecs]
+		obstacle.time_usec = req->header.stamp.toNSec() / 1000;					//!< [microsecs]
 		obstacle.sensor_type = utils::enum_value(MAV_DISTANCE_SENSOR::LASER);			//!< defaults is laser type (depth sensor, Lidar)
-		map_distances = cm_ranges.cast<uint16_t>();						//!< [centimeters]
-		std::fill(obstacle.distances.begin() + n, obstacle.distances.end(), UINT16_MAX);	//!< fill the rest of the array values as "Unknown"
-		obstacle.increment = req->angle_increment * RAD_TO_DEG;					//!< [degrees]
 		obstacle.min_distance = req->range_min * 1e2;						//!< [centimeters]
 		obstacle.max_distance = req->range_max * 1e2;						//!< [centimeters]
 


### PR DESCRIPTION
This PR attempts to resolve issue https://github.com/mavlink/mavros/issues/1082.  The issue is that the obstacle_distance plugin does not correctly handle LaserScan messages from sensors with more than 72 distances.  The limitation comes from the [OBSTACLE_DISTANCE mavlink message](https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE) which can only carry up to 72 distances.

The existing code simply truncates the data while the new code instead "compresses" the data to fit.  It does this by combining adjacent distances (always choosing the shortest distance).

So as to ensure as little impact as possible on existing users of this plugin, the new "compression" code is separated out with an if/else.

I've tested this on an Nvidia Tx2 running ROS/mavros with an RPLidarA2.  I modified the RPLidar's node.cpp file to send messages of three sizes: 36 distances, 72 distances and 360 distances.  The distances were hard-coded to always be index * 10cm to make it easy to check the results.

>    // testing code to send LaserScan to mavros::obstacle_distance plugin
>     scan_msg.intensities.resize(36);
>     scan_msg.ranges.resize(36);
>     scan_msg.angle_increment = 360 / 36 * M_PI / 180.0f;
>     for (size_t i = 0; i < scan_msg.ranges.size(); i++) {
>         scan_msg.ranges[i] = 0.1f * i;
>     }
>     scan_msg.range_max = 0.1f * scan_msg.ranges.size() + 1;
>     pub->publish(scan_msg);

Below are the testing results showing there are no changes to behaviour when there are 36 or 72 distances.
![before-36-and-72-slots](https://user-images.githubusercontent.com/1498098/51907963-b3207600-240b-11e9-9574-504a88ded432.png)


Below are the testing results when more than 72 distances are sent.  In this case 360 distances are sent
![before-after-with-360deg-sensor](https://user-images.githubusercontent.com/1498098/51907287-b0248600-2409-11e9-9996-71e504cde450.png)

Any and all feedback more than welcome!