### PR TITLE
mavros_extras/obstacle_distance: Change namespace, add angle_offset

### DIFF
--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -259,6 +259,6 @@ wheel_odometry:
 
 # obstacle_distance
 obstacle_distance:
-  mav_frame: "BODY_FRD"       # PX4 1.10 supports GLOBAL, LOCAL_NED, BODY_FRD
+  mav_frame: "GLOBAL"       # PX4 1.10 supports GLOBAL, LOCAL_NED, BODY_FRD
 
 # vim:set ts=2 sw=2 et:

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -257,4 +257,8 @@ wheel_odometry:
     frame_id: "odom"
     child_frame_id: "base_link"
 
+# obstacle_distance
+obstacle_distance:
+  mav_frame: "BODY_FRD"       # PX4 1.10 supports GLOBAL, LOCAL_NED, BODY_FRD
+
 # vim:set ts=2 sw=2 et:

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -36,7 +36,7 @@ using mavlink::common::MAV_DISTANCE_SENSOR;
 class ObstacleDistancePlugin : public plugin::PluginBase {
 public:
 	ObstacleDistancePlugin() : PluginBase(),
-		obstacle_nh("~obstacle")
+		obstacle_nh("~obstacle_distance")
 	{ }
 
 	void initialize(UAS &uas_)

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -109,6 +109,8 @@ private:
 		obstacle.min_distance = req->range_min * 1e2;							//!< [centimeters]
 		obstacle.max_distance = req->range_max * 1e2;							//!< [centimeters]
 		obstacle.frame = utils::enum_value(frame);
+		// Assume angle_increment is positive and incoming message is in a FRD/NED frame
+		obstacle.angle_offset = req->angle_min * RAD_TO_DEG;						//!< [degrees]
 
 		ROS_DEBUG_STREAM_NAMED("obstacle_distance", "OBSDIST: sensor type: " << utils::to_string_enum<MAV_DISTANCE_SENSOR>(obstacle.sensor_type)
 										     << std::endl << obstacle.to_yaml());


### PR DESCRIPTION
While trying to set up collision prevention, I've found several issues with the `obstacle_distance` plugin:
* The parameter namespace for `obstacle_distance` is `obstacle`, which is not very discoverable;
* `angle_offset` is always zero in the MAVLink message.

This P/R changes the namespace to match the plugin name, adds an example parameter in `px4_config.yaml` (I'm not familiar with Ardupilot, not sure the plugin works with it), and uses `angle_min` from ROS `sensor_msgs::LaserScan` as `angle_offset`. This worked for me with a D435+depthimage_to_laserscan (and a simple node to "flip" the laserscan message).