### PR TITLE
Visualization of the direction of the device

### DIFF
--- a/mavros_extras/src/visualization.cpp
+++ b/mavros_extras/src/visualization.cpp
@@ -225,7 +225,7 @@ static void create_vehicle_markers( int num_rotors, float arm_len, float body_wi
 				rotor.color.r = 1.0;
 				rotor.color.g = 0;
 				rotor.color.b = 0;
-				rotor.color.a = 1.0;
+				rotor.color.a = 0.8;
 			}
 		}
 		

--- a/mavros_extras/src/visualization.cpp
+++ b/mavros_extras/src/visualization.cpp
@@ -160,7 +160,7 @@ static void publish_lt_marker(const geometry_msgs::PoseStamped::ConstPtr &target
 /**
  * @brief publish vehicle
  */
-static void create_vehicle_markers( int num_rotors, float arm_len, float body_width, float body_height )
+static void create_vehicle_markers( int num_rotors, float arm_len, float body_width, float body_height, int prop_direction)
 {
 	if ( num_rotors <= 0 ) num_rotors = 2;
 
@@ -188,10 +188,6 @@ static void create_vehicle_markers( int num_rotors, float arm_len, float body_wi
 	rotor.scale.x = 0.2 * marker_scale;
 	rotor.scale.y = 0.2 * marker_scale;
 	rotor.scale.z = 0.01 * marker_scale;
-	rotor.color.r = 0.4;
-	rotor.color.g = 0.4;
-	rotor.color.b = 0.4;
-	rotor.color.a = 0.8;
 	rotor.pose.position.z = 0;
 
 	// arm marker template
@@ -214,6 +210,26 @@ static void create_vehicle_markers( int num_rotors, float arm_len, float body_wi
 
 	for ( float angle = angle_increment / 2; angle <= (2 * M_PI); angle += angle_increment )
 	{
+		if ( !prop_direction ) {
+			rotor.color.r = 0.4;
+			rotor.color.g = 0.4;
+			rotor.color.b = 0.4;
+			rotor.color.a = 0.8;
+		} else {
+			if ( angle <= (M_PI / 2) - 0.0175 || angle >= (M_PI * 3 / 2) + 0.0175 ) {
+				rotor.color.r = 0.8;
+				rotor.color.g = 0.8;
+				rotor.color.b = 0.8;
+				rotor.color.a = 0.8;
+			} else {
+				rotor.color.r = 1.0;
+				rotor.color.g = 0;
+				rotor.color.b = 0;
+				rotor.color.a = 1.0;
+			}
+		}
+		
+		
 		rotor.pose.position.x = arm_len * cos(angle) * marker_scale;
 		rotor.pose.position.y = arm_len * sin(angle) * marker_scale;
 		rotor.id++;
@@ -272,7 +288,7 @@ int main(int argc, char *argv[])
 	ros::NodeHandle nh;
 	ros::NodeHandle priv_nh("~");
 
-	int num_rotors;
+	int num_rotors, prop_direction;
 	double arm_len, body_width, body_height;
 
 	priv_nh.param<std::string>("fixed_frame_id", fixed_frame_id, "map");
@@ -284,8 +300,9 @@ int main(int argc, char *argv[])
 	priv_nh.param("body_width", body_width, 0.15 );
 	priv_nh.param("body_height", body_height, 0.10 );
 	priv_nh.param("max_track_size", max_track_size, 1000 );
+	priv_nh.param("prop_direction", prop_direction, 0);
 
-	create_vehicle_markers( num_rotors, arm_len, body_width, body_height );
+	create_vehicle_markers( num_rotors, arm_len, body_width, body_height, prop_direction );
 
 	track_marker_pub = nh.advertise<visualization_msgs::Marker>("track_markers", 10);
 	vehicle_marker_pub = nh.advertise<visualization_msgs::MarkerArray>("vehicle_marker", 10);


### PR DESCRIPTION
In the current implementation, it is completely unclear where the "nose" of the device is directed.
In order not to overload the scene with elements, I propose adding a parameter that will tint the front and rear propellers in different colors, red and white, respectively. This logic used on DJI propellers on the f450 and f500 frame.