### PR TITLE
Change odometry subscription queue to 1 to avoid buffering.

### DIFF
--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -62,7 +62,7 @@ public:
 		odom_pub = odom_nh.advertise<nav_msgs::Odometry>("in", 10);
 
 		// subscribers
-		odom_sub = odom_nh.subscribe("out", 10, &OdometryPlugin::odom_cb, this);
+		odom_sub = odom_nh.subscribe("out", 1, &OdometryPlugin::odom_cb, this);
 	}
 
 	Subscriptions get_subscriptions()


### PR DESCRIPTION
I was fighting a delay pushing odom over sik radios because I wanted to get mocap working without an onboard computer for a particular application. I fixed this by setting the subscription queue to 1 and I think this is probably a good idea in general.