### PR TITLE
TF tree and odometry plugin

### DIFF
--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -272,6 +272,16 @@ public:
 	tf2_ros::StaticTransformBroadcaster tf2_static_broadcaster;
 
 	/**
+	 * @brief Add static transform. To publish all static transforms at once, we stack them in a std::vector.
+	 *
+	 * @param frame_id    parent frame for transform
+	 * @param child_id    child frame for transform
+	 * @param tr          transform
+	 * @param vector      vector of transforms
+	 */
+	void add_static_transform(const std::string &frame_id, const std::string &child_id, const Eigen::Affine3d &tr, std::vector<geometry_msgs::TransformStamped>& vector);
+
+	/**
 	 * @brief Publishes static transform.
 	 *
 	 * @param frame_id    parent frame for transform

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -213,19 +213,9 @@ mocap:
 
 # odom
 odometry:
-  in:
-    frame_id: "odom"
-    child_frame_id: "base_link"
-    frame_tf:
-      local_frame: "local_origin_ned"
-      body_frame_orientation: "flu"
-  out:
-    frame_tf:
-      # available: check MAV_FRAME odometry local frames in
-      # https://mavlink.io/en/messages/common.html
-      local_frame: "vision_ned"
-      # available: ned, frd or flu (though only the tf to frd is supported)
-      body_frame_orientation: "frd"
+  fcu:
+    odom_parent_id_des: "map"    # desired parent frame rotation of the FCU's odometry
+    odom_child_id_des: "base_link"    # desired child frame rotation of the FCU's odometry
 
 # px4flow
 px4flow:
@@ -238,7 +228,7 @@ px4flow:
 vision_pose:
   tf:
     listen: false           # enable tf listener (disable topic subscribers)
-    frame_id: "map"
+    frame_id: "odom"
     child_frame_id: "vision_estimate"
     rate_limit: 10.0
 
@@ -259,12 +249,12 @@ wheel_odometry:
   wheel1: {x: 0.0, y:  0.15, radius: 0.05} # x-, y-offset (m,NED) and radius (m)
   send_raw: true              # send wheel's RPM and cumulative distance (~/wheel_odometry/rpm, ~/wheel_odometry/distance)
   send_twist: false           # send geometry_msgs/TwistWithCovarianceStamped instead of nav_msgs/Odometry
-  frame_id: "map"             # origin frame
+  frame_id: "odom"             # origin frame
   child_frame_id: "base_link" # body-fixed frame
   vel_error: 0.1              # wheel velocity measurement error 1-std (m/s)
   tf:
-    send: true
-    frame_id: "map"
+    send: false
+    frame_id: "odom"
     child_frame_id: "base_link"
 
 # vim:set ts=2 sw=2 et:

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -52,12 +52,12 @@ UAS::UAS() :
 	}
 
 	// Publish helper TFs used for frame transformation in the odometry plugin
-	std::vector<geometry_msgs::TransformStamped> transformVector;
-	stack_static_transform("map", "map_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transformVector);
-	stack_static_transform("odom", "odom_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transformVector);
-	stack_static_transform("base_link", "base_link_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),transformVector);
+	std::vector<geometry_msgs::TransformStamped> transform_vector;
+	add_static_transform("map", "map_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transform_vector);
+	add_static_transform("odom", "odom_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transform_vector);
+	add_static_transform("base_link", "base_link_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),transform_vector);
 
-	tf2_static_broadcaster.sendTransform(transformVector);
+	tf2_static_broadcaster.sendTransform(transform_vector);
 }
 
 /* -*- heartbeat handlers -*- */

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -51,9 +51,13 @@ UAS::UAS() :
 		ros::shutdown();
 	}
 
