### PR TITLE
Add support for SERVO_OUTPUT_RAW msg

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -140,6 +140,7 @@ add_library(mavros_plugins
   src/plugins/vfr_hud.cpp
   src/plugins/waypoint.cpp
   src/plugins/wind_estimation.cpp
+  src/plugins/servo_output_raw.cpp
 )
 add_dependencies(mavros_plugins
   mavros

--- a/mavros/mavros_plugins.xml
+++ b/mavros/mavros_plugins.xml
@@ -77,4 +77,7 @@
 	<class name="wind_estimation" type="mavros::std_plugins::WindEstimationPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish wind estimates</description>
 	</class>
+	<class name="servo_output_raw" type="mavros::std_plugins::ServoOutputRawPlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>ServoOutputRaw msg</description>
+	</class>
 </library>

--- a/mavros/src/plugins/hil.cpp
+++ b/mavros/src/plugins/hil.cpp
@@ -113,6 +113,11 @@ private:
 
 		hil_actuator_controls_msg->header.stamp = m_uas->synchronise_stamp(hil_actuator_controls.time_usec);
 		const auto &arr = hil_actuator_controls.controls;
+		for (int i = 0; i < hil_actuator_controls.controls.size(); i++) {
+			std::cout << hil_actuator_controls.controls[i] << " ";
+		}
+		std::cout << "\n";
+
 		std::copy(arr.cbegin(), arr.cend(), hil_actuator_controls_msg->controls.begin());
 		hil_actuator_controls_msg->mode = hil_actuator_controls.mode;
 		hil_actuator_controls_msg->flags = hil_actuator_controls.flags;

--- a/mavros/src/plugins/servo_output_raw.cpp
+++ b/mavros/src/plugins/servo_output_raw.cpp
@@ -1,0 +1,82 @@
+/**
+ * @brief Servo Output Raw plugin
+ * @file servo_output_raw.cpp
+ * @author Roman Fedorenko <frontwise@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2020 Roman Fedorenko.
+ *
+ */
+#include <mavros/mavros_plugin.h>
+#include <eigen_conversions/eigen_msg.h>
+
+#include <mavros_msgs/ServoOutputRaw.h>
+
+namespace mavros {
+namespace std_plugins {
+/**
+ * @brief Servo Output Raw plugin
+ */
+class ServoOutputRawPlugin : public plugin::PluginBase {
+public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+	ServoOutputRawPlugin() : PluginBase(),
+		plugin_nh("~")
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		servo_output_raw_pub = plugin_nh.advertise<mavros_msgs::ServoOutputRaw>("servo_output_raw", 10);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return {
+			       make_handler(&ServoOutputRawPlugin::handle_servo_output_raw),
+		};
+	}
+
+private:
+	ros::NodeHandle plugin_nh;
+
+	ros::Publisher servo_output_raw_pub;
+
+	/* -*- rx handlers -*- */
+
+	void handle_servo_output_raw(const mavlink::mavlink_message_t *msg, mavlink::common::msg::SERVO_OUTPUT_RAW &servo_output_raw) {
+		auto servo_output_raw_msg = boost::make_shared<mavros_msgs::ServoOutputRaw>();
+
+		servo_output_raw_msg->header.stamp = m_uas->synchronise_stamp(servo_output_raw.time_usec);
+		servo_output_raw_msg->port	      = servo_output_raw.port;
+		servo_output_raw_msg->servo1_raw  = servo_output_raw.servo1_raw;
+		servo_output_raw_msg->servo2_raw  = servo_output_raw.servo2_raw;
+		servo_output_raw_msg->servo3_raw  = servo_output_raw.servo3_raw;
+		servo_output_raw_msg->servo4_raw  = servo_output_raw.servo4_raw;
+		servo_output_raw_msg->servo5_raw  = servo_output_raw.servo5_raw;
+		servo_output_raw_msg->servo6_raw  = servo_output_raw.servo6_raw;
+		servo_output_raw_msg->servo7_raw  = servo_output_raw.servo7_raw;
+		servo_output_raw_msg->servo8_raw  = servo_output_raw.servo8_raw;
+		servo_output_raw_msg->servo9_raw  = servo_output_raw.servo9_raw;
+		servo_output_raw_msg->servo10_raw = servo_output_raw.servo10_raw;
+		servo_output_raw_msg->servo11_raw = servo_output_raw.servo11_raw;
+		servo_output_raw_msg->servo12_raw = servo_output_raw.servo12_raw;
+		servo_output_raw_msg->servo13_raw = servo_output_raw.servo13_raw;
+		servo_output_raw_msg->servo14_raw = servo_output_raw.servo14_raw;
+		servo_output_raw_msg->servo15_raw = servo_output_raw.servo15_raw;
+		servo_output_raw_msg->servo16_raw = servo_output_raw.servo16_raw;
+
+		servo_output_raw_pub.publish(servo_output_raw_msg);
+	}
+
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::std_plugins::ServoOutputRawPlugin, mavros::plugin::PluginBase)

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -55,6 +55,7 @@ add_message_files(
   WaypointList.msg
   WaypointReached.msg
   WheelOdomStamped.msg
+  ServoOutputRaw.msg
 )
 
 add_service_files(

--- a/mavros_msgs/msg/ServoOutputRaw.msg
+++ b/mavros_msgs/msg/ServoOutputRaw.msg
@@ -1,0 +1,24 @@
+# HilActuatorControls.msg
+#
+# ROS representation of MAVLink SERVO_OUTPUT_RAW
+# See mavlink message documentation here:
+# https://mavlink.io/en/messages/common.html#SERVO_OUTPUT_RAW
+
+std_msgs/Header header
+uint8 port	        #	Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.
+uint16 servo1_raw	#   us	Servo output 1 value
+uint16 servo2_raw	#   us	Servo output 2 value
+uint16 servo3_raw	#   us	Servo output 3 value
+uint16 servo4_raw	#   us	Servo output 4 value
+uint16 servo5_raw	#   us	Servo output 5 value
+uint16 servo6_raw	#   us	Servo output 6 value
+uint16 servo7_raw	#   us	Servo output 7 value
+uint16 servo8_raw	#   us	Servo output 8 value
+uint16 servo9_raw   #   us	Servo output 9 value
+uint16 servo10_raw  #   us	Servo output 10 value
+uint16 servo11_raw  #   us	Servo output 11 value
+uint16 servo12_raw  #   us	Servo output 12 value
+uint16 servo13_raw  #   us	Servo output 13 value
+uint16 servo14_raw  #   us	Servo output 14 value
+uint16 servo15_raw  #   us	Servo output 15 value
+uint16 servo16_raw  #   us	Servo output 16 value


### PR DESCRIPTION
This PR adds support for SERVO_OUTPUT_RAW msg. 
MAVLink SERVO_OUTPUT_RAW message  contains current PWM controls on all actuators.
This PR adds transmission of it to ROS topic of new type ServoOutputRaw.msg.