### PR TITLE
Update apm_config.yaml - Adding thrust_scaling to 1.0 in setpoint_raw msg

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -98,6 +98,10 @@ setpoint_attitude:
     frame_id: "map"
     child_frame_id: "target_attitude"
     rate_limit: 50.0
+    
+ # setpoint_raw
+ setpoint_raw:
+  thrust_scaling: 1.0       # specify thrust scaling (normalized, 0 to 1) for thrust (like PX4)
 
 # setpoint_position
 setpoint_position:


### PR DESCRIPTION
Setting thrust_scaling in the setpoint_raw message (in my case, to use /mavros/setpoint_raw/attitude)
Without it, when using Gazebo, get the following problem
"Recieved thrust, but ignore_thrust is true: the most likely cause of this is a failure to specify the thrust_scaling parameters on px4/apm_config.yaml. Actuation will be ignored." from the function void attitude_cb in setpoint_raw.cpp (http://docs.ros.org/kinetic/api/mavros/html/setpoint__raw_8cpp_source.html)