### PR TITLE
Add vtol plugin for vtol transitions

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -25,6 +25,7 @@
 #include <mavros_msgs/CommandTOL.h>
 #include <mavros_msgs/CommandTriggerControl.h>
 #include <mavros_msgs/CommandTriggerInterval.h>
+#include <mavros_msgs/CommandVtolTransition.h>
 
 namespace mavros {
 namespace std_plugins {
@@ -74,6 +75,7 @@ public:
 		land_srv = cmd_nh.advertiseService("land", &CommandPlugin::land_cb, this);
 		trigger_control_srv = cmd_nh.advertiseService("trigger_control", &CommandPlugin::trigger_control_cb, this);
 		trigger_interval_srv = cmd_nh.advertiseService("trigger_interval", &CommandPlugin::trigger_interval_cb, this);
+		vtol_transition_srv = cmd_nh.advertiseService("vtol_transition", &CommandPlugin::vtol_transition_cb, this);
 	}
 
 	Subscriptions get_subscriptions()
@@ -97,6 +99,7 @@ private:
 	ros::ServiceServer land_srv;
 	ros::ServiceServer trigger_control_srv;
 	ros::ServiceServer trigger_interval_srv;
+	ros::ServiceServer vtol_transition_srv;
 
 	bool use_comp_id_system_control;
 
@@ -387,6 +390,17 @@ private:
 				req.integration_time,
 				0, 0, 0, 0, 0,
 				res.success, res.result);
+	}
+
+	bool vtol_transition_cb(mavros_msgs::CommandVtolTransition::Request &req,
+			mavros_msgs::CommandVtolTransition::Response &res)
+	{
+		using mavlink::common::MAV_CMD;
+		return send_command_long_and_wait(false,
+			enum_value(MAV_CMD::DO_VTOL_TRANSITION), false,
+			req.state,
+			0, 0, 0, 0, 0, 0,
+			res.success, res.result);
 	}
 };
 }	// namespace std_plugins

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -66,6 +66,7 @@ add_service_files(
   CommandTOL.srv
   CommandTriggerControl.srv
   CommandTriggerInterval.srv
+  CommandVtolTransition.srv
   FileChecksum.srv
   FileClose.srv
   FileList.srv

--- a/mavros_msgs/srv/CommandVtolTransition.srv
+++ b/mavros_msgs/srv/CommandVtolTransition.srv
@@ -1,0 +1,16 @@
+
+# MAVLink command: DO_VTOL_TRANSITION
+# https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION
+
+std_msgs/Header header
+
+# MAV_VTOL_STATE
+uint8 STATE_MC = 3
+uint8 STATE_FW = 4
+
+uint8 state              # See enum MAV_VTOL_STATE.
+
+---
+bool success
+uint8 result            # Raw result returned by COMMAND_ACK
+ 


### PR DESCRIPTION
Recent [support](https://github.com/PX4/Firmware/pull/12532) for offboard mode on fixedwing has enabled VTOLs to be controlled fully in offboard mode in both fixed wing and multirotor modes.

This PR enables being able to command a transition using the `MAV_CMD_DO_VTOL_TRANSITION` mavlink message to trigger a transition using a rosservice.

The video and log below shows a single position setpoint is sent to the vehicle as [0, 0, 10.0], and a transition is triggered in between. The setpoint is passed on as a L1 reference, therefore the vehicle circles around the setpoint when in fixed wing mode.

Video: https://youtu.be/NZy6nbt0cnk
Log: https://review.px4.io/plot_app?log=fbf73fe6-ee15-437a-a0cb-3d3da0037222