### PR TITLE
Feature obstacle distance fix

### DIFF
--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -101,7 +101,9 @@ private:
 					}
 				}
 			}
-			obstacle.increment = ceil(req->angle_increment * RAD_TO_DEG * scale_factor);	//!< [degrees]
+			const float increment_deg = req->angle_increment * RAD_TO_DEG * double(fixed.ranges.size()) / obstacle.distances.size();
+			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);  //!< Round to nearest integer.
+			obstacle.increment_f = increment_deg;
 		}
 
 		obstacle.time_usec = req->header.stamp.toNSec() / 1000;					//!< [microsecs]

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -84,7 +84,7 @@ private:
 			std::fill(obstacle.distances.begin() + req->ranges.size(), obstacle.distances.end(), UINT16_MAX);	//!< fill the rest of the array values as "Unknown"
 
 			const float increment_deg = req->angle_increment * RAD_TO_DEG;
-			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);  //!< Round to nearest integer.
+			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);	//!< Round to nearest integer.
 			obstacle.increment_f = increment_deg;
 		} else {
 			// all distances from sensor will not fit so we combine adjacent distances always taking the shortest distance
@@ -102,7 +102,7 @@ private:
 				}
 			}
 			const float increment_deg = req->angle_increment * RAD_TO_DEG * double(fixed.ranges.size()) / obstacle.distances.size();
-			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);  //!< Round to nearest integer.
+			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);	//!< Round to nearest integer.
 			obstacle.increment_f = increment_deg;
 		}
 


### PR DESCRIPTION
Hello,

I was having some issues with ardupilot's Obstacle Avoidance Database; obstacles were showing up in unexpected places. The laserscanner on our drone is installed so that the forward vector is backwards, so I rotated the laserscan by 180 degrees on the z-axis. The rotation seemed to cause a strange discontinuity in the returned obstacles. So, I visualized the adsb vehicle messages I was receiving (green circles), the testing laserscan (red) and the obstacle_distance message reinterpreted as a laserscan (yellow). The results of this can be seen below. The obstacle_distance message has not been rotated to align with the laserscan; partially because of visibility, but mostly because of laziness.

![original](https://user-images.githubusercontent.com/28626563/83188582-8d85a880-a0f5-11ea-8876-01eeba039567.png)

As you can see, the initial part of the adsb messages are quite off the actual laserscan. You may also notice that the obstacle_distance's distance measurements exceed 360 degrees around; I believe the latter leads to the former. The increment appears to be the culprit here. The laserscan I'm providing as 2048 ranges; far exceeding the obstacle_distance's size limit of 72. In that case, two issues arise. Firstly, the obstacle's increment is set, but not the increment_f. These are both set when the number of ranges is less than 72, so it seems odd that it was not set in this case. Secondly, the increment is rounded upward, resulting in significant overlap which I believe causes that strange behavior in the adsb messages. Once again, this is not the case when a laserscan has fewer than 72 ranges; it is rounded normally.

Upon implementing the changes, I saw marked improvement of the adsb message accuracy. For reference, here's the result using the new increment_f:

![float](https://user-images.githubusercontent.com/28626563/83188617-9d04f180-a0f5-11ea-8400-88b688a34fc6.png)

And here's the normally rounded int increment:

![int](https://user-images.githubusercontent.com/28626563/83188670-abeba400-a0f5-11ea-8676-30808ba4490e.png)

As you can see, much improved. There is still a slight gap in the spiral, but it's far less of an issue.