### PR TITLE
fix for global_position/local sometimes having incorrect position

### DIFF
--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -325,7 +325,7 @@ private:
 						map_point.x(), map_point.y(), map_point.z());
 
 			// Set the current fix as the "map" origin if it's not set
-			if (!is_map_init) {
+			if (!is_map_init && fix->status.status == 0) {
 				map_origin.x() = fix->latitude;
 				map_origin.y() = fix->longitude;
 				map_origin.z() = fix->altitude;

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -325,7 +325,7 @@ private:
 						map_point.x(), map_point.y(), map_point.z());
 
 			// Set the current fix as the "map" origin if it's not set
-			if (!is_map_init && fix->status.status == 0) {
+			if (!is_map_init && fix->status.status >= sensor_msgs::NavSatStatus::STATUS_FIX) {
 				map_origin.x() = fix->latitude;
 				map_origin.y() = fix->longitude;
 				map_origin.z() = fix->altitude;


### PR DESCRIPTION
This check makes sure the gp_origin is not incorrectly set when mavros is launch before aircraft has completed its boot up and obtained a gps fix.  The issue is described in this issue here https://github.com/mavlink/mavros/issues/1213

