### PR TITLE
fake_gps: Fix assignment typo

### DIFF
--- a/mavros_extras/src/plugins/fake_gps.cpp
+++ b/mavros_extras/src/plugins/fake_gps.cpp
@@ -90,7 +90,7 @@ public:
 		fp_nh.param<int>("fix_type", ft_i, utils::enum_value(GPS_FIX_TYPE::NO_GPS));
 		fix_type = static_cast<GPS_FIX_TYPE>(ft_i);
 		fp_nh.param("gps_rate", _gps_rate, 5.0);		// GPS data rate of 5hz
-		gps_rate : _gps_rate;
+		gps_rate = _gps_rate;
 		fp_nh.param("eph", eph, 2.0);
 		fp_nh.param("epv", epv, 2.0);
 		fp_nh.param<float>("horiz_accuracy", horiz_accuracy, 0.0f);


### PR DESCRIPTION
This colon should probably be an equals sign.
With the colon, this assignment becomes a label instead,
and `_gps_rate` after the colon becomes an unused
expression result.

Glancing at the code, I suppose the result of this bug is that the default gps rate of 5 Hz was used always, even if the "gps_rate" node param was set to something else.