### PR TITLE
wind plugin: fix ArduPilot wind transformation

### DIFF
--- a/mavros/src/plugins/wind_estimation.cpp
+++ b/mavros/src/plugins/wind_estimation.cpp
@@ -61,11 +61,10 @@ private:
 	void handle_apm_wind(const mavlink::mavlink_message_t *msg, mavlink::ardupilotmega::msg::WIND &wind)
 	{
 		const double speed = wind.speed;
-		const double course = -angles::from_degrees(wind.direction);	// direction "from" -> direction "to"
+		const double course = angles::from_degrees(wind.direction) + M_PI;	// direction "from" -> direction "to"
 
 		auto twist_cov = boost::make_shared<geometry_msgs::TwistWithCovarianceStamped>();
 		twist_cov->header.stamp = ros::Time::now();
-		// TODO: check math's
 		twist_cov->twist.twist.linear.x = speed * std::sin(course);	// E
 		twist_cov->twist.twist.linear.y = speed * std::cos(course);	// N
 		twist_cov->twist.twist.linear.z = -wind.speed_z;// D -> U


### PR DESCRIPTION
This PR fixes the 180 degree rotation of the wind direction in the ArduPilot wind message handler. I also further tested this code in the ArduPilot SITL simulator, so I removed the TODO comment.