### PR TITLE
apm.launch: Avoid warning:

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -20,6 +20,6 @@
 		<arg name="tgt_component" value="$(arg tgt_component)" />
 		<arg name="log_output" value="$(arg log_output)" />
 		<arg name="fcu_protocol" value="$(arg fcu_protocol)" />
-		<arg name="respawn_mavros" default="$(arg respawn_mavros)" />
+		<arg name="respawn_mavros" value="$(arg respawn_mavros)" />
 	</include>
 </launch>


### PR DESCRIPTION
Warning: You are using <arg> inside an <include> tag with the default=XY attribute - which is superfluous.
         Use value=XY instead for less confusion.
         Attribute name: respawn_mavros