### PR TITLE
obstacle_distance: Fix wrong angle increment

### DIFF
--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -82,7 +82,7 @@ private:
 				}
 			}
 			std::fill(obstacle.distances.begin() + req->ranges.size(), obstacle.distances.end(), UINT16_MAX);	//!< fill the rest of the array values as "Unknown"
-			obstacle.increment = req->angle_increment * RAD_TO_DEG;				//!< [degrees]
+			obstacle.increment_f = req->angle_increment * RAD_TO_DEG;				//!< [degrees]
 		} else {
 			// all distances from sensor will not fit so we combine adjacent distances always taking the shortest distance
 			size_t scale_factor = ceil(double(req->ranges.size()) / obstacle.distances.size());

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -82,7 +82,10 @@ private:
 				}
 			}
 			std::fill(obstacle.distances.begin() + req->ranges.size(), obstacle.distances.end(), UINT16_MAX);	//!< fill the rest of the array values as "Unknown"
-			obstacle.increment_f = req->angle_increment * RAD_TO_DEG;				//!< [degrees]
+
+			const float increment_deg = req->angle_increment * RAD_TO_DEG;
+			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);  //!< Round to nearest integer.
+			obstacle.increment_f = increment_deg;
 		} else {
 			// all distances from sensor will not fit so we combine adjacent distances always taking the shortest distance
 			size_t scale_factor = ceil(double(req->ranges.size()) / obstacle.distances.size());


### PR DESCRIPTION
The computation `req->angle_increment * RAD_TO_DEG` correctly computes
angle increment in degrees as a float, but the `increment` field of the
OBSTACLE_DISTANCE MAVLink message is a uint8, so the float value gets
truncated. So if your real increment is 10 degrees, you may have a floating
point value of something like 9.9999997, which results in the integer value
9 getting written to the increment field.

An improvement would be to round properly, with something like

`static_cast<uint8_t>(increment_deg_float)`,

but a better solution is to allow non-integer degree values for the
increment, which is supported by the `increment_f` field. According
to the MAVLink reference, increment_f is used instead of increment
whenever increment_f is nonzero.

---

NOTE: `increment_f` is a Mavlink 2 extension, so I dunno if it's okay to assume that we're running Mavlink 2, or if I need to add a check for that and alternatively use the old uint `increment` field.