### PR TITLE
Fix global origin conversion to ecef

### DIFF
--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -237,10 +237,10 @@ private:
 			 * Note: "earth" frame, in ECEF, of the global origin
 			 */
 			GeographicLib::Geocentric earth(GeographicLib::Constants::WGS84_a(),
-					GeographicLib::Constants::WGS84_f());
+				GeographicLib::Constants::WGS84_f());
 
 			earth.Forward(g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude,
-					g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude);
+				g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude);
 
 			gp_global_origin_pub.publish(g_origin);
 		}

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -227,6 +227,10 @@ private:
 		g_origin->header.frame_id = tf_global_frame_id;
 		g_origin->header.stamp = ros::Time::now();
 
+		g_origin->position.latitude = glob_orig.latitude / 1E7;
+		g_origin->position.longitude = glob_orig.longitude / 1E7;
+		g_origin->position.altitude = glob_orig.altitude / 1E3 + m_uas->geoid_to_ellipsoid_height(&g_origin->position);	// convert height amsl to height above the ellipsoid
+
 		try {
 			/**
 			 * @brief Conversion from geodetic coordinates (LLA) to ECEF (Earth-Centered, Earth-Fixed)
@@ -235,7 +239,7 @@ private:
 			GeographicLib::Geocentric earth(GeographicLib::Constants::WGS84_a(),
 					GeographicLib::Constants::WGS84_f());
 
-			earth.Forward(glob_orig.latitude / 1E7, glob_orig.longitude / 1E7, glob_orig.altitude / 1E3,
+			earth.Forward(g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude,
 					g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude);
 
 			gp_global_origin_pub.publish(g_origin);


### PR DESCRIPTION
# Summary

A Lat/Lon/Alt(AMSL) was being converted to ECEF by a function expecting Lat/Lon/Alt(HAE), so I changed the altitude to HAE prior to converting.

# Testing

I took some data of the vehicle gps position (lat/lon/alt above ellipsoid) and the global origin (ecef) both before and after the change. During data collection, the PX4 simulation had just started and the vehicle had not moved/flown from starting point.


## Before

```
$ rostopic echo -n 1 -b gp_origin_before_2019-08-16-14-19-07.bag /mavros/global_position/raw/fix
header:
  seq: 1829
  stamp:
    secs: 1565979547
    nsecs: 336346368
  frame_id: "pose_estimation"
status:
  status: 0
  service: 1
latitude: 52.0911111
longitude: 5.1202772
altitude: 43.4971884361
position_covariance: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
position_covariance_type: 2
---

$ rostopic echo -n 1 -b gp_origin_before_2019-08-16-14-19-07.bag /mavros/global_position/gp_origin
header:
  seq: 373
  stamp:
    secs: 1565979547
    nsecs: 627877547
  frame_id: "ecef"
position:
  latitude: 3911296.44418
  longitude: 350469.193864
  altitude: 5009038.4254
---
```

## It's Wrong

But this data is inconsistent. A correct LLA to ECEF conversion would give:

```
X: 3911323 m
Y: 350472 m
Z: 5009073 m
```

which you can see from this screenshot.

![lla_to_ecef](https://user-images.githubusercontent.com/1399452/63191066-a5dc7900-c035-11e9-8d1e-1951ad525315.png)

[source link](https://www.oc.nps.edu/oc2902w/coord/llhxyz.htm?source=post_page---------------------------)

## After

```
$ rostopic echo -n 1 -b gp_origin_after_2019-08-16-14-28-29.bag
/mavros/global_position/raw/fix
header:
  seq: 655
  stamp:
    secs: 1565980109
    nsecs: 338078976
  frame_id: "pose_estimation"
status:
  status: 0
  service: 1
latitude: 52.0911111
longitude: 5.1202773
altitude: 43.5021884559
position_covariance: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
position_covariance_type: 2
---

$ rostopic echo -n 1 -b gp_origin_after_2019-08-16-14-28-29.bag /mavros/global_position/gp_origin
header:
  seq: 133
  stamp:
    secs: 1565980109
    nsecs: 393125187
  frame_id: "ecef"
position:
  latitude: 3911322.95545
  longitude: 350471.569389
  altitude: 5009072.60612
---
```

`/mavros/global_position/gp_origin` matches the expected ECEF values.