### PR TITLE
add yaw to CMD_DO_SET_HOME

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -339,7 +339,7 @@ private:
 		return send_command_long_and_wait(false,
 			enum_value(MAV_CMD::DO_SET_HOME), 1,
 			(req.current_gps) ? 1.0 : 0.0,
-			0, 0, 0, req.latitude, req.longitude, req.altitude,
+			0, 0, req.yaw, req.latitude, req.longitude, req.altitude,
 			res.success, res.result);
 	}
 

--- a/mavros_msgs/srv/CommandHome.srv
+++ b/mavros_msgs/srv/CommandHome.srv
@@ -1,6 +1,7 @@
 # request set new home position
 
 bool current_gps
+float32 yaw
 float32 latitude
 float32 longitude
 float32 altitude


### PR DESCRIPTION
Adding yaw to CMD_DO_SET_HOME. Implementation in PX4 is already done (https://github.com/PX4/Firmware/pull/14810).