### PR TITLE
updates apmrover2 modes and allows for arduboat mode changes

### DIFF
--- a/mavros/src/lib/uas_stringify.cpp
+++ b/mavros/src/lib/uas_stringify.cpp
@@ -84,14 +84,18 @@ static const cmode_map arducopter_cmode_map{{
  * APMrover2/defines.h
  */
 static const cmode_map apmrover2_cmode_map{{
-	{ 0, "MANUAL" },
-	{ 2, "LEARNING" },
-	{ 3, "STEERING" },
-	{ 4, "HOLD" },
-	{ 10, "AUTO" },
-	{ 11, "RTL" },
-	{ 15, "GUIDED" },
-	{ 16, "INITIALISING" }
+    { 0, "MANUAL" },
+    { 1, "ACRO" },
+    { 3, "STEERING" },
+    { 4, "HOLD" },
+    { 5, "LOITER" },
+    { 6, "FOLLOW" },
+    { 7, "SIMPLE" },
+    { 10, "AUTO" },
+    { 11, "RTL" },
+    { 12, "SMART_RTL" },
+    { 15, "GUIDED" },
+    { 16, "INITIALISING" }
 }};
 
 /** ArduSub custom mode -> string
@@ -260,6 +264,8 @@ bool UAS::cmode_from_str(std::string cmode_str, uint32_t &custom_mode)
 		else if (type == MAV_TYPE::FIXED_WING)
 			return cmode_find_cmap(arduplane_cmode_map, cmode_str, custom_mode);
 		else if (type == MAV_TYPE::GROUND_ROVER)
+			return cmode_find_cmap(apmrover2_cmode_map, cmode_str, custom_mode);
+		else if (type == MAV_TYPE::SURFACE_BOAT)
 			return cmode_find_cmap(apmrover2_cmode_map, cmode_str, custom_mode);
 		else if (type == MAV_TYPE::SUBMARINE)
 			return cmode_find_cmap(ardusub_cmode_map, cmode_str, custom_mode);


### PR DESCRIPTION
`UAS::cmode_from_str(std::string cmode_str, uint32_t &custom_mode)` now accommodates `MAV_TYPE::SURFACE_BOAT`. Also updates `cmode_map apmrover2_cmode_map` to mimic modes found at https://github.com/ArduPilot/ardupilot/blob/master/APMrover2/mode.h