### PR TITLE
play_tune: Write new plugin

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(mavros_extras
   src/plugins/mocap_pose_estimate.cpp
   src/plugins/obstacle_distance.cpp
   src/plugins/odom.cpp
+  src/plugins/play_tune.cpp
   src/plugins/px4flow.cpp
   src/plugins/rangefinder.cpp
   src/plugins/trajectory.cpp

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -44,6 +44,9 @@
 	<class name="odom" type="mavros::extra_plugins::OdometryPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Send odometry to FCU from another estimator.</description>
 	</class>
+	<class name="play_tune" type="mavros::extra_plugins::PlayTunePlugin" base_class_type="mavros::plugin::PluginBase">
+		<description>Send tunes for the FCU to play.</description>
+	</class>
 	<class name="px4flow" type="mavros::extra_plugins::PX4FlowPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Publish OPTICAL_FLOW message data from FCU or PX4Flow module.</description>
 	</class>

--- a/mavros_extras/src/plugins/play_tune.cpp
+++ b/mavros_extras/src/plugins/play_tune.cpp
@@ -6,52 +6,52 @@ namespace mavros
 {
 namespace extra_plugins
 {
-
 class PlayTunePlugin : public plugin::PluginBase
 {
-  public:
-    PlayTunePlugin() : PluginBase(), nh("~") {}
+public:
+	PlayTunePlugin() : PluginBase(), nh("~") {}
 
-    void initialize(UAS& uas_) override
-    {
-        PluginBase::initialize(uas_);
-        sub = nh.subscribe("play_tune", 1, &PlayTunePlugin::callback, this);
-    }
+	void initialize(UAS& uas_) override
+	{
+		PluginBase::initialize(uas_);
+		sub = nh.subscribe("play_tune", 1, &PlayTunePlugin::callback, this);
+	}
 
-    Subscriptions get_subscriptions() override { return { /* No subscriptions */ }; }
+	Subscriptions get_subscriptions() override {
+		return { /* No subscriptions */ };
+	}
 
-  private:
-    ros::NodeHandle nh;
-    ros::Subscriber sub;
+private:
+	ros::NodeHandle nh;
+	ros::Subscriber sub;
 
-    void callback(const mavros_msgs::PlayTuneV2::ConstPtr& tune)
-    {
-        auto msg = mavlink::common::msg::PLAY_TUNE_V2{};
-        m_uas->msg_set_target(msg);
+	void callback(const mavros_msgs::PlayTuneV2::ConstPtr& tune)
+	{
+		auto msg = mavlink::common::msg::PLAY_TUNE_V2{};
+		m_uas->msg_set_target(msg);
 
-        switch (tune->format)
-        {
-            case mavros_msgs::PlayTuneV2::TUNE_FORMAT_QBASIC1_1:
-                msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::QBASIC1_1);
-                break;
+		switch (tune->format)
+		{
+		case mavros_msgs::PlayTuneV2::TUNE_FORMAT_QBASIC1_1:
+			msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::QBASIC1_1);
+			break;
 
-            case mavros_msgs::PlayTuneV2::TUNE_FORMAT_MML_MODERN:
-                msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::MML_MODERN);
-                break;
+		case mavros_msgs::PlayTuneV2::TUNE_FORMAT_MML_MODERN:
+			msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::MML_MODERN);
+			break;
 
-            default:
-                ROS_ERROR_NAMED("play_tune", "Invalid tune format: '%i'", tune->format);
-                return;
-        }
+		default:
+			ROS_ERROR_NAMED("play_tune", "Invalid tune format: '%i'", tune->format);
+			return;
+		}
 
-        mavlink::set_string_z(msg.tune, tune->tune);
+		mavlink::set_string_z(msg.tune, tune->tune);
 
-        UAS_FCU(m_uas)->send_message_ignore_drop(msg);
-    }
+		UAS_FCU(m_uas)->send_message_ignore_drop(msg);
+	}
 };
-
-}  // namespace extra_plugins
-}  // namespace mavros
+}	// namespace extra_plugins
+}	// namespace mavros
 
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::PlayTunePlugin, mavros::plugin::PluginBase)

--- a/mavros_extras/src/plugins/play_tune.cpp
+++ b/mavros_extras/src/plugins/play_tune.cpp
@@ -29,24 +29,8 @@ private:
 	{
 		auto msg = mavlink::common::msg::PLAY_TUNE_V2{};
 		m_uas->msg_set_target(msg);
-
-		switch (tune->format)
-		{
-		case mavros_msgs::PlayTuneV2::TUNE_FORMAT_QBASIC1_1:
-			msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::QBASIC1_1);
-			break;
-
-		case mavros_msgs::PlayTuneV2::TUNE_FORMAT_MML_MODERN:
-			msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::MML_MODERN);
-			break;
-
-		default:
-			ROS_ERROR_NAMED("play_tune", "Invalid tune format: '%i'", tune->format);
-			return;
-		}
-
+		msg.format = tune->format;
 		mavlink::set_string_z(msg.tune, tune->tune);
