### PR TITLE
Fix tf loop

### DIFF
--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -54,8 +54,6 @@ UAS::UAS() :
 	// send static transform from "local_origin" (ENU) to "local_origin_ned" (NED)
 	publish_static_transform("local_origin", "local_origin_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)));
 	publish_static_transform("fcu", "fcu_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)));
-	// for being able to apply the transforms at the data coming from the FCU, the opposite transform is also required
-	publish_static_transform("fcu_frd", "fcu", Eigen::Affine3d(ftf::quaternion_from_rpy(-M_PI, 0, 0)));
 }
 
 /* -*- heartbeat handlers -*- */

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -47,7 +47,7 @@ UAS::UAS() :
 	catch (const std::exception &e) {
 		// catch exception and shutdown node
 		ROS_FATAL_STREAM("UAS: GeographicLib exception: " << e.what() <<
-			" | Run install_geographiclib_dataset.sh script in order to install Geoid Model dataset!");
+				" | Run install_geographiclib_dataset.sh script in order to install Geoid Model dataset!");
 		ros::shutdown();
 	}
 


### PR DESCRIPTION
There's a tf tree loop that's cased by broadcasting two static transforms between the same frames. Most ROS code ignores this but some nodes get very upset when they see a loop.