### PR TITLE
landing_target: Fix cartesian to displacement bug

### DIFF
--- a/mavros_extras/src/plugins/landing_target.cpp
+++ b/mavros_extras/src/plugins/landing_target.cpp
@@ -197,19 +197,19 @@ private:
 	void inline cartesian_to_displacement(const Eigen::Vector3d &pos, Eigen::Vector2f &angle) {
 		float angle_rad = atan(pos.y() / pos.x()) * (M_PI / 180.0);
 
-		if ((pos.x() && pos.y()) > 0) {
+		if (pos.x() > 0 && pos.y() > 0) {
 			angle.x() = angle_rad;
 			angle.y() = -angle_rad;
 		}
-		else if ((pos.x() < 0 && pos.y()) > 0) {
+		else if (pos.x() < 0 && pos.y() > 0) {
 			angle.x() = M_PI - angle_rad;
 			angle.y() = angle_rad;
 		}
-		else if ((pos.x() && pos.y()) < 0) {
+		else if (pos.x() < 0 && pos.y() < 0) {
 			angle.x() = M_PI + angle_rad;
 			angle.y() = M_PI - angle_rad;
 		}
-		else if ((pos.x() < 0 && pos.y()) < 0) {
+		else if (pos.x() > 0 && pos.y() < 0) {
 			angle.x() = -angle_rad;
 			angle.y() = M_PI + angle_rad;
 		}


### PR DESCRIPTION
I think these four conditionals are buggy:

The first is    (x and y) > 0
and should be   (x > 0) and (y > 0)
(This one actually works the way it's written.)

The second is   (x < 0 and y) > 0
and should be   (x < 0) and (y > 0)

The third is    (x and y) < 0
and should be   (x < 0) and (y < 0)

The fourth is   (x < 0 and y) < 0
and should be   (x > 0) and (y < 0)