### PR TITLE
Setpoint trajectory plugin using MultiDOFJointTrajectory message

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -133,6 +133,7 @@ add_library(mavros_plugins
   src/plugins/setpoint_position.cpp
   src/plugins/setpoint_raw.cpp
   src/plugins/setpoint_velocity.cpp
+  src/plugins/setpoint_trajectory.cpp
   src/plugins/sys_status.cpp
   src/plugins/sys_time.cpp
   src/plugins/vfr_hud.cpp

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -47,6 +47,9 @@
 	<class name="setpoint_raw" type="mavros::std_plugins::SetpointRawPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Access to raw POSITION_TARGET_LOCAL_NED messages.</description>
 	</class>
+	<class name="setpoint_trajectory" type="mavros::std_plugins::SetpointTrajectoryPlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>Send to FCU setpoints from trajectory.</description>
+	</class>
 	<class name="vfr_hud" type="mavros::std_plugins::VfrHudPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish VFR HUD data and WIND estimations.</description>
 	</class>

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -121,19 +121,32 @@ private:
 			position = ftf::to_eigen(setpoint_target->transforms[0].translation);
 			tf::quaternionMsgToEigen(setpoint_target->transforms[0].rotation, attitude);
 		} else {
-			type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::X_IGNORE) | uint16_t(POSITION_TARGET_TYPEMASK::Y_IGNORE) | uint16_t(POSITION_TARGET_TYPEMASK::Z_IGNORE);
+			type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::X_IGNORE)
+							| uint16_t(POSITION_TARGET_TYPEMASK::Y_IGNORE) 
+							| uint16_t(POSITION_TARGET_TYPEMASK::Z_IGNORE);
+
 		}
 
-		if(!setpoint_target->velocities.empty()) velocity = ftf::to_eigen(setpoint_target->velocities[0].linear);
-		else type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::VX_IGNORE) | uint16_t(POSITION_TARGET_TYPEMASK::VY_IGNORE) | uint16_t(POSITION_TARGET_TYPEMASK::VZ_IGNORE);
+		if(!setpoint_target->velocities.empty()){
+			velocity = ftf::to_eigen(setpoint_target->velocities[0].linear);
+
+		} else {
+			type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::VX_IGNORE)
+							| uint16_t(POSITION_TARGET_TYPEMASK::VY_IGNORE) 
+							| uint16_t(POSITION_TARGET_TYPEMASK::VZ_IGNORE);
+
+		}
 		
-		if(!setpoint_target->accelerations.empty()) af = ftf::to_eigen(setpoint_target->accelerations[0].linear);
-		else type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::AX_IGNORE) | uint16_t(POSITION_TARGET_TYPEMASK::AY_IGNORE) | uint16_t(POSITION_TARGET_TYPEMASK::AZ_IGNORE);
+		if(!setpoint_target->accelerations.empty()){
+			af = ftf::to_eigen(setpoint_target->accelerations[0].linear);
+		} else {
+			type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::AX_IGNORE) 
+							| uint16_t(POSITION_TARGET_TYPEMASK::AY_IGNORE) 
+							| uint16_t(POSITION_TARGET_TYPEMASK::AZ_IGNORE);
+
+		}
 
 		// Transform frame ENU->NED
-		position = ftf::transform_frame_enu_ned(position);
-		velocity = ftf::transform_frame_enu_ned(velocity);
-		af = ftf::transform_frame_enu_ned(af);
 		Eigen::Quaterniond q = ftf::transform_orientation_enu_ned(
 				ftf::transform_orientation_baselink_aircraft(attitude));
 		yaw = ftf::quaternion_get_yaw(q);
@@ -142,9 +155,9 @@ private:
 					trajectory_target_msg->header.stamp.toNSec() / 1000000,
 					1,
 					type_mask,
-					position,
-					velocity,
-					af,
+					ftf::transform_frame_enu_ned(position),
+					ftf::transform_frame_enu_ned(velocity),
+					ftf::transform_frame_enu_ned(af),
 					yaw, 0);
 	
 		next_setpoint_target = setpoint_target + 1;

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -120,6 +120,7 @@ private:
 		if(!setpoint_target->transforms.empty()){
 			position = ftf::to_eigen(setpoint_target->transforms[0].translation);
 			tf::quaternionMsgToEigen(setpoint_target->transforms[0].rotation, attitude);
+
 		} else {
 			type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::X_IGNORE)
 							| uint16_t(POSITION_TARGET_TYPEMASK::Y_IGNORE) 
