### PR TITLE
moving ACK_TIMEOUT_DEFAULT out of class

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -28,6 +28,7 @@
 
 namespace mavros {
 namespace std_plugins {
+static constexpr double ACK_TIMEOUT_DEFAULT = 5.0;
 using utils::enum_value;
 using lock_guard = std::lock_guard<std::mutex>;
 using unique_lock = std::unique_lock<std::mutex>;
@@ -105,7 +106,6 @@ private:
 	bool use_comp_id_system_control;
 
 	L_CommandTransaction ack_waiting_list;
-	static constexpr double ACK_TIMEOUT_DEFAULT = 5.0;
 	ros::Duration command_ack_timeout_dt;
 
 	/* -*- message handlers -*- */


### PR DESCRIPTION
Due to a recent commit, I got the following erros:

```
[ERROR] [1569574307.019612897]: Plugin command load exception: Failed to load library /home/dummy/sitebots-controller/devel/lib//libmavros_plugins.so. Make sure that you are calling the PLU
GINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library (Poco exception = /home/dummy/sitebots-con
troller/devel/lib//libmavros_plugins.so: undefined symbol: _ZN6mavros11std_plugins13CommandPlugin19ACK_TIMEOUT_DEFAULTE)
```

Moving the static constexpr ACK_TIMEOUT_DEFAULT out of the class resolved that issue for me. This is consistent with the double constants in ./mavros/src/plugins/imu.cpp and ./mavros/src/plugins/hil.cpp.