### PR TITLE
added manual flag to mavros/state

### DIFF
--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -728,6 +728,7 @@ private:
 		state_msg->connected = true;
 		state_msg->armed = !!(hb.base_mode & enum_value(MAV_MODE_FLAG::SAFETY_ARMED));
 		state_msg->guided = !!(hb.base_mode & enum_value(MAV_MODE_FLAG::GUIDED_ENABLED));
+		state_msg->manual_input = !!(hb.base_mode & enum_value(MAV_MODE_FLAG::MANUAL_INPUT_ENABLED));
 		state_msg->mode = vehicle_mode;
 		state_msg->system_status = hb.system_status;
 

--- a/mavros_msgs/msg/State.msg
+++ b/mavros_msgs/msg/State.msg
@@ -11,5 +11,6 @@ std_msgs/Header header
 bool connected
 bool armed
 bool guided
+bool manual_input
 string mode
 uint8 system_status


### PR DESCRIPTION
We need to know whether the drone is in a manual state or not. In the HEARTBEAT mavlink message there is a flag for that. The alternative would be to see if /mavros/state/mode is any of the manual modes, but this PR would be more compliant with mavlink. 