### PR TITLE
TypoFix : Update apm_config.yaml

### DIFF
--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -100,7 +100,7 @@ setpoint_attitude:
     rate_limit: 50.0
     
  # setpoint_raw
- setpoint_raw:
+setpoint_raw:
   thrust_scaling: 1.0       # specify thrust scaling (normalized, 0 to 1) for thrust (like PX4)
 
 # setpoint_position


### PR DESCRIPTION
Seems to be a typo to fix. There is a space to remove for the setpoint_raw. Without it, apm.launch is not working.