### PR TITLE
Add Mount Control plugin to control mount continuously

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(mavros_extras
   src/plugins/vision_pose_estimate.cpp
   src/plugins/vision_speed_estimate.cpp
   src/plugins/wheel_odometry.cpp
+  src/plugins/mount_control.cpp
 )
 add_dependencies(mavros_extras
   ${catkin_EXPORTED_TARGETS}

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -56,4 +56,7 @@
 	<class name="vision_speed_estimate" type="mavros::extra_plugins::VisionSpeedEstimatePlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Send vision speed estimate to FCU.</description>
 	</class>
+	<class name="mount_control" type="mavros::extra_plugins::MountControlPlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>Send Mission command to control a camera or a antenna mount.</description>
+	</class>
 </library>

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -1,0 +1,73 @@
+/**
+ * @brief Mouny Control plugin
+ * @file mount_control.cpp
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2018 Jaeyoung Lim.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+
+#include <mavros_msgs/CompanionProcessStatus.h>
+
+namespace mavros {
+namespace extra_plugins {
+
+//! Mavlink enumerations
+using mavlink::common::MAV_TYPE;
+using mavlink::common::MAV_STATE;
+using mavlink::common::MAV_COMPONENT;
+using mavlink::common::MAV_MOUNT_MODE;
+using utils::enum_value;
+
+/**
+ * @brief Mount Control plugin
+ *
+ * Publishes Mission commands to control the camera or antenna mount.
+ * @see status_cb()
+ */
+class MountControlPlugin : public plugin::PluginBase {
+public:
+	MountControlPlugin() : PluginBase(),
+	status_nh("~mount_control")
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		status_sub = status_nh.subscribe("command", 10, &MountControlPlugin::status_cb, this);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return { /* Rx disabled */ };
+	}
+
+private:
+	ros::NodeHandle status_nh;
+	ros::Subscriber status_sub;
+
+	/**
+	 * @brief Send mount control commands to vehicle
+	 *
+	 * Message specification: https://mavlink.io/en/messages/common.html#DO_MOUNT_CONTROL
+	 * @param req	received MountControl msg
+	 */
+	void status_cb(const mavros_msgs::CompanionProcessStatus::ConstPtr &req)
+	{
+	}
+};
+}	// namespace extra_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::MountControlPlugin, mavros::plugin::PluginBase)

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -16,7 +16,7 @@
 
 #include <mavros/mavros_plugin.h>
 
-#include <mavros_msgs/CompanionProcessStatus.h>
+#include <mavros_msgs/MountControl.h>
 
 namespace mavros {
 namespace extra_plugins {
@@ -37,14 +37,14 @@ using utils::enum_value;
 class MountControlPlugin : public plugin::PluginBase {
 public:
 	MountControlPlugin() : PluginBase(),
-	status_nh("~mount_control")
+	mount_nh("~mount_control")
 	{ }
 
 	void initialize(UAS &uas_)
 	{
 		PluginBase::initialize(uas_);
 
-		status_sub = status_nh.subscribe("command", 10, &MountControlPlugin::status_cb, this);
+		command_sub = mount_nh.subscribe("command", 10, &MountControlPlugin::command_cb, this);
 	}
 
 	Subscriptions get_subscriptions()
@@ -53,8 +53,8 @@ public:
 	}
 
 private:
-	ros::NodeHandle status_nh;
-	ros::Subscriber status_sub;
+	ros::NodeHandle mount_nh;
+	ros::Subscriber command_sub;
 
 	/**
 	 * @brief Send mount control commands to vehicle
@@ -62,7 +62,7 @@ private:
 	 * Message specification: https://mavlink.io/en/messages/common.html#DO_MOUNT_CONTROL
 	 * @param req	received MountControl msg
 	 */
-	void status_cb(const mavros_msgs::CompanionProcessStatus::ConstPtr &req)
+	void command_cb(const mavros_msgs::MountControl::ConstPtr &req)
 	{
 	}
 };

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -7,7 +7,7 @@
  * @{
  */
 /*
- * Copyright 2018 Jaeyoung Lim.
+ * Copyright 2019 Jaeyoung Lim.
  *
  * This file is part of the mavros package and subject to the license terms
  * in the top-level LICENSE file of the mavros repository.
@@ -22,10 +22,8 @@ namespace mavros {
 namespace extra_plugins {
 
 //! Mavlink enumerations
-using mavlink::common::MAV_TYPE;
-using mavlink::common::MAV_STATE;
-using mavlink::common::MAV_COMPONENT;
 using mavlink::common::MAV_MOUNT_MODE;
+using mavlink::common::MAV_CMD;
 using utils::enum_value;
 
 /**
@@ -59,11 +57,27 @@ private:
 	/**
 	 * @brief Send mount control commands to vehicle
 	 *
-	 * Message specification: https://mavlink.io/en/messages/common.html#DO_MOUNT_CONTROL
+	 * Message specification: https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONTROL
 	 * @param req	received MountControl msg
 	 */
 	void command_cb(const mavros_msgs::MountControl::ConstPtr &req)
 	{
+		mavlink::common::msg::COMMAND_LONG cmd {};
+
+		const uint8_t tgt_sys_id = m_uas->get_tgt_system();
+		const uint8_t tgt_comp_id = m_uas->get_tgt_component();
+		cmd.target_system = tgt_sys_id;
+		cmd.target_component = tgt_comp_id;
+		cmd.command = enum_value(MAV_CMD::DO_MOUNT_CONTROL);
+		cmd.param1 = req->pitch;
+		cmd.param2 = req->roll;
+		cmd.param3 = req->yaw;
+		cmd.param4 = req->altitude; // 
+		cmd.param5 = req->latitude; // lattitude in degrees * 1E7
+		cmd.param6 = req->longitude; // longitude in degrees * 1E7
+		cmd.param7 = req->mode; // MAV_MOUNT_MODE
+
+		UAS_FCU(m_uas)->send_message_ignore_drop(cmd);
 	}
 };
 }	// namespace extra_plugins

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -30,7 +30,7 @@ using utils::enum_value;
  * @brief Mount Control plugin
  *
  * Publishes Mission commands to control the camera or antenna mount.
