### PR TITLE
Add error message in install_geographiclib_datasets.sh

### DIFF
--- a/mavros/scripts/install_geographiclib_datasets.sh
+++ b/mavros/scripts/install_geographiclib_datasets.sh
@@ -21,6 +21,12 @@ run_get() {
 
 	echo "Installing GeographicLib $tool $model"
 	geographiclib-get-$tool $model >/dev/null 2>&1
+	
+	files=$(shopt -s nullglob dotglob; echo /usr/share/GeographicLib/$dir/$model* /usr/local/share/GeographicLib/$dir/$model*)
+	if (( ! ${#files} )); then
+		echo "Error while installing GeographicLib $tool $model"
+		return
+	fi
 }
 
 # check which command script is available


### PR DESCRIPTION
Now script hasn't got error handler. Some time ago it was the problem with SourceForge mirrors. But this script didn't print any errors. And it was so difficult to understand, what the problem with dataset.

After path if dataset isn't downloaded, the script will write an error meaasge.