### PR TITLE
Use SET_POSITION_TARGET_GLBOAL_INT for global position setpoints

### DIFF
--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -92,6 +92,7 @@ public:
 
 private:
 	friend class SetPositionTargetLocalNEDMixin;
+	friend class SetPositionTargetGlobalIntMixin;
 	friend class TF2ListenerMixin;
 
 	ros::NodeHandle sp_nh;


### PR DESCRIPTION
Previously global position setpoints were converted into local position setpoints in the setpoint position plugin. This was a workaround since flight controllers were not supporting the mavlink message `SET_POSITION_TARGET_GLOBAL_INT`.

Following https://github.com/PX4/Firmware/pull/12819, I think it makes sense to have the proper implementation of passing the [`SET_POSITION_TARGET_GLOBAL_INT`](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT) for setpoints. I did not get rid of the previous workaround on converting the global position setpoints to local position setpoints, but moved it to subscribe to the topic `~global_to_local` to make it more explicit that it is doing the conversions on the companion side. 

Still there are a few things that needs to be resolved:
a. I am having problems using `plugin::SetPositionTargetGlobalIntMixin` with the following error. 
```
Errors     << mavros:make /home/jaeyoung/catkin_ws/logs/mavros/build.make.000.log                                                                                                                                                                                                                               
In file included from /home/jaeyoung/catkin_ws/src/mavros/mavros/src/plugins/setpoint_position.cpp:18:0:
/home/jaeyoung/catkin_ws/src/mavros/mavros/include/mavros/setpoint_mixin.h: In instantiation of ‘void mavros::plugin::SetPositionTargetGlobalIntMixin<D>::set_position_target_global_int(uint32_t, uint8_t, uint16_t, int32_t, int32_t, float, Eigen::Vector3d, Eigen::Vector3d, float, float) [with D = mavros::std_plugins::SetpointPositionPlugin; uint32_t = unsigned int; uint8_t = unsigned char; uint16_t = short unsigned int; int32_t = int; Eigen::Vector3d = Eigen::Matrix<double, 3, 1>]’:
/home/jaeyoung/catkin_ws/src/mavros/mavros/src/plugins/setpoint_position.cpp:262:3:   required from here
/home/jaeyoung/catkin_ws/src/mavros/mavros/include/mavros/setpoint_mixin.h:91:25: error: ‘mavros::plugin::SetPositionTargetGlobalIntMixin<mavros::std_plugins::SetpointPositionPlugin>’ is an inaccessible base of ‘mavros::std_plugins::SetpointPositionPlugin’
   mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
```

b. @TSC21 suggested to use `geographic_msgs/GeoPoint` for the global position setpoints, but the fields for yaw, velocity and acceleration fields are missing that will be filled out in `SET_POSITION_TARGET_GLOBAL_INT`. Would having another subscriber for attitude make sense?