### PR TITLE
distance_sensor: Allow configurable variance window size

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -143,6 +143,7 @@ distance_sensor:
     field_of_view: 0.0  # XXX TODO
     send_tf: false
     sensor_position: {x:  0.0, y:  0.0, z:  -0.1}
+    variance_window_size: 50 # Default window size for variance calculations
   rangefinder_sub:
     subscriber: true
     id: 1

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -143,6 +143,7 @@ distance_sensor:
     field_of_view: 0.0  # XXX TODO
     send_tf: true
     sensor_position: {x:  0.0, y:  0.0, z:  -0.1}
+    variance_window_size: 50 # Default window size for variance calculations
   lidarlite_pub:
     id: 1
     frame_id: "lidarlite_laser"
@@ -150,6 +151,7 @@ distance_sensor:
     field_of_view: 0.0  # XXX TODO
     send_tf: true
     sensor_position: {x:  0.0, y:  0.0, z:  -0.1}
+    variance_window_size: 50 # Default window size for variance calculations
   sonar_1_sub:
     subscriber: true
     id: 2

--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -280,7 +280,7 @@ void DistanceSensorItem::range_cb(const sensor_msgs::Range::ConstPtr &msg)
 	uint8_t covariance_ = 0;
 
 	if (covariance > 0) covariance_ = covariance;
-	else if (variance_window_size <= 0) covariance_ = 0;
+	else if (variance_window_size <= 0) covariance_ = 255; // Assume unknown variance
 	else covariance_ = uint8_t(calculate_variance(msg->range) * 1E2);	// in cm
 
 	/** @todo Propose changing covarince from uint8_t to float */

--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -280,7 +280,7 @@ void DistanceSensorItem::range_cb(const sensor_msgs::Range::ConstPtr &msg)
 	uint8_t covariance_ = 0;
 
 	if (covariance > 0) covariance_ = covariance;
-	else if (variance_window_size <= 0) covariance_ = 255; // Assume unknown variance
+	else if (variance_window_size <= 0) covariance_ = UINT8_MAX; // Assume unknown variance
 	else covariance_ = uint8_t(calculate_variance(msg->range) * 1E2);	// in cm
 
 	/** @todo Propose changing covarince from uint8_t to float */


### PR DESCRIPTION
Currently ```distance_sensor``` plugin from ```mavros_extras``` uses a sample window with a hardcoded size to calculate distance sensor variance that is sent to the autopilot. This results in incorrectly large variances for low-frequency sensors (especially "smart" sensors that calculate variance themselves), especially during takeoff and landing. To compensate for that I suggest adding a parameter to ```distance_sensor``` with the desired window size.

This P/R introduces a new parameter, ```variance_window_size```, to the ```distance_sensor``` plugin. It controls how many samples will be used in the (co)variance calculation, and defaults to 50 (the old, hardcoded size). If this parameter is set to 0 or a negative value, the variance calculations are disabled, and the distance sensor (co)variance is set to 0.