-
 		UAS_FCU(m_uas)->send_message_ignore_drop(msg);
 	}
 };

--- a/mavros_extras/src/plugins/play_tune.cpp
+++ b/mavros_extras/src/plugins/play_tune.cpp
@@ -27,8 +27,7 @@ class PlayTunePlugin : public plugin::PluginBase
     void callback(const mavros_msgs::PlayTuneV2::ConstPtr& tune)
     {
         auto msg = mavlink::common::msg::PLAY_TUNE_V2{};
-        msg.target_system = m_uas->get_tgt_system();
-        msg.target_component = m_uas->get_tgt_component();
+        m_uas->msg_set_target(msg);
 
         switch (tune->format)
         {
@@ -45,8 +44,7 @@ class PlayTunePlugin : public plugin::PluginBase
                 return;
         }
 
-        std::strncpy(msg.tune.data(), tune->tune.c_str(), sizeof(msg.tune));
-        msg.tune.back() = '\0';
+        mavlink::set_string_z(msg.tune, tune->tune);
 
         UAS_FCU(m_uas)->send_message_ignore_drop(msg);
     }

--- a/mavros_extras/src/plugins/play_tune.cpp
+++ b/mavros_extras/src/plugins/play_tune.cpp
@@ -1,0 +1,59 @@
+#include <mavros/mavros_plugin.h>
+#include <mavros_msgs/PlayTuneV2.h>
+#include <cstring>
+
+namespace mavros
+{
+namespace extra_plugins
+{
+
+class PlayTunePlugin : public plugin::PluginBase
+{
+  public:
+    PlayTunePlugin() : PluginBase(), nh("~") {}
+
+    void initialize(UAS& uas_) override
+    {
+        PluginBase::initialize(uas_);
+        sub = nh.subscribe("play_tune", 1, &PlayTunePlugin::callback, this);
+    }
+
+    Subscriptions get_subscriptions() override { return { /* No subscriptions */ }; }
+
+  private:
+    ros::NodeHandle nh;
+    ros::Subscriber sub;
+
+    void callback(const mavros_msgs::PlayTuneV2::ConstPtr& tune)
+    {
+        auto msg = mavlink::common::msg::PLAY_TUNE_V2{};
+        msg.target_system = m_uas->get_tgt_system();
+        msg.target_component = m_uas->get_tgt_component();
+
+        switch (tune->format)
+        {
+            case mavros_msgs::PlayTuneV2::TUNE_FORMAT_QBASIC1_1:
+                msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::QBASIC1_1);
+                break;
+
+            case mavros_msgs::PlayTuneV2::TUNE_FORMAT_MML_MODERN:
+                msg.format = static_cast<uint32_t>(mavlink::common::TUNE_FORMAT::MML_MODERN);
+                break;
+
+            default:
+                ROS_ERROR_NAMED("play_tune", "Invalid tune format: '%i'", tune->format);
+                return;
+        }
+
+        std::strncpy(msg.tune.data(), tune->tune.c_str(), sizeof(msg.tune));
+        msg.tune.back() = '\0';
+
+        UAS_FCU(m_uas)->send_message_ignore_drop(msg);
+    }
+};
+
+}  // namespace extra_plugins
+}  // namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::PlayTunePlugin, mavros::plugin::PluginBase)

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -44,6 +44,7 @@ add_message_files(
   OverrideRCIn.msg
   Param.msg
   ParamValue.msg
+  PlayTuneV2.msg
   PositionTarget.msg
   RCIn.msg
   RCOut.msg

--- a/mavros_msgs/msg/PlayTuneV2.msg
+++ b/mavros_msgs/msg/PlayTuneV2.msg
@@ -1,0 +1,9 @@
+# Play tune V2
+#
+# https://mavlink.io/en/messages/common.html#PLAY_TUNE_V2
+
+uint8 TUNE_FORMAT_QBASIC1_1 = 1
+uint8 TUNE_FORMAT_MML_MODERN = 2
+
+uint8 format
+string tune

--- a/mavros_msgs/msg/PlayTuneV2.msg
+++ b/mavros_msgs/msg/PlayTuneV2.msg
@@ -2,8 +2,9 @@
 #
 # https://mavlink.io/en/messages/common.html#PLAY_TUNE_V2
 
-uint8 TUNE_FORMAT_QBASIC1_1 = 1
-uint8 TUNE_FORMAT_MML_MODERN = 2
+## TUNE_FORMAT enum
+uint8 QBASIC1_1 = 1
+uint8 MML_MODERN = 2
 
 uint8 format
 string tune


### PR DESCRIPTION
Now that PX4 has proper handling of incoming PLAY_TUNE/PLAY_TUNE_V2 mavlink messages, I've written a tiny plugin that allows sending these tunes from ROS.

I've added a mavros_msgs/PlayTuneV2 for this, to make the interface clear, which includes the tune format and tune string.

Tested on a pixhawk with PX4 v1.11, and it plays as expected.