### PR TITLE
Add gps_status plugin to publish GPS_RAW and GPS_RTK messages from FCU.

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(mavros_extras
   src/plugins/distance_sensor.cpp
   src/plugins/fake_gps.cpp
   src/plugins/gps_rtk.cpp
+  src/plugins/gps_status.cpp
   src/plugins/landing_target.cpp
   src/plugins/log_transfer.cpp
   src/plugins/mocap_pose_estimate.cpp

--- a/mavros_extras/README.md
+++ b/mavros_extras/README.md
@@ -34,6 +34,12 @@ fake\_gps
 Sends fake GPS from local position estimation source data (motion capture, vision) to FCU.
 
 
+gps\_status
+-----------
+
+Publish GPS\_RAW and GPS\_RTK messages from FCU.
+
+
 gps\_rtk
 --------
 

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -20,6 +20,9 @@
 	<class name="fake_gps" type="mavros::extra_plugins::FakeGPSPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description> Sends fake GPS from local position estimation source data (motion capture, vision) to FCU.</description>
 	</class>
+	<class name="gps_status" type="mavros::extra_plugins::GpsStatusPlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>Publish GPS_RAW and GPS_RTK messages from FCU.</description>
+	</class>
 	<class name="gps_rtk" type="mavros::extra_plugins::GpsRtkPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Sends the RTCM messages to the FCU for the RTK Fix.</description>
 	</class>

--- a/mavros_extras/package.xml
+++ b/mavros_extras/package.xml
@@ -8,6 +8,7 @@
 
   <maintainer email="vooon341@gmail.com">Vladimir Ermakov</maintainer>
   <author email="vooon341@gmail.com">Vladimir Ermakov</author>
+  <author email="amilcar.lucas@iav.de">Amilcar Lucas</author>
   <license>GPLv3</license>
   <license>LGPLv3</license>
   <license>BSD</license>

--- a/mavros_extras/src/plugins/gps_status.cpp
+++ b/mavros_extras/src/plugins/gps_status.cpp
@@ -1,0 +1,185 @@
+/**
+ * @brief GPS status plugin
+ * @file gps_status.cpp
+ * @author Amilcar Lucas <amilcar.lucas@iav.de>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2019 Ardupilot.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <mavros_msgs/GPSRAW.h>
+#include <mavros_msgs/GPSRTK.h>
+
+namespace mavros {
+namespace extra_plugins {
+using mavlink::common::RTK_BASELINE_COORDINATE_SYSTEM;
+
+/**
+ * @brief Mavlink GPS status plugin.
+ *
+ * This plugin publishes GPS sensor data from a Mavlink compatible FCU to ROS.
+ */
+class GpsStatusPlugin : public plugin::PluginBase {
+public:
+	GpsStatusPlugin() : PluginBase(),
+		gpsstatus_nh("~gpsstatus")
+	{ }
+
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+
+		gps1_raw_pub = gpsstatus_nh.advertise<mavros_msgs::GPSRAW>("gps1/raw", 10);
+		gps2_raw_pub = gpsstatus_nh.advertise<mavros_msgs::GPSRAW>("gps2/raw", 10);
+		gps1_rtk_pub = gpsstatus_nh.advertise<mavros_msgs::GPSRTK>("gps1/rtk", 10);
+		gps2_rtk_pub = gpsstatus_nh.advertise<mavros_msgs::GPSRTK>("gps2/rtk", 10);
+	}
+
+	Subscriptions get_subscriptions()
+	{
+		return {
+			       make_handler(&GpsStatusPlugin::handle_gps_raw_int),
+			       make_handler(&GpsStatusPlugin::handle_gps2_raw),
+			       make_handler(&GpsStatusPlugin::handle_gps_rtk),
+			       make_handler(&GpsStatusPlugin::handle_gps2_rtk)
+		};
+	}
+
+private:
+	ros::NodeHandle gpsstatus_nh;
+
+	ros::Publisher gps1_raw_pub;
+	ros::Publisher gps2_raw_pub;
+	ros::Publisher gps1_rtk_pub;
+	ros::Publisher gps2_rtk_pub;
+
+	/* -*- callbacks -*- */
+	/**
+	 * @brief Publish <a href="https://mavlink.io/en/messages/common.html#GPS_RAW_INT">mavlink GPS_RAW_INT message</a> into the gps1/raw topic.
+	 */
+	void handle_gps_raw_int(const mavlink::mavlink_message_t *msg, mavlink::common::msg::GPS_RAW_INT &mav_msg) {
+		auto ros_msg = boost::make_shared<mavros_msgs::GPSRAW>();
+		ros_msg->header            = m_uas->synchronized_header("/wgs84", mav_msg.time_usec);
+		ros_msg->fix_type          = mav_msg.fix_type;
+		ros_msg->lat               = mav_msg.lat;
+		ros_msg->lon               = mav_msg.lon;
+		ros_msg->alt               = mav_msg.alt;
+		ros_msg->eph               = mav_msg.eph;
+		ros_msg->epv               = mav_msg.epv;
+		ros_msg->vel               = mav_msg.vel;
+		ros_msg->cog               = mav_msg.cog;
+		ros_msg->satellites_visible = mav_msg.satellites_visible;
+		ros_msg->alt_ellipsoid     = mav_msg.alt_ellipsoid;
+		ros_msg->h_acc             = mav_msg.h_acc;
+		ros_msg->v_acc             = mav_msg.v_acc;
+		ros_msg->vel_acc           = mav_msg.vel_acc;
+		ros_msg->hdg_acc           = mav_msg.hdg_acc;
+		ros_msg->dgps_numch        = UINT8_MAX;	// information not available in GPS_RAW_INT mavlink message
+		ros_msg->dgps_age          = UINT32_MAX;// information not available in GPS_RAW_INT mavlink message
+
+		gps1_raw_pub.publish(ros_msg);
+	}
+
+	/**
+	 * @brief Publish <a href="https://mavlink.io/en/messages/common.html#GPS2_RAW">mavlink GPS2_RAW message</a> into the gps2/raw topic.
+	 */
+	void handle_gps2_raw(const mavlink::mavlink_message_t *msg, mavlink::common::msg::GPS2_RAW &mav_msg) {
+		auto ros_msg = boost::make_shared<mavros_msgs::GPSRAW>();
+		ros_msg->header            = m_uas->synchronized_header("/wgs84", mav_msg.time_usec);
+		ros_msg->fix_type          = mav_msg.fix_type;
+		ros_msg->lat               = mav_msg.lat;
+		ros_msg->lon               = mav_msg.lon;
+		ros_msg->alt               = mav_msg.alt;
+		ros_msg->eph               = mav_msg.eph;
+		ros_msg->epv               = mav_msg.epv;
+		ros_msg->vel               = mav_msg.vel;
+		ros_msg->cog               = mav_msg.cog;
+		ros_msg->satellites_visible = mav_msg.satellites_visible;
+		ros_msg->alt_ellipsoid     = INT32_MAX;	// information not available in GPS2_RAW mavlink message
+		ros_msg->h_acc             = UINT32_MAX;// information not available in GPS2_RAW mavlink message
+		ros_msg->v_acc             = UINT32_MAX;// information not available in GPS2_RAW mavlink message
+		ros_msg->vel_acc           = UINT32_MAX;// information not available in GPS2_RAW mavlink message
+		ros_msg->hdg_acc           = UINT32_MAX;// information not available in GPS2_RAW mavlink message
+		ros_msg->dgps_numch        = mav_msg.dgps_numch;
+		ros_msg->dgps_age          = mav_msg.dgps_age;
+
+		gps2_raw_pub.publish(ros_msg);
+	}
+
+	/**
+	 * @brief Publish <a href="https://mavlink.io/en/messages/common.html#GPS_RTK">mavlink GPS_RTK message</a> into the gps1/rtk topic.
+	 */
+	void handle_gps_rtk(const mavlink::mavlink_message_t *msg, mavlink::common::msg::GPS_RTK &mav_msg) {
+		auto ros_msg = boost::make_shared<mavros_msgs::GPSRTK>();
+		switch (static_cast<RTK_BASELINE_COORDINATE_SYSTEM>(mav_msg.baseline_coords_type))
+		{
+		case RTK_BASELINE_COORDINATE_SYSTEM::ECEF:
+			ros_msg->header.frame_id = "earth";
+			break;
+		case RTK_BASELINE_COORDINATE_SYSTEM::NED:
+			ros_msg->header.frame_id = "map";
+			break;
+		default:
+			ROS_ERROR_NAMED("gps_status", "GPS_RTK.baseline_coords_type MAVLink field has unknown \"%d\" value", mav_msg.baseline_coords_type);
+		}
+		ros_msg->header              = m_uas->synchronized_header(ros_msg->header.frame_id, mav_msg.time_last_baseline_ms * 1000);
+		ros_msg->rtk_receiver_id     = mav_msg.rtk_receiver_id;
+		ros_msg->wn                  = mav_msg.wn;
+		ros_msg->tow                 = mav_msg.tow;
+		ros_msg->rtk_health          = mav_msg.rtk_health;
+		ros_msg->rtk_rate            = mav_msg.rtk_rate;
+		ros_msg->nsats               = mav_msg.nsats;
+		ros_msg->baseline_a          = mav_msg.baseline_a_mm;
+		ros_msg->baseline_b          = mav_msg.baseline_b_mm;
+		ros_msg->baseline_c          = mav_msg.baseline_c_mm;
+		ros_msg->accuracy            = mav_msg.accuracy;
+		ros_msg->iar_num_hypotheses  = mav_msg.iar_num_hypotheses;
+
+		gps1_rtk_pub.publish(ros_msg);
+	}
+
+	/**
+	 * @brief Publish <a href="https://mavlink.io/en/messages/common.html#GPS2_RTK">mavlink GPS2_RTK message</a> into the gps2/rtk topic.
+	 */
+	void handle_gps2_rtk(const mavlink::mavlink_message_t *msg, mavlink::common::msg::GPS2_RTK &mav_msg) {
+		auto ros_msg = boost::make_shared<mavros_msgs::GPSRTK>();
+		switch (static_cast<RTK_BASELINE_COORDINATE_SYSTEM>(mav_msg.baseline_coords_type))
+		{
+		case RTK_BASELINE_COORDINATE_SYSTEM::ECEF:
+			ros_msg->header.frame_id = "earth";
+			break;
+		case RTK_BASELINE_COORDINATE_SYSTEM::NED:
+			ros_msg->header.frame_id = "map";
+			break;
+		default:
+			ROS_ERROR_NAMED("gps_status", "GPS_RTK2.baseline_coords_type MAVLink field has unknown \"%d\" value", mav_msg.baseline_coords_type);
+		}
+		ros_msg->header              = m_uas->synchronized_header(ros_msg->header.frame_id, mav_msg.time_last_baseline_ms * 1000);
+		ros_msg->rtk_receiver_id     = mav_msg.rtk_receiver_id;
+		ros_msg->wn                  = mav_msg.wn;
+		ros_msg->tow                 = mav_msg.tow;
+		ros_msg->rtk_health          = mav_msg.rtk_health;
+		ros_msg->rtk_rate            = mav_msg.rtk_rate;
+		ros_msg->nsats               = mav_msg.nsats;
+		ros_msg->baseline_a          = mav_msg.baseline_a_mm;
+		ros_msg->baseline_b          = mav_msg.baseline_b_mm;
+		ros_msg->baseline_c          = mav_msg.baseline_c_mm;
+		ros_msg->accuracy            = mav_msg.accuracy;
+		ros_msg->iar_num_hypotheses  = mav_msg.iar_num_hypotheses;
+
+		gps2_rtk_pub.publish(ros_msg);
+	}
+};
+}	// namespace extra_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::GpsStatusPlugin, mavros::plugin::PluginBase)

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -22,6 +22,8 @@ add_message_files(
   ExtendedState.msg
   FileEntry.msg
   GlobalPositionTarget.msg
+  GPSRAW.msg
+  GPSRTK.msg
   HilActuatorControls.msg
   HilControls.msg
   HilGPS.msg

--- a/mavros_msgs/msg/GPSRAW.msg
+++ b/mavros_msgs/msg/GPSRAW.msg
@@ -1,0 +1,36 @@
+# FCU GPS RAW message for the gps_status plugin
+# A merge of <a href="https://mavlink.io/en/messages/common.html#GPS_RAW_INT">mavlink GPS_RAW_INT</a> and 
+# <a href="https://mavlink.io/en/messages/common.html#GPS2_RAW">mavlink GPS2_RAW</a> messages.
+
+std_msgs/Header header
+## GPS_FIX_TYPE enum
+uint8 GPS_FIX_TYPE_NO_GPS     = 0    # No GPS connected
+uint8 GPS_FIX_TYPE_NO_FIX     = 1    # No position information, GPS is connected
+uint8 GPS_FIX_TYPE_2D_FIX     = 2    # 2D position
+uint8 GPS_FIX_TYPE_3D_FIX     = 3    # 3D position
+uint8 GPS_FIX_TYPE_DGPS       = 4    # DGPS/SBAS aided 3D position
+uint8 GPS_FIX_TYPE_RTK_FLOATR = 5    # TK float, 3D position
+uint8 GPS_FIX_TYPE_RTK_FIXEDR = 6    # TK Fixed, 3D position
+uint8 GPS_FIX_TYPE_STATIC     = 7    # Static fixed, typically used for base stations
+uint8 GPS_FIX_TYPE_PPP        = 8    # PPP, 3D position
+uint8 fix_type      # [GPS_FIX_TYPE] GPS fix type
+
+int32 lat           # [degE7] Latitude (WGS84, EGM96 ellipsoid)
+int32 lon           # [degE7] Longitude (WGS84, EGM96 ellipsoid)
+int32 alt           # [mm] Altitude (MSL). Positive for up. Note that virtually all GPS modules provide the MSL altitude in addition to the WGS84 altitude.
+uint16 eph          # GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX
+uint16 epv          # GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX
+uint16 vel          # [cm/s] GPS ground speed. If unknown, set to: UINT16_MAX
+uint16 cog          # [cdeg] Course over ground (NOT heading, but direction of movement), 0.0..359.99 degrees. If unknown, set to: UINT16_MAX
+uint8 satellites_visible # Number of satellites visible. If unknown, set to 255
+
+# -*- only available with MAVLink v2.0 and GPS_RAW_INT messages -*-
+int32 alt_ellipsoid # [mm] Altitude (above WGS84, EGM96 ellipsoid). Positive for up.
+uint32 h_acc        # [mm] Position uncertainty. Positive for up.
+uint32 v_acc        # [mm] Altitude uncertainty. Positive for up.
+uint32 vel_acc      # [mm] Speed uncertainty. Positive for up.
+int32  hdg_acc      # [degE5] Heading / track uncertainty
+
+# -*- only available with MAVLink v2.0 and GPS2_RAW messages -*-
+uint8 dgps_numch    # Number of DGPS satellites
+uint32 dgps_age     # [ms] Age of DGPS info

--- a/mavros_msgs/msg/GPSRTK.msg
+++ b/mavros_msgs/msg/GPSRTK.msg
@@ -1,0 +1,18 @@
+# FCU GPS RTK message for the gps_status plugin
+# A copy of <a href="https://mavlink.io/en/messages/common.html#GPS_RTK">mavlink GPS_RTK message</a>
+
+std_msgs/Header header
+
+uint8 rtk_receiver_id      # Identification of connected RTK receiver.
+int16 wn                   # GPS Week Number of last baseline.
+uint32 tow                 # [ms] GPS Time of Week of last baseline.
+uint8 rtk_health           # GPS-specific health report for RTK data.
+uint8 rtk_rate             # [Hz] Rate of baseline messages being received by GPS.
+uint8 nsats                # Current number of sats used for RTK calculation.
+int32 baseline_a           # [mm] Current baseline in ECEF x or NED north component, depends on header.frame_id.
+int32 baseline_b           # [mm] Current baseline in ECEF y or NED east component, depends on header.frame_id.
+int32 baseline_c           # [mm] Current baseline in ECEF z or NED down component, depends on header.frame_id.
+uint32 accuracy            # Current estimate of baseline accuracy.
+int32 iar_num_hypotheses   # Current number of integer ambiguity hypotheses.
+
+


### PR DESCRIPTION
The timestamps for the gps_status topics take into account the mavlink time and uses the convienence function