### PR TITLE
remove leading space before setpoint_raw in apm_config.yaml

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -99,8 +99,8 @@ setpoint_attitude:
     child_frame_id: "target_attitude"
     rate_limit: 50.0
     
- # setpoint_raw
- setpoint_raw:
+# setpoint_raw
+setpoint_raw:
   thrust_scaling: 1.0       # specify thrust scaling (normalized, 0 to 1) for thrust (like PX4)
 
 # setpoint_position


### PR DESCRIPTION
Possible regression from: https://github.com/mavlink/mavros/commit/762895ccc01a3ae3b2de9a3f4dfc894afdd65668

This space causes an error when running `roslaunch`:

```
error loading <rosparam> tag:
        file /opt/ros/kinetic/share/mavros/launch/apm_config.yaml contains invalid YAML:
while parsing a block mapping
  in "<string>", line 4, column 1:
    startup_px4_usb_quirk: false
    ^
expected <block end>, but found '<block mapping start>'
  in "<string>", line 103, column 2:
     setpoint_raw:
     ^
XML is <rosparam command="load" file="$(arg config_yaml)"/>
The traceback for the exception was written to the log file
```