### PR TITLE
added tf2_eigen to dependencies

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
   urdf
   tf
+  tf2_eigen
 )
 
 ## System dependencies are found with CMake's conventions

--- a/mavros_extras/package.xml
+++ b/mavros_extras/package.xml
@@ -28,6 +28,7 @@
   <depend>visualization_msgs</depend>
   <depend>urdf</depend>
   <depend>tf</depend>
+  <depend>tf2_eigen</depend>
 
   <export>
     <mavros plugin="${prefix}/mavros_plugins.xml" />


### PR DESCRIPTION
As stated in #1166 mavros_extras does not build with 
`catkin build`
because odom.cpp includes tf2_eigen headers, but tf2_eigen is not listed as dependency. This PR fixes the issue.