@@ -139,6 +140,7 @@ private:
 		
 		if(!setpoint_target->accelerations.empty()){
 			af = ftf::to_eigen(setpoint_target->accelerations[0].linear);
+
 		} else {
 			type_mask = type_mask | uint16_t(POSITION_TARGET_TYPEMASK::AX_IGNORE) 
 							| uint16_t(POSITION_TARGET_TYPEMASK::AY_IGNORE) 
@@ -152,7 +154,7 @@ private:
 		yaw = ftf::quaternion_get_yaw(q);
 
 		set_position_target_local_ned(
-					trajectory_target_msg->header.stamp.toNSec() / 1000000,
+					ros::Time::now().toNSec() / 1000000,
 					1,
 					type_mask,
 					ftf::transform_frame_enu_ned(position),

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -1,0 +1,169 @@
+/**
+ * @brief SetpointTRAJECTORY plugin
+ * @file setpoint_trajectory.cpp
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2019 Jaeyoung Lim.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <mavros/setpoint_mixin.h>
+#include <eigen_conversions/eigen_msg.h>
+
+#include <mavros_msgs/PositionTarget.h>
+#include <trajectory_msgs/MultiDOFJointTrajectory.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief Setpoint TRAJECTORY plugin
+ *
+ * Receive trajectory setpoints and send setpoint_raw setpoints along the trajectory.
+ */
+class SetpointTrajectoryPlugin : public plugin::PluginBase,
+	private plugin::SetPositionTargetLocalNEDMixin<SetpointTrajectoryPlugin>,
+	private plugin::SetPositionTargetGlobalIntMixin<SetpointTrajectoryPlugin>,
+	private plugin::SetAttitudeTargetMixin<SetpointTrajectoryPlugin> {
+public:
+	SetpointTrajectoryPlugin() : PluginBase(),
+		sp_nh("~setpoint_trajectory"),
+		TRAJ_SAMPLING_DT(TRAJ_SAMPLING_MS / 1000.0)
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		bool tf_listen;
+
+		local_sub = sp_nh.subscribe("local", 10, &SetpointTrajectoryPlugin::local_cb, this);
+		target_local_pub = sp_nh.advertise<mavros_msgs::PositionTarget>("target_trajectory", 10);
+
+		sp_timer = sp_nh.createTimer(ros::Duration(0.01), &SetpointTrajectoryPlugin::reference_cb, this);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return {
+				make_handler(&SetpointTrajectoryPlugin::handle_position_target_local_ned),
+		};
+	}
+
+private:
+	friend class SetPositionTargetLocalNEDMixin;
+	friend class SetPositionTargetGlobalIntMixin;
+	friend class SetAttitudeTargetMixin;
+	ros::NodeHandle sp_nh;
+
+	ros::Timer sp_timer;
+
+	ros::Time refstart_time;
+
+	ros::Subscriber local_sub, global_sub, attitude_sub;
+	ros::Publisher target_local_pub, target_global_pub, target_attitude_pub;
+
+	trajectory_msgs::MultiDOFJointTrajectory trajectory_target_msg;
+
+	static constexpr int TRAJ_SAMPLING_MS = 100;
+
+	const ros::Duration TRAJ_SAMPLING_DT;
+
+	/* -*- message handlers -*- */
+	void handle_position_target_local_ned(const mavlink::mavlink_message_t *msg, mavlink::common::msg::POSITION_TARGET_LOCAL_NED &tgt)
+	{
+		// Transform desired position,velocities,and accels from ENU to NED frame
+		auto position = ftf::transform_frame_ned_enu(Eigen::Vector3d(tgt.x, tgt.y, tgt.z));
+		auto velocity = ftf::transform_frame_ned_enu(Eigen::Vector3d(tgt.vx, tgt.vy, tgt.vz));
+		auto af = ftf::transform_frame_ned_enu(Eigen::Vector3d(tgt.afx, tgt.afy, tgt.afz));
+		float yaw = ftf::quaternion_get_yaw(
+					ftf::transform_orientation_aircraft_baselink(
+						ftf::transform_orientation_ned_enu(
+							ftf::quaternion_from_rpy(0.0, 0.0, tgt.yaw))));
+		Eigen::Vector3d ang_vel_ned(0.0, 0.0, tgt.yaw_rate);
+		auto ang_vel_enu = ftf::transform_frame_ned_enu(ang_vel_ned);
+		float yaw_rate = ang_vel_enu.z();
+
+		auto target = boost::make_shared<mavros_msgs::PositionTarget>();
+
+		target->header.stamp = m_uas->synchronise_stamp(tgt.time_boot_ms);
+		target->coordinate_frame = tgt.coordinate_frame;
+		target->type_mask = tgt.type_mask;
+		tf::pointEigenToMsg(position, target->position);
+		tf::vectorEigenToMsg(velocity, target->velocity);
+		tf::vectorEigenToMsg(af, target->acceleration_or_force);
+		target->yaw = yaw;
+		target->yaw_rate = yaw_rate;
+
+		target_local_pub.publish(target);
+	}
+
+	/* -*- callbacks -*- */
+
+	void local_cb(const trajectory_msgs::MultiDOFJointTrajectory& msg)
+	{
+		trajectory_target_msg = msg;
+
+		//Start trajectory from when trajectory message was received
+		//TODO: Should this be the time that is stamped in the trajectory?
+		refstart_time = ros::Time::now();
+	}
+
+	void reference_cb(const ros::TimerEvent &event)
+	{
+
+		ros::Duration curr_time_from_start;
+		curr_time_from_start = ros::Time::now() - refstart_time;
+	
+		for(size_t i = 0; i < trajectory_target_msg.points.size(); i++){
+
+			Eigen::Vector3d position, velocity, af;
+			Eigen::Quaterniond attitude;
+			float yaw, yaw_rate;
+			trajectory_msgs::MultiDOFJointTrajectoryPoint pt = trajectory_target_msg.points[i];
+			uint16_t type_mask;
+			if(pt.time_from_start.toSec() >= curr_time_from_start.toSec() ) { //TODO: Better logic to handle this case?
+				if(!pt.transforms.empty()){
+				position << pt.transforms[0].translation.x, pt.transforms[0].translation.y, pt.transforms[0].translation.z;
+				attitude = Eigen::Quaterniond(pt.transforms[0].rotation.w, pt.transforms[0].rotation.x, pt.transforms[0].rotation.y, pt.transforms[0].rotation.z);
+				} else {
+					type_mask = type_mask || mavros_msgs::PositionTarget::IGNORE_PX || mavros_msgs::PositionTarget::IGNORE_PY || mavros_msgs::PositionTarget::IGNORE_PZ;
+				}
+
+				if(!pt.velocities.empty()) velocity << pt.velocities[0].linear.x, pt.velocities[0].linear.y, pt.velocities[0].linear.z;
+				else type_mask = type_mask || mavros_msgs::PositionTarget::IGNORE_VX || mavros_msgs::PositionTarget::IGNORE_VY || mavros_msgs::PositionTarget::IGNORE_VZ;
+				
+				if(!pt.accelerations.empty()) af << pt.accelerations[0].linear.x, pt.accelerations[0].linear.y, pt.accelerations[0].linear.z;
+				else type_mask = type_mask || mavros_msgs::PositionTarget::IGNORE_VX || mavros_msgs::PositionTarget::IGNORE_VY || mavros_msgs::PositionTarget::IGNORE_VZ;
+
+				// Transform frame ENU->NED
+				position = ftf::transform_frame_enu_ned(position);
+				velocity = ftf::transform_frame_enu_ned(velocity);
+				af = ftf::transform_frame_enu_ned(af);
+				yaw = ftf::quaternion_get_yaw(attitude);
+
+				set_position_target_local_ned(
+							trajectory_target_msg.header.stamp.toNSec() / 1000000,
+							1,
+							0,
+							position,
+							velocity,
+							af,
+							yaw, 0);
+				break;
+			}
+		}
+	}
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::SetpointTrajectoryPlugin, mavros::plugin::PluginBase)

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -71,6 +71,9 @@ public:
 
 private:
 	friend class SetPositionTargetLocalNEDMixin;
+	using lock_guard = std::lock_guard<std::mutex>;
+	std::mutex mutex;
+
 	ros::NodeHandle sp_nh;
 
 	ros::Timer sp_timer;
@@ -118,6 +121,8 @@ private:
 
 	void local_cb(const trajectory_msgs::MultiDOFJointTrajectory::ConstPtr &req)
 	{
+		lock_guard lock(mutex);
+
 		if(static_cast<MAV_FRAME>(mav_frame) == MAV_FRAME::BODY_NED || static_cast<MAV_FRAME>(mav_frame) == MAV_FRAME::BODY_OFFSET_NED){
 			transform = ftf::StaticTF::BASELINK_TO_AIRCRAFT;
 		} else {
@@ -135,6 +140,7 @@ private:
 	void reference_cb(const ros::TimerEvent &event)
 	{
 		using mavlink::common::POSITION_TARGET_TYPEMASK;
+		lock_guard lock(mutex);
 
 		if(!trajectory_target_msg)
 			return;

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -142,7 +142,7 @@ private:
 		Eigen::Vector3d position, velocity, af;
 		Eigen::Quaterniond attitude;
 		float yaw, yaw_rate;
-		uint16_t type_mask;		
+		uint16_t type_mask = 0;		
 		if(!setpoint_target->transforms.empty()){
 			position = ftf::detail::transform_static_frame(ftf::to_eigen(setpoint_target->transforms[0].translation), transform);
 			attitude = ftf::detail::transform_orientation(ftf::to_eigen(setpoint_target->transforms[0].rotation), transform);


### PR DESCRIPTION
As MAVs are dynamically constrained, the capability to track trajectories are important for high performance maneuvers. As the flight controller do not provide trajectory tracking capabilities, current implementation of trajectory planners usually send setpoints to the flight controller in order of time. This trivial task has been implemented on the planner side outside of mavros.

This PR adds a plugin to mavros for setting a trajectory as a setpoint using the [MultiDOFJointTrajectory](http://docs.ros.org/melodic/api/trajectory_msgs/html/msg/MultiDOFJointTrajectory.html) message.

The plugin receives a trajectory, and sends the reference with the [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED) message to the flight controller by comparing the time in the trajectory message.

It also publishes the desired trajectory as a `nav_msgs/Path` message so that it can be visualized.
@mhkabir 