- * @see status_cb()
+ * @see command_cb()
  */
 class MountControlPlugin : public plugin::PluginBase {
 public:

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -64,10 +64,8 @@ private:
 	{
 		mavlink::common::msg::COMMAND_LONG cmd {};
 
-		const uint8_t tgt_sys_id = m_uas->get_tgt_system();
-		const uint8_t tgt_comp_id = m_uas->get_tgt_component();
-		cmd.target_system = tgt_sys_id;
-		cmd.target_component = tgt_comp_id;
+		cmd.target_system = m_uas->get_tgt_system();
+		cmd.target_component = m_uas->get_tgt_component();
 		cmd.command = enum_value(MAV_CMD::DO_MOUNT_CONTROL);
 		cmd.param1 = req->pitch;
 		cmd.param2 = req->roll;

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -31,6 +31,7 @@ add_message_files(
   LogEntry.msg
   ManualControl.msg
   Mavlink.msg
+  MountControl.msg
   OpticalFlowRad.msg
   OverrideRCIn.msg
   Param.msg

--- a/mavros_msgs/msg/MountControl.msg
+++ b/mavros_msgs/msg/MountControl.msg
@@ -1,0 +1,16 @@
+# MAVLink message: DO_MOUNT_CONTROL
+# https://mavlink.io/en/messages/common.html#DO_MOUNT_CONTROL
+
+std_msgs/Header header
+
+uint8 mode # See enum MAV_MOUNT_MODE.
+uint8 MAV_MOUNT_MODE_RETRACT = 0
+uint8 MAV_MOUNT_MODE_NEUTRAL = 1
+uint8 MAV_MOUNT_MODE_MAVLINK_TARGETING = 2
+uint8 MAV_MOUNT_MODE_RC_TARGETING = 3
+uint8 MAV_MOUNT_MODE_GPS_POINT = 4
+
+float32[3] rollpitchyaw # degrees or degrees/second depending on pitch input.
+float32 altitude  # altitude depending on mount mode.
+float32 lattitude # latitude in degrees * 1E7, set if appropriate mount mode.
+float32 longitude # longitude in degrees * 1E7, set if appropriate mount mode.

--- a/mavros_msgs/msg/MountControl.msg
+++ b/mavros_msgs/msg/MountControl.msg
@@ -1,5 +1,5 @@
 # MAVLink message: DO_MOUNT_CONTROL
-# https://mavlink.io/en/messages/common.html#DO_MOUNT_CONTROL
+# https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONTROL
 
 std_msgs/Header header
 
@@ -10,7 +10,9 @@ uint8 MAV_MOUNT_MODE_MAVLINK_TARGETING = 2
 uint8 MAV_MOUNT_MODE_RC_TARGETING = 3
 uint8 MAV_MOUNT_MODE_GPS_POINT = 4
 
-float32[3] rollpitchyaw # degrees or degrees/second depending on pitch input.
+float32 pitch # roll degrees or degrees/second depending on mount mode.
+float32 roll # roll degrees or degrees/second depending on mount mode.
+float32 yaw # roll degrees or degrees/second depending on mount mode.
 float32 altitude  # altitude depending on mount mode.
-float32 lattitude # latitude in degrees * 1E7, set if appropriate mount mode.
+float32 latitude # latitude in degrees * 1E7, set if appropriate mount mode.
 float32 longitude # longitude in degrees * 1E7, set if appropriate mount mode.


### PR DESCRIPTION
I have been trying to control the gimbal continously while the vehicle is constantly being commanded with continuous setpoints in offboard mode. This can be used for image based object / human tracking control. 

I have been trying to use `actuator_setpoints` with mixer group = 2 but this led to some [problems](https://discuss.px4.io/t/on-realtime-control-of-gimbal-from-companion-computer/11468). However, to use actuator control setpoints, `vmount` needs to be disabled.

A better alternative is to use `MAV_CMD_DO_MOUNT_CONTROL` message as this utilizes the `vmount` running on the drone. However, the `command` plugin in mavros only has a service interface, which is not suited for controlling the gimbal continuously.

**Solution**
This PR adds a MountControl plugin, which streams a `MAV_CMD_DO_MOUNT_CONTROL` mavlink stream by subscribing to a topic `~mount_control/command`. A custom `MountControl.msg` was defined for this interafce.

**Test data / coverage**
The vehicle is flown in offboard mode to follow a circular trajectory while being streamed mount control setpoints. 
- log : https://review.px4.io/plot_app?log=b83e0ef5-3429-4a92-a062-3cd496808c03
- video: https://youtu.be/k99cxt65rx8

**Additional context**
This provides a alternative to the issues with controlling the gimbal with `actuator_control` messages as in https://github.com/PX4/Firmware/issues/12029
The video above is comparable to the video below where the gimbal is controlled by actuator setpoints: https://youtu.be/vEbUaGOuFjs
