### PR TITLE
Cannot set parameter to 0.0 using /mavros/param/set

### DIFF
--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -56,6 +56,7 @@ public:
 	XmlRpcValue param_value;
 	uint16_t param_index;
 	uint16_t param_count;
+	MT param_type;
 
 	void set_value(mavlink::common::msg::PARAM_VALUE &pmsg)
 	{
@@ -86,30 +87,37 @@ public:
 		case enum_value(MT::INT8):
 			int_tmp = uv.param_int8;
 			param_value = int_tmp;
+			param_type = MT::INT8;
 			break;
 		case enum_value(MT::UINT8):
 			int_tmp = uv.param_uint8;
 			param_value = int_tmp;
+			param_type = MT::UINT8;
 			break;
 		case enum_value(MT::INT16):
 			int_tmp = uv.param_int16;
 			param_value = int_tmp;
+			param_type = MT::INT16;
 			break;
 		case enum_value(MT::UINT16):
 			int_tmp = uv.param_uint16;
 			param_value = int_tmp;
+			param_type = MT::UINT16;
 			break;
 		case enum_value(MT::INT32):
 			int_tmp = uv.param_int32;
 			param_value = int_tmp;
+			param_type = MT::INT32;
 			break;
 		case enum_value(MT::UINT32):
 			int_tmp = uv.param_uint32;
 			param_value = int_tmp;
+			param_type = MT::UINT32;
 			break;
 		case enum_value(MT::REAL32):
 			float_tmp = uv.param_float;
 			param_value = float_tmp;
+			param_type = MT::REAL32;
 			break;
 		// [[[end]]] (checksum: 5950e4ee032d4aa198b953f56909e129)
 
@@ -890,6 +898,8 @@ private:
 			if (req.value.integer != 0)
 				to_send.param_value = static_cast<int>(req.value.integer);
 			else if (req.value.real != 0.0)
+				to_send.param_value = req.value.real;
+			else if (param_it->second.param_type == mavlink::common::MAV_PARAM_TYPE::REAL32)
 				to_send.param_value = req.value.real;
 			else
 				to_send.param_value = 0;

--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -56,7 +56,6 @@ public:
 	XmlRpcValue param_value;
 	uint16_t param_index;
 	uint16_t param_count;
-	MT param_type;
 
 	void set_value(mavlink::common::msg::PARAM_VALUE &pmsg)
 	{
@@ -87,37 +86,30 @@ public:
 		case enum_value(MT::INT8):
 			int_tmp = uv.param_int8;
 			param_value = int_tmp;
-			param_type = MT::INT8;
 			break;
 		case enum_value(MT::UINT8):
 			int_tmp = uv.param_uint8;
 			param_value = int_tmp;
-			param_type = MT::UINT8;
 			break;
 		case enum_value(MT::INT16):
 			int_tmp = uv.param_int16;
 			param_value = int_tmp;
-			param_type = MT::INT16;
 			break;
 		case enum_value(MT::UINT16):
 			int_tmp = uv.param_uint16;
 			param_value = int_tmp;
-			param_type = MT::UINT16;
 			break;
 		case enum_value(MT::INT32):
 			int_tmp = uv.param_int32;
 			param_value = int_tmp;
-			param_type = MT::INT32;
 			break;
 		case enum_value(MT::UINT32):
 			int_tmp = uv.param_uint32;
 			param_value = int_tmp;
-			param_type = MT::UINT32;
 			break;
 		case enum_value(MT::REAL32):
 			float_tmp = uv.param_float;
 			param_value = float_tmp;
-			param_type = MT::REAL32;
 			break;
 		// [[[end]]] (checksum: 5950e4ee032d4aa198b953f56909e129)
 
@@ -899,7 +891,7 @@ private:
 				to_send.param_value = static_cast<int>(req.value.integer);
 			else if (req.value.real != 0.0)
 				to_send.param_value = req.value.real;
-			else if (param_it->second.param_type == mavlink::common::MAV_PARAM_TYPE::REAL32)
+			else if (param_it->second.param_value.getType() == XmlRpc::XmlRpcValue::Type::TypeDouble)
 				to_send.param_value = req.value.real;
 			else
 				to_send.param_value = 0;


### PR DESCRIPTION
Solution to https://github.com/mavlink/mavros/issues/1461

# Description of the solution:
- When loading parameters, store the parameter type
- When setting a parameter, check whether it is a known real-valued parameter. If so, use `0.0`.

# How to test this:
Launch mavros and type the following in another terminal:
```
rosservice call /mavros/param/set "param_id: 'EKF2_EV_POS_X'
value:
  integer: 0
  real: 0.0"
```

In the current `master` branch in `mavros`, we see the following output:
```
[ INFO] [1598654552.748968591, 13.868000000]: FCU: [pm] param types mismatch param: EKF2_EV_POS_X
[ WARN] [1598654553.710428267, 14.828000000]: PR: Resend param set for EKF2_EV_POS_X, retries left 2
[ INFO] [1598654553.714391652, 14.832000000]: FCU: [pm] param types mismatch param: EKF2_EV_POS_X
[ WARN] [1598654554.712170340, 15.828000000]: PR: Resend param set for EKF2_EV_POS_X, retries left 1
[ INFO] [1598654554.715163866, 15.832000000]: FCU: [pm] param types mismatch param: EKF2_EV_POS_X
[ WARN] [1598654555.713471139, 16.828000000]: PR: Resend param set for EKF2_EV_POS_X, retries left 0
[ INFO] [1598654555.717080441, 16.832000000]: FCU: [pm] param types mismatch param: EKF2_EV_POS_X
[ERROR] [1598654556.713230983, 17.828000000]: PR: Param set for EKF2_EV_POS_X timed out.
```

On the proposed PR, the value succeeds to change! We can confirm it by using 
```
rosservice call /mavros/param/get "param_id: 'EKF2_EV_POS_X'"
```

closes https://github.com/mavlink/mavros/issues/1461