-	// send static transform from "local_origin" (ENU) to "local_origin_ned" (NED)
-	publish_static_transform("local_origin", "local_origin_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)));
-	publish_static_transform("fcu", "fcu_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)));
+	// Publish helper TFs used for frame transformation in the odometry plugin
+	std::vector<geometry_msgs::TransformStamped> transformVector;
+	stack_static_transform("map", "map_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transformVector);
+	stack_static_transform("odom", "odom_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transformVector);
+	stack_static_transform("base_link", "base_link_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),transformVector);
+
+	tf2_static_broadcaster.sendTransform(transformVector);
 }
 
 /* -*- heartbeat handlers -*- */
@@ -221,6 +225,19 @@ sensor_msgs::NavSatFix::Ptr UAS::get_gps_fix()
 }
 
 /* -*- transform -*- */
+
+//! Stack static transform into vector
+void UAS::add_static_transform(const std::string &frame_id, const std::string &child_id, const Eigen::Affine3d &tr, std::vector<geometry_msgs::TransformStamped>& vector)
+{
+	geometry_msgs::TransformStamped static_transform;
+
+	static_transform.header.stamp = ros::Time::now();
+	static_transform.header.frame_id = frame_id;
+	static_transform.child_frame_id = child_id;
+	tf::transformEigenToMsg(tr, static_transform.transform);
+
+	vector.emplace_back(static_transform);
+}
 
 //! Publishes static transform
 void UAS::publish_static_transform(const std::string &frame_id, const std::string &child_id, const Eigen::Affine3d &tr)

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -68,7 +68,7 @@ public:
 	Subscriptions get_subscriptions()
 	{
 		return {
-			       make_handler(&OdometryPlugin::handle_odom)
+			make_handler(&OdometryPlugin::handle_odom)
 		};
 	}
 

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -31,103 +31,38 @@ using Matrix6d = Eigen::Matrix<double, 6, 6, Eigen::RowMajor>;
 /**
  * @brief Odometry plugin
  *
- * Sends odometry data to the FCU position and attitude estimators.
- * @see odom_cb()
+ * Sends odometry data to the FCU estimator and
+ * publishes odometry data that comes from FCU.
+ *
+ * This plugin is following ROS REP 147. Pose is expressed in parent frame. (Quaternion rotates from child to parent)
+ * The twist is expressed in the child frame.
+ *
+ * @see odom_cb()	transforming and sending odometry to fcu
+ * @see handle_odom()	receiving and transforming odometry from fcu
  */
 class OdometryPlugin : public plugin::PluginBase {
 public:
-	EIGEN_MAKE_ALIGNED_OPERATOR_NEW 	// XXX(vooon): added to try to fix #1223. Not sure that it is needed because class do not have Eigen:: fields.
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW		// XXX(vooon): added to try to fix #1223. Not sure that it is needed because class do not have Eigen:: fields.
 
 	OdometryPlugin() : PluginBase(),
 		odom_nh("~odometry"),
-		body_frame_orientation_in_desired("flu"),
-		body_frame_orientation_out_desired("frd"),
-		child_frame_id("base_link"),
-		frame_id("odom"),
-		local_frame_in("local_origin_ned"),
-		local_frame_out("vision_ned")
+		fcu_odom_parent_id_des("map"),
+		fcu_odom_child_id_des("base_link")
 	{ }
 
 	void initialize(UAS &uas_)
 	{
 		PluginBase::initialize(uas_);
 
-		odom_nh.param<std::string>("frame_id", frame_id, "odom");
-		odom_nh.param<std::string>("child_frame_id", child_frame_id, "base_link");
-
-		// frame tf params:
-		odom_nh.param<std::string>("in/frame_tf/local_frame", local_frame_in, "local_origin_ned");
-		odom_nh.param<std::string>("out/frame_tf/local_frame", local_frame_out, "vision_ned");
-		odom_nh.param<std::string>("in/frame_tf/body_frame_orientation", body_frame_orientation_in_desired, "flu");
-		odom_nh.param<std::string>("out/frame_tf/body_frame_orientation", body_frame_orientation_out_desired, "frd");
-
-		boost::algorithm::to_lower(local_frame_out);
-		boost::algorithm::to_lower(body_frame_orientation_out_desired);
+		// frame params:
+		odom_nh.param<std::string>("fcu/odom_parent_id_des", fcu_odom_parent_id_des, "map");
+		odom_nh.param<std::string>("fcu/odom_child_id_des", fcu_odom_child_id_des, "base_link");
 
 		// publishers
 		odom_pub = odom_nh.advertise<nav_msgs::Odometry>("in", 10);
 
 		// subscribers
 		odom_sub = odom_nh.subscribe("out", 10, &OdometryPlugin::odom_cb, this);
-
-		//! Map from param string to local MAV_FRAME
-		const std::unordered_map<std::string, MAV_FRAME> lf_map {
-			{ "vision_enu", MAV_FRAME::VISION_ENU },
-			{ "vision_ned", MAV_FRAME::VISION_NED },
-			{ "mocap_enu", MAV_FRAME::MOCAP_ENU },
-			{ "mocap_ned", MAV_FRAME::MOCAP_NED }
-		};
-
-		//! Map from param string to body MAV_FRAME
-		const std::unordered_map<std::string, MAV_FRAME> bf_map {
-			{ "ned", MAV_FRAME::BODY_NED },
-			{ "frd", MAV_FRAME::BODY_FRD },
-			{ "flu", MAV_FRAME::BODY_FLU }
-		};
-
-		// Determine input frame_id naming
-		if (local_frame_in == "local_origin_ned")
-			local_frame_orientation_in = local_frame_in;
-		else
-			ROS_FATAL_NAMED("odom", "ODOM: invalid input local frame \"%s\"", local_frame_in.c_str());
-
-		// Determine output frame_id naming - considering the ROS msg frame_id
-		// as "odom" by default
-		auto lf_it = lf_map.find(local_frame_out);
-		if (lf_it != lf_map.end()) {
-			lf_id = lf_it->second;
-			auto orient = local_frame_out.substr(local_frame_out.length() - 3);
-			if (orient != "enu") {
-				local_frame_orientation_out = "local_origin_" + orient;
-			} else {
-				local_frame_orientation_out = "local_origin";
-			}
-		}
-		else
-			ROS_FATAL_NAMED("odom", "ODOM: invalid ouput local frame \"%s\"", local_frame_out.c_str());
-
-		// Determine input child_frame_id naming
-		auto bf_it_in = bf_map.find(body_frame_orientation_in_desired);
-		if (bf_it_in != bf_map.end()) {
-			if (body_frame_orientation_in_desired != "flu")
-				body_frame_orientation_in_desired = "fcu_" + body_frame_orientation_in_desired;
-			else
-				body_frame_orientation_in_desired = "fcu";
-		}
-		else
-			ROS_FATAL_NAMED("odom", "ODOM: invalid input body frame orientation \"%s\"", body_frame_orientation_in_desired.c_str());
-
-		// Determine output child_frame_id naming
-		auto bf_it = bf_map.find(body_frame_orientation_out_desired);
-		if (bf_it != bf_map.end()) {
-			bf_id = bf_it->second;
-			if (body_frame_orientation_out_desired != "flu")
-				body_frame_orientation_out_desired = "fcu_" + body_frame_orientation_out_desired;
-			else
-				body_frame_orientation_in_desired = "fcu";
-		}
-		else
-			ROS_FATAL_NAMED("odom", "ODOM: invalid output body frame orientation \"%s\"", body_frame_orientation_out_desired.c_str());
 	}
 
 	Subscriptions get_subscriptions()
@@ -142,52 +77,22 @@ private:
 	ros::Publisher odom_pub;			//!< nav_msgs/Odometry publisher
 	ros::Subscriber odom_sub;			//!< nav_msgs/Odometry subscriber
 
-	std::string local_frame_in;			//!< orientation and source of the input local frame
-	std::string local_frame_out;			//!< orientation and source of the output local frame
-	std::string local_frame_orientation_in;		//!< orientation of the local frame (input data)
-	std::string local_frame_orientation_out;	//!< orientation of the local frame (output data)
-	std::string body_frame_orientation_in_desired;	//!< orientation of the body frame (input data)
-	std::string body_frame_orientation_out_desired;	//!< orientation of the body frame (output data)
-	std::string frame_id;				//!< parent frame identifier
-	std::string child_frame_id;			//!< child frame identifier
-
-	MAV_FRAME lf_id;				//!< local frame (pose) ID
-	MAV_FRAME bf_id;				//!< body frame (pose) ID
+	std::string fcu_odom_parent_id_des;			//!< desired orientation of the fcu odometry message's parent frame
+	std::string fcu_odom_child_id_des;			//!< desired orientation of the fcu odometry message's child frame
 
 	/**
-	 * @brief Lookup transforms
-	 * @todo Implement in a more general fashion in the API IOT apply frame transforms
-	 * This should also run in parallel on a thread
-	 * @param[in] &frame_id The parent frame of reference
-	 * @param[in] &child_frame_id The child frame of reference
-	 * @param[in] &local_frame_orientation The desired local frame orientation
-	 * @param[in] &body_frame_orientation The desired body frame orientation
-	 * @param[in,out] &tf_parent2local The affine transform from the parent frame to the local frame
-	 * @param[in,out] &tf_child2local The affine transform from the child frame to the local frame
-	 * @param[in,out] &tf_parent2body The affine transform from the parent frame to the body frame
-	 * @param[in,out] &tf_child2body The affine transform from the child frame to the body frame
+	 * @brief Lookup static transform with error handling
+	 * @param[in] &target The parent frame of the transformation you want to get
+	 * @param[in] &source The child frame of the transformation you want to get
+	 * @param[in,out] &tf_source2target The affine transform from the source to target
 	 */
-	void transform_lookup(const std::string &frame_id, const std::string &child_frame_id,
-		const std::string &local_frame_orientation, const std::string &body_frame_orientation,
-		Eigen::Affine3d &tf_parent2local, Eigen::Affine3d &tf_child2local,
-		Eigen::Affine3d &tf_parent2body, Eigen::Affine3d &tf_child2body)
+	void lookup_static_transform(const std::string &target, const std::string &source,
+				Eigen::Affine3d &tf_source2target)
 	{
 		try {
-			// transform lookup WRT local frame
-			tf_parent2local = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-				frame_id, local_frame_orientation,
-				ros::Time(0)));
-			tf_child2local = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-				child_frame_id, local_frame_orientation,
-				ros::Time(0)));
-
-			// transform lookup WRT body frame
-			tf_parent2body = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-				frame_id, body_frame_orientation,
-				ros::Time(0)));
-			tf_child2body = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
-				child_frame_id, body_frame_orientation,
-				ros::Time(0)));
+			// transform lookup at current time.
+			tf_source2target = tf2::transformToEigen(m_uas->tf2_buffer.lookupTransform(
+							target, source, ros::Time(0)));
 		} catch (tf2::TransformException &ex) {
 			ROS_ERROR_THROTTLE_NAMED(1, "odom", "ODOM: Ex: %s", ex.what());
 			return;
@@ -198,35 +103,26 @@ private:
 	 * @brief Handle ODOMETRY MAVlink message.
 	 *
 	 * Message specification: https://mavlink.io/en/messages/common.html#ODOMETRY
+	 *
+	 * Callback for mavlink ODOMETRY messages sent from the FCU. According to the mavlink specification,
+	 * all quantities are for the child frame (fcu_frd), expressed in the parent frame (local_origin_ned).
+	 * To be compliant with ROS REP 147 for the published nav_msgs/Odometry, the data will be appropriately
+	 * transformed and published. Frames for the publish message should be specified in specified
+	 *  in the rosparams "odometry/fcu/odom_*_id_des" (set in px4_config.yaml).
+	 *
 	 * @param msg	Received Mavlink msg
-	 * @param att	ATTITUDE msg
+	 * @param odom_msg	ODOMETRY msg
 	 */
 	void handle_odom(const mavlink::mavlink_message_t *msg, mavlink::common::msg::ODOMETRY &odom_msg)
 	{
-		/*** Send fcu_frd <-> local_origin_ned transform ***/
-		geometry_msgs::TransformStamped transform;
-		transform.header.stamp = m_uas->synchronise_stamp(odom_msg.time_usec);
-		transform.header.frame_id = "local_origin_ned";
-		transform.child_frame_id = "fcu_frd";
-
-		tf::vectorEigenToMsg(Eigen::Vector3d(odom_msg.x, odom_msg.y, odom_msg.z), transform.transform.translation);
-		tf::quaternionEigenToMsg(ftf::mavlink_to_quaternion(odom_msg.q), transform.transform.rotation);
-
-		m_uas->tf2_broadcaster.sendTransform(transform);
-		/***************************************************/
-
 		/**
-		 * Required affine rotations to apply transforms
+		 * Required rotations to transform the FCU's odometry msg tto desired parent and child frame
 		 */
-		Eigen::Affine3d tf_parent2local;
-		Eigen::Affine3d tf_child2local;
-		Eigen::Affine3d tf_parent2body;
-		Eigen::Affine3d tf_child2body;
+		Eigen::Affine3d tf_parent2parent_des;
+		Eigen::Affine3d tf_child2child_des;
 
-		//! Lookup to the required trans
-		transform_lookup("local_origin_ned", "fcu_frd",
-			local_frame_orientation_in, body_frame_orientation_in_desired,
-			tf_parent2local, tf_child2local, tf_parent2body, tf_child2body);
+		lookup_static_transform(fcu_odom_parent_id_des, "map_ned", tf_parent2parent_des);
+		lookup_static_transform( fcu_odom_child_id_des, "base_link_frd", tf_child2child_des);
 
 		//! Build 6x6 pose covariance matrix to be transformed and sent
 		Matrix6d cov_pose = Matrix6d::Zero();
@@ -245,44 +141,29 @@ private:
 
 		auto odom = boost::make_shared<nav_msgs::Odometry>();
 
-		odom->header = m_uas->synchronized_header(frame_id, odom_msg.time_usec);
-		odom->child_frame_id = child_frame_id;
+		odom->header = m_uas->synchronized_header(fcu_odom_parent_id_des, odom_msg.time_usec);
+		odom->child_frame_id = fcu_odom_child_id_des;
 
 		/**
-		 * Position parsing
+		 * Position parsing to desired parent
 		 */
-		position = Eigen::Vector3d(tf_parent2local.linear() * Eigen::Vector3d(odom_msg.x, odom_msg.y, odom_msg.z));
+		position = Eigen::Vector3d(tf_parent2parent_des.linear() * Eigen::Vector3d(odom_msg.x, odom_msg.y, odom_msg.z));
 		tf::pointEigenToMsg(position, odom->pose.pose.position);
 
 		/**
-		 * Orientation parsing
+		 * Orientation parsing. Quaternion has to be the rotation from desired child frame to desired parent frame
 		 */
-		Eigen::Quaterniond q_parent2child(ftf::mavlink_to_quaternion(odom_msg.q));
-		Eigen::Affine3d tf_local2body = tf_parent2local * q_parent2child * tf_child2body.inverse();
-		orientation = Eigen::Quaterniond(tf_local2body.linear());
+		Eigen::Quaterniond q_child2parent(ftf::mavlink_to_quaternion(odom_msg.q));
+		Eigen::Affine3d tf_childDes2parentDes = tf_parent2parent_des * q_child2parent * tf_child2child_des.inverse();
+		orientation = Eigen::Quaterniond(tf_childDes2parentDes.linear());
 		tf::quaternionEigenToMsg(orientation, odom->pose.pose.orientation);
-
-		r_pose.block<3, 3>(0, 0) = r_pose.block<3, 3>(3, 3) = tf_parent2local.linear();
 
 		/**
 		 * Velocities parsing
-		 * Linear and angular velocities are in the same frame as child_frame_id.
+		 * Linear and angular velocities are transforned to the desired child_frame.
 		 */
-		auto set_tf = [&](Eigen::Affine3d affineTf) {
-				lin_vel = Eigen::Vector3d(affineTf.linear() * Eigen::Vector3d(odom_msg.vx, odom_msg.vy, odom_msg.vz));
-				ang_vel = Eigen::Vector3d(affineTf.linear() * Eigen::Vector3d(odom_msg.rollspeed, odom_msg.pitchspeed, odom_msg.yawspeed));
-				r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = affineTf.linear();
-			};
-
-		if (odom_msg.child_frame_id == odom_msg.frame_id) {
-			// the child_frame_id would be the same reference frame as frame_id
-			set_tf(tf_child2local);
-		}
-		else {
-			// the child_frame_id would be the WRT a body frame reference
-			set_tf(tf_child2body);
-		}
-
+		lin_vel = Eigen::Vector3d(tf_child2child_des.linear() * Eigen::Vector3d(odom_msg.vx, odom_msg.vy, odom_msg.vz));
+		ang_vel = Eigen::Vector3d(tf_child2child_des.linear() * Eigen::Vector3d(odom_msg.rollspeed, odom_msg.pitchspeed, odom_msg.yawspeed));
 		tf::vectorEigenToMsg(lin_vel, odom->twist.twist.linear);
 		tf::vectorEigenToMsg(ang_vel, odom->twist.twist.angular);
 
@@ -290,10 +171,12 @@ private:
 		 * Covariances parsing
 		 */
 		//! Transform pose covariance matrix
+		r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = tf_child2child_des.linear();
 		cov_pose = r_pose * cov_pose * r_pose.transpose();
 		Eigen::Map<Matrix6d>(odom->pose.covariance.data(), cov_pose.rows(), cov_pose.cols()) = cov_pose;
 
 		//! Transform twist covariance matrix
+		r_pose.block<3, 3>(0, 0) = r_pose.block<3, 3>(3, 3) = tf_parent2parent_des.linear();
 		cov_vel = r_vel * cov_vel * r_vel.transpose();
 		Eigen::Map<Matrix6d>(odom->twist.covariance.data(), cov_vel.rows(), cov_vel.cols()) = cov_vel;
 
@@ -304,6 +187,10 @@ private:
 	/**
 	 * @brief Sends odometry data msgs to the FCU.
 	 *
+	 * Callback to odometry that should go to FCU. The frame_ids in the odom message
+	 * have to fit the frames that are are added to the tf tree. The odometry message
+	 * gets rotated such that the parent frame is "odom_ned" and the child frame is "base_link_frd".
+	 *
 	 * Message specification: https://mavlink.io/en/messages/common.html#ODOMETRY
 	 * @param req	received Odometry msg
 	 */
@@ -312,15 +199,11 @@ private:
 		/**
 		 * Required affine rotations to apply transforms
 		 */
-		Eigen::Affine3d tf_parent2local;
-		Eigen::Affine3d tf_child2local;
-		Eigen::Affine3d tf_parent2body;
-		Eigen::Affine3d tf_child2body;
+		Eigen::Affine3d tf_parent2parent_des;
+		Eigen::Affine3d tf_child2child_des;
 
-		//! Build 6x6 pose covariance matrix to be transformed and sent
-		transform_lookup(odom->header.frame_id, odom->child_frame_id,
-			local_frame_orientation_out, body_frame_orientation_out_desired,
-			tf_parent2local, tf_child2local, tf_parent2body, tf_child2body);
+		lookup_static_transform("odom_ned", odom->header.frame_id, tf_parent2parent_des);
+		lookup_static_transform("base_link_frd", odom->child_frame_id, tf_child2child_des);
 
 		//! Build 6x6 pose covariance matrix to be transformed and sent
 		ftf::Covariance6d cov_pose = odom->pose.covariance;
@@ -341,46 +224,30 @@ private:
 		Matrix6d r_vel = Matrix6d::Zero();	//!< Zero initialized velocity 6-D Covariance matrix. WRT child_frame_id
 
 		mavlink::common::msg::ODOMETRY msg {};
+		msg.frame_id = utils::enum_value(MAV_FRAME::LOCAL_FRD);
+		msg.child_frame_id = utils::enum_value(MAV_FRAME::BODY_FRD);
 
 		/**
-		 * Position and orientation are in the same frame as frame_id.
-		 * For a matter of simplicity, and given the existent MAV_FRAME
-		 * enum values, the default frame_id will be a local frame of
-		 * reference, so the pose is WRT a local frame.
+		 * Position parsing from odometry's parent frame to "LOCAL_FRD" frame.
 		 */
-		position = Eigen::Vector3d(tf_parent2local.linear() * ftf::to_eigen(odom->pose.pose.position));
-
-		// Orientation represented by a quaternion rotation from the local frame to XYZ body frame
-		Eigen::Quaterniond q_parent2child(ftf::to_eigen(odom->pose.pose.orientation));
-		Eigen::Affine3d tf_local2body = tf_parent2local * q_parent2child * tf_child2body.inverse();
-		orientation = Eigen::Quaterniond(tf_local2body.linear());
-
-		r_pose.block<3, 3>(0, 0) = r_pose.block<3, 3>(3, 3) = tf_parent2local.linear();
-
-		msg.frame_id = utils::enum_value(lf_id);
+		position = Eigen::Vector3d(tf_parent2parent_des.linear() * ftf::to_eigen(odom->pose.pose.position));
 
 		/**
-		 * Linear and angular velocities are in the same frame as child_frame_id.
-		 * Same logic here applies as above.
+		 * Orientation parsing.
 		 */
-		auto set_tf = [&](Eigen::Affine3d affineTf, MAV_FRAME frame_id) {
-				lin_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.linear));
-				ang_vel = Eigen::Vector3d(affineTf.linear() * ftf::to_eigen(odom->twist.twist.angular));
-				r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = affineTf.linear();
+		Eigen::Quaterniond q_child2parent(ftf::to_eigen(odom->pose.pose.orientation));
+		Eigen::Affine3d tf_childDes2parentDes = tf_parent2parent_des * q_child2parent * tf_child2child_des.inverse();
+		orientation = Eigen::Quaterniond(tf_childDes2parentDes.linear());
 
-				msg.child_frame_id = utils::enum_value(frame_id);
-			};
-
-		if (odom->child_frame_id == "world" || odom->child_frame_id == "odom") {
-			// the child_frame_id would be the same reference frame as frame_id
-			set_tf(tf_child2local, lf_id);
-		}
-		else {
-			// the child_frame_id would be the WRT a body frame reference
-			set_tf(tf_child2body, bf_id);
-		}
+		/**
+		 * Linear and angular velocities are transformed to base_link_frd
+		 */
+		lin_vel = Eigen::Vector3d(tf_child2child_des.linear() * ftf::to_eigen(odom->twist.twist.linear));
+		ang_vel = Eigen::Vector3d(tf_child2child_des.linear() * ftf::to_eigen(odom->twist.twist.angular));
 
 		/** Apply covariance transforms */
