### PR TITLE
gps_rtk: fix multi segment messages

### DIFF
--- a/mavros_extras/src/plugins/gps_rtk.cpp
+++ b/mavros_extras/src/plugins/gps_rtk.cpp
@@ -78,7 +78,7 @@ private:
 			for (uint8_t fragment_id = 0; fragment_id < 4 && data_it < end_it; fragment_id++) {
 				uint8_t len = std::min((size_t) std::distance(data_it, end_it), max_frag_len);
 				rtcm_data.flags = 1;				// LSB set indicates message is fragmented
-				rtcm_data.flags |= fragment_id++ << 1;		// Next 2 bits are fragment id
+				rtcm_data.flags |= fragment_id << 1;		// Next 2 bits are fragment id
 				rtcm_data.flags |= seq_u5;		// Next 5 bits are sequence id
 				rtcm_data.len = len;
 


### PR DESCRIPTION
Adding fragment_id in both the for loop an in the variable redundant and duplicated