### PR TITLE
Don't publish distance sensor when orientation is wrong

### DIFF
--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -224,6 +224,7 @@ private:
 						sensor->topic_name.c_str(),
 						utils::to_string_enum<MAV_SENSOR_ORIENTATION>(dist_sen.orientation).c_str(),
 						utils::to_string_enum<MAV_SENSOR_ORIENTATION>(sensor->orientation).c_str());
+			return;
 		}
 
 		auto range = boost::make_shared<sensor_msgs::Range>();


### PR DESCRIPTION
Right now, if you get a distance sensor message from mavlink, and its orientation does not match the expected orientation (from your mavros config), the plugin prints an error but still publishes the data to ros, with the configured frame_id. It's probably better to not produce data when we know it's incorrect, so we suggest adding an early return to the relevant block.