### PR TITLE
Fix uninitialized IMU data

### DIFF
--- a/mavros/src/plugins/imu.cpp
+++ b/mavros/src/plugins/imu.cpp
@@ -192,11 +192,11 @@ private:
 		imu_ned_msg->angular_velocity_covariance = angular_velocity_cov;
 		imu_ned_msg->linear_acceleration_covariance = linear_acceleration_cov;
 
-		if(!received_linear_accel) {
+		if (!received_linear_accel) {
 			// Set element 0 of covariance matrix to -1 if no data received as per sensor_msgs/Imu defintion
 			imu_enu_msg->linear_acceleration_covariance[0] = -1;
 			imu_ned_msg->linear_acceleration_covariance[0] = -1;
-			}
+		}
 
 		/** Store attitude in base_link ENU
 		 *  @snippet src/plugins/imu.cpp store_enu

--- a/mavros/src/plugins/imu.cpp
+++ b/mavros/src/plugins/imu.cpp
@@ -52,7 +52,10 @@ public:
 		has_hr_imu(false),
 		has_raw_imu(false),
 		has_scaled_imu(false),
-		has_att_quat(false)
+		has_att_quat(false),
+		received_linear_accel(false),
+		linear_accel_vec_flu(Eigen::Vector3d::Zero()),
+		linear_accel_vec_frd(Eigen::Vector3d::Zero())
 	{ }
 
 	void initialize(UAS &uas_)
@@ -118,6 +121,7 @@ private:
 	bool has_raw_imu;
 	bool has_scaled_imu;
 	bool has_att_quat;
+	bool received_linear_accel;
 	Eigen::Vector3d linear_accel_vec_flu;
 	Eigen::Vector3d linear_accel_vec_frd;
 	ftf::Covariance3d linear_acceleration_cov;
@@ -188,6 +192,12 @@ private:
 		imu_ned_msg->angular_velocity_covariance = angular_velocity_cov;
 		imu_ned_msg->linear_acceleration_covariance = linear_acceleration_cov;
 
+		if(!received_linear_accel) {
+			// Set element 0 of covariance matrix to -1 if no data received as per sensor_msgs/Imu defintion
+			imu_enu_msg->linear_acceleration_covariance[0] = -1;
+			imu_ned_msg->linear_acceleration_covariance[0] = -1;
+			}
+
 		/** Store attitude in base_link ENU
 		 *  @snippet src/plugins/imu.cpp store_enu
 		 */
@@ -231,6 +241,7 @@ private:
 		// Save readings
 		linear_accel_vec_flu = accel_flu;
 		linear_accel_vec_frd = accel_frd;
+		received_linear_accel = true;
 
 		imu_msg->orientation_covariance = unk_orientation_cov;
 		imu_msg->angular_velocity_covariance = angular_velocity_cov;


### PR DESCRIPTION
Depending on order of messages from the FCU, it was possible for the `imu/data` topic messages to contain uninitialised linear acceleration values. Added initialisation of the `linear_accel` values.

Also added a check that accelerometer data has been received. If this is not the case, element 0 of the covariance matrix is set to -1 as per the [`sensor_msgs/Imu`](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html) definition.