### PR TITLE
Add mount mode with MAV_CMD_DO_MOUNT_CONFIGURE

### DIFF
--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -37,6 +37,7 @@ using utils::enum_value;
 class MountControlPlugin : public plugin::PluginBase {
 public:
 	MountControlPlugin() : PluginBase(),
+	nh("~"),
 	mount_nh("~mount_control")
 	{ }
 
@@ -55,6 +56,7 @@ public:
 	}
 
 private:
+	ros::NodeHandle nh;
 	ros::NodeHandle mount_nh;
 	ros::Subscriber command_sub;
  	ros::ServiceServer configure_srv;
@@ -89,7 +91,7 @@ private:
         using mavlink::common::MAV_CMD;
 
         try {
-            auto client = mount_nh.serviceClient<mavros_msgs::CommandLong>("cmd/command");
+            auto client = nh.serviceClient<mavros_msgs::CommandLong>("cmd/command");
 
             mavros_msgs::CommandLong cmd{};
 

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -80,6 +80,7 @@ add_service_files(
   LogRequestData.srv
   LogRequestEnd.srv
   LogRequestList.srv
+  MountConfigure.srv
   MessageInterval.srv
   ParamGet.srv
   ParamPull.srv

--- a/mavros_msgs/srv/MountConfigure.srv
+++ b/mavros_msgs/srv/MountConfigure.srv
@@ -3,19 +3,25 @@
 
 std_msgs/Header header
 
-uint8 mode # See enum MAV_MOUNT_MODE.
-uint8 MAV_MOUNT_MODE_RETRACT = 0
-uint8 MAV_MOUNT_MODE_NEUTRAL = 1
-uint8 MAV_MOUNT_MODE_MAVLINK_TARGETING = 2
-uint8 MAV_MOUNT_MODE_RC_TARGETING = 3
-uint8 MAV_MOUNT_MODE_GPS_POINT = 4
+uint8 mode              # See enum MAV_MOUNT_MODE.
+#MAV_MOUNT_MODE
+uint8 MODE_RETRACT = 0
+uint8 MODE_NEUTRAL = 1
+uint8 MODE_MAVLINK_TARGETING = 2
+uint8 MODE_RC_TARGETING = 3
+uint8 MODE_GPS_POINT = 4
 
-bool stabilize_roll # stabilize roll? (1 = yes, 0 = no)
-bool stabilize_pitch # stabilize pitch? (1 = yes, 0 = no)
-bool stabilize_yaw # stabilize yaw? (1 = yes, 0 = no)
-uint8 roll_input # roll input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)
-uint8 pitch_input # pitch input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)
-uint8 yaw_input # yaw input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)
+bool stabilize_roll     # stabilize roll? (1 = yes, 0 = no)
+bool stabilize_pitch    # stabilize pitch? (1 = yes, 0 = no)
+bool stabilize_yaw      # stabilize yaw? (1 = yes, 0 = no)
+uint8 roll_input        # roll input (See enum MOUNT_INPUT)
+uint8 pitch_input       # pitch input (See enum MOUNT_INPUT)
+uint8 yaw_input         # yaw input (See enum MOUNT_INPUT)
+
+#MOUNT_INPUT
+uint8 INPUT_ANGLE_BODY_FRAME = 0
+uint8 INPUT_ANGULAR_RATE = 1
+uint8 INPUT_ANGLE_ABSOLUTE_FRAME = 2
 ---
 bool success
 # raw result returned by COMMAND_ACK

--- a/mavros_msgs/srv/MountConfigure.srv
+++ b/mavros_msgs/srv/MountConfigure.srv
@@ -1,0 +1,22 @@
+# MAVLink message: DO_MOUNT_CONTROL
+# https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONFIGURE
+
+std_msgs/Header header
+
+uint8 mode # See enum MAV_MOUNT_MODE.
+uint8 MAV_MOUNT_MODE_RETRACT = 0
+uint8 MAV_MOUNT_MODE_NEUTRAL = 1
+uint8 MAV_MOUNT_MODE_MAVLINK_TARGETING = 2
+uint8 MAV_MOUNT_MODE_RC_TARGETING = 3
+uint8 MAV_MOUNT_MODE_GPS_POINT = 4
+
+bool stabilize_roll # stabilize roll? (1 = yes, 0 = no)
+bool stabilize_pitch # stabilize pitch? (1 = yes, 0 = no)
+bool stabilize_yaw # stabilize yaw? (1 = yes, 0 = no)
+uint8 roll_input # roll input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)
+uint8 pitch_input # pitch input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)
+uint8 yaw_input # yaw input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)
+---
+bool success
+# raw result returned by COMMAND_ACK
+uint8 result


### PR DESCRIPTION
This PR is a follow up of #1257 where it adds a service to configure the `MOUNT_MODE` for the `mount_control` plugin