### PR TITLE
mavros/src/plugins/command.cpp: log if command's wait ack timeout

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -42,6 +42,7 @@ public:
 	explicit CommandTransaction(uint16_t command) :
 		ack(),
 		expected_command(command),
+		// Default result if wait ack timeout
 		result(enum_value(mavlink::common::MAV_RESULT::FAILED))
 	{ }
 };
@@ -180,6 +181,9 @@ private:
 			bool is_not_timeout = wait_ack_for(*ack_it);
 			lock.lock();
 
+			if (!is_not_timeout) {
+				ROS_WARN_NAMED("cmd", "CMD: Command %u -- wait ack timeout", command);
+			}
 			success = is_not_timeout && ack_it->result == enum_value(MAV_RESULT::ACCEPTED);
 			result = ack_it->result;
 


### PR DESCRIPTION
It's confusing now, when you receive an answer: 4 (`MAV_RESULT_FAILED`) on command long, because after you dig into command processing side, in my case it's px4 firmware, you'll see that there is no possible answer `MAV_RESULT_FAILED` on the command.

This changes make it more explicit.

Thanks!