### PR TITLE
Get topic local_position/velocity back from local_position/velocity_local 

### DIFF
--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -57,7 +57,7 @@ public:
 
 		local_position = lp_nh.advertise<geometry_msgs::PoseStamped>("pose", 10);
 		local_position_cov = lp_nh.advertise<geometry_msgs::PoseWithCovarianceStamped>("pose_cov", 10);
-		local_velocity_local = lp_nh.advertise<geometry_msgs::TwistStamped>("velocity_local", 10);
+		local_velocity_local = lp_nh.advertise<geometry_msgs::TwistStamped>("velocity", 10);
 		local_velocity_body = lp_nh.advertise<geometry_msgs::TwistStamped>("velocity_body", 10);
 		local_velocity_cov = lp_nh.advertise<geometry_msgs::TwistWithCovarianceStamped>("velocity_body_cov", 10);
 		local_accel = lp_nh.advertise<geometry_msgs::AccelWithCovarianceStamped>("accel", 10);


### PR DESCRIPTION
I have realized that the topic `local_position/velocity` has been replaced by `local_position/velocity_local`. 
This seems to have been triggered first by #1142 and a fix for this changed the topic name in #1160 

It took me some time to find this and fix it in a [package](https://github.com/Jaeyoung-Lim/mavros_controllers) I am using, and I believe this would be true for a lot of other packages that depend on mavros.

I don't understand what is the reasoning behind the change of the topic name to `velocity_local` rather than keeping it  as `velocity` while introducing the new body frame velocity as `velocity_body`. The change is not even documented in the [mavros wiki](http://wiki.ros.org/mavros), which most people go for reference on the list of topics.
