### PR TITLE
Add trajectory_msgs as dependency

### DIFF
--- a/mavros_extras/package.xml
+++ b/mavros_extras/package.xml
@@ -25,6 +25,7 @@
   <depend>mavros_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>trajectory_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>urdf</depend>
   <depend>tf</depend>


### PR DESCRIPTION
This Fixes #1344 where it adds a new dependency for `trajectory_msgs` that was introduced by #1301 