+		r_pose.block<3, 3>(0, 0) = r_pose.block<3, 3>(3, 3) = tf_parent2parent_des.linear();
+		r_vel.block<3, 3>(0, 0) = r_vel.block<3, 3>(3, 3) = tf_child2child_des.linear();
 		cov_pose_map = r_pose * cov_pose_map * r_pose.transpose();
 		cov_vel_map  = r_vel  * cov_vel_map  * r_vel.transpose();
 


### PR DESCRIPTION

With this PR a proper tf tree is built and the odometry plugin simplified. This should simplify providing the FCU with external position/odometry information.

Fixes #1293

The suggested changes include:
- odom plugin is not publishing tfs anymore.
- multiple static tfs are published in uas_data.cpp. (includes a fix proposed by @mhkabir )
- transform between local frame and body frame is published by local_position. 
  (needed to change the frame_id in px4_config.yaml)
- change default frame_id in px4_config.yaml for all plugin.  (to be discussed)
- simplify the odom plugin to support less frame options.
- fixed inconsistent usage and naming of transformations.

UPDATED: tf tree (including frames that are published by Realsense T265 VIO sensor):
![Screenshot from 2019-09-20 10-22-03](https://user-images.githubusercontent.com/23532607/65311425-97cbcc00-db90-11e9-8f86-3ea0109c5edc.png)

The send odometry messages, both to and from FCU, have been tested. If you want to test it your self, you have to wait for the Firmware PR that will solve some confusion in mavlink_receiver.cpp and mavlink_messages.cpp

@TSC21 @mhkabir 