### PR TITLE
libmavconn: simplify parse_buffer, and fix dropped_packets and parse_error counters

### DIFF
--- a/libmavconn/include/mavconn/interface.h
+++ b/libmavconn/include/mavconn/interface.h
@@ -255,7 +255,7 @@ protected:
 	size_t conn_id;
 
 	inline mavlink::mavlink_status_t *get_status_p() {
-		return &m_status;
+		return &m_parse_status;
 	}
 
 	inline mavlink::mavlink_message_t *get_buffer_p() {
@@ -277,8 +277,9 @@ protected:
 private:
 	friend const mavlink::mavlink_msg_entry_t* mavlink::mavlink_get_msg_entry(uint32_t msgid);
 
-	mavlink::mavlink_status_t m_status;
+	mavlink::mavlink_status_t m_parse_status;
 	mavlink::mavlink_message_t m_buffer;
+	mavlink::mavlink_status_t m_mavlink_status;
 
 	std::atomic<size_t> tx_total_bytes, rx_total_bytes;
 	std::recursive_mutex iostat_mutex;

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -40,8 +40,9 @@ std::atomic<size_t> MAVConnInterface::conn_id_counter {0};
 MAVConnInterface::MAVConnInterface(uint8_t system_id, uint8_t component_id) :
 	sys_id(system_id),
 	comp_id(component_id),
-	m_status {},
+	m_parse_status {},
 	m_buffer {},
+	m_mavlink_status {},
 	tx_total_bytes(0),
 	rx_total_bytes(0),
 	last_tx_total_bytes(0),
@@ -54,7 +55,7 @@ MAVConnInterface::MAVConnInterface(uint8_t system_id, uint8_t component_id) :
 
 mavlink_status_t MAVConnInterface::get_status()
 {
-	return m_status;
+	return m_mavlink_status;
 }
 
 MAVConnInterface::IOStat MAVConnInterface::get_iostat()
@@ -94,7 +95,6 @@ void MAVConnInterface::iostat_rx_add(size_t bytes)
 
 void MAVConnInterface::parse_buffer(const char *pfx, uint8_t *buf, const size_t bufsize, size_t bytes_received)
 {
-	mavlink::mavlink_status_t status;
 	mavlink::mavlink_message_t message;
 
 	assert(bufsize >= bytes_received);
@@ -103,18 +103,7 @@ void MAVConnInterface::parse_buffer(const char *pfx, uint8_t *buf, const size_t 
 	for (; bytes_received > 0; bytes_received--) {
 		auto c = *buf++;
 
-		// based on mavlink_parse_char()
-		auto msg_received = static_cast<Framing>(mavlink::mavlink_frame_char_buffer(&m_buffer, &m_status, c, &message, &status));
-		if (msg_received == Framing::bad_crc || msg_received == Framing::bad_signature) {
-			mavlink::_mav_parse_error(&m_status);
-			m_status.msg_received = mavlink::MAVLINK_FRAMING_INCOMPLETE;
-			m_status.parse_state = mavlink::MAVLINK_PARSE_STATE_IDLE;
-			if (c == MAVLINK_STX) {
-				m_status.parse_state = mavlink::MAVLINK_PARSE_STATE_GOT_STX;
-				m_buffer.len = 0;
-				mavlink::mavlink_start_checksum(&m_buffer);
-			}
-		}
+		auto msg_received = static_cast<Framing>(mavlink::mavlink_frame_char_buffer(&m_buffer, &m_parse_status, c, &message, &m_mavlink_status));
 
 		if (msg_received != Framing::incomplete) {
 			log_recv(pfx, message, msg_received);
@@ -184,14 +173,14 @@ void MAVConnInterface::send_message_ignore_drop(const mavlink::Message &msg, uin
 void MAVConnInterface::set_protocol_version(Protocol pver)
 {
 	if (pver == Protocol::V10)
-		m_status.flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+		m_mavlink_status.flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
 	else
-		m_status.flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+		m_mavlink_status.flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
 }
 
 Protocol MAVConnInterface::get_protocol_version()
 {
-	if (m_status.flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)
+	if (m_mavlink_status.flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)
 		return Protocol::V10;
 	else
 		return Protocol::V20;


### PR DESCRIPTION
Currently the dropped_packets & parse_error counters are always published as 0 in mavros_diag.cpp.
This seems to be caused by using the wrong status struct.

Seems like mavros was editing m_status after mavlink_frame_char_buffer. This struct
seems to be the parsing state, and looks like it shouldn't be modified by the caller (for example
status->parse_error is zeroed out in the end of mavlink_frame_char_buffer).
Also, the crc & signature checks done in mavros seems redundant.

r_mavlink_status seems to be the struct that holds the mavlink connection information, therefore I
changed get_status to return it instead.

This fixes #1285.