### PR TITLE
Dispatch GCS IP address

### DIFF
--- a/libmavconn/include/mavconn/udp.h
+++ b/libmavconn/include/mavconn/udp.h
@@ -60,6 +60,8 @@ public:
 		return socket.is_open();
 	}
 
+	std::string get_remote_endpoint() const;
+
 private:
 	boost::asio::io_service io_service;
 	std::unique_ptr<boost::asio::io_service::work> io_work;

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -304,4 +304,10 @@ void MAVConnUDP::do_sendto(bool check_tx_state)
 					sthis->tx_in_progress = false;
 			});
 }
+
+std::string MAVConnUDP::get_remote_endpoint() const
+{
+	return to_string_ss(remote_ep);
+}
+
 }	// namespace mavconn

--- a/mavros/src/lib/mavros.cpp
+++ b/mavros/src/lib/mavros.cpp
@@ -213,8 +213,9 @@ void MavRos::spin()
 				const auto endpoint_valid = endpoint.find("255.255.255.255") == std::string::npos;
 
 				if (endpoint_valid) {
-					const auto ip = endpoint.substr(0, endpoint.find(":"));
-					pub.publish(ip);
+					std_msgs::String msg;
+					msg.data = endpoint.substr(0, endpoint.find(":"));
+					pub.publish(msg);
 					finished = true;
 				}
 			}


### PR DESCRIPTION
Hi all! Are you still open for PRs on the ROS 1 version of mavros?

I wanted to get the IP of the ground control station that mavros/mavconn connects to, so I made this change. I'm not sure if this is something you want in the upstream mavros, but I'm making this PR to find out.

It runs a 1 Hz timer in the main mavros loop that checks the ip stored in the MAVConnUDP instance (through a new public const method), and publishes it on a latched topic `gcp_ip`. It only does this once.

This implementation works, but it feels like it could be integrated in a nicer way. All suggestions appreciated.