### PR TITLE
Fix warnings

### DIFF
--- a/libmavconn/include/mavconn/msgbuffer.h
+++ b/libmavconn/include/mavconn/msgbuffer.h
@@ -32,8 +32,8 @@ struct MsgBuffer {
 	ssize_t pos;
 
 	MsgBuffer() :
-		pos(0),
-		len(0)
+		len(0),
+		pos(0)
 	{ }
 
 	/**
@@ -71,8 +71,8 @@ struct MsgBuffer {
 	 * @param[in] nbytes should be less than MAX_SIZE
 	 */
 	MsgBuffer(const uint8_t *bytes, ssize_t nbytes) :
-		pos(0),
-		len(nbytes)
+		len(nbytes),
+		pos(0)
 	{
 		assert(0 < nbytes && nbytes < MAX_SIZE);
 		memcpy(data, bytes, nbytes);

--- a/libmavconn/include/mavconn/serial.h
+++ b/libmavconn/include/mavconn/serial.h
@@ -40,7 +40,7 @@ public:
 	 */
 	MAVConnSerial(uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
 			std::string device = DEFAULT_DEVICE, unsigned baudrate = DEFAULT_BAUDRATE, bool hwflow = false);
-	~MAVConnSerial();
+	virtual ~MAVConnSerial();
 
 	void close() override;
 

--- a/libmavconn/include/mavconn/tcp.h
+++ b/libmavconn/include/mavconn/tcp.h
@@ -49,7 +49,7 @@ public:
 	 */
 	explicit MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 			boost::asio::io_service &server_io);
-	~MAVConnTCPClient();
+	virtual ~MAVConnTCPClient();
 
 	void close() override;
 
@@ -103,7 +103,7 @@ public:
 	 */
 	MAVConnTCPServer(uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
 			std::string bind_host = DEFAULT_BIND_HOST, unsigned short bind_port = DEFAULT_BIND_PORT);
-	~MAVConnTCPServer();
+	virtual ~MAVConnTCPServer();
 
 	void close() override;
 

--- a/libmavconn/include/mavconn/udp.h
+++ b/libmavconn/include/mavconn/udp.h
@@ -48,7 +48,7 @@ public:
 	MAVConnUDP(uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
 			std::string bind_host = DEFAULT_BIND_HOST, unsigned short bind_port = DEFAULT_BIND_PORT,
 			std::string remote_host = DEFAULT_REMOTE_HOST, unsigned short remote_port = DEFAULT_REMOTE_PORT);
-	~MAVConnUDP();
+	virtual ~MAVConnUDP();
 
 	void close() override;
 

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -40,11 +40,11 @@ using mavlink::mavlink_message_t;
 MAVConnSerial::MAVConnSerial(uint8_t system_id, uint8_t component_id,
 		std::string device, unsigned baudrate, bool hwflow) :
 	MAVConnInterface(system_id, component_id),
+	io_service(),
+	serial_dev(io_service),
 	tx_in_progress(false),
 	tx_q {},
-	rx_buf {},
-	io_service(),
-	serial_dev(io_service)
+	rx_buf {}
 {
 	using SPB = boost::asio::serial_port_base;
 

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -77,13 +77,13 @@ static bool resolve_address_tcp(io_service &io, size_t chan, std::string host, u
 MAVConnTCPClient::MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 		std::string server_host, unsigned short server_port) :
 	MAVConnInterface(system_id, component_id),
+	io_service(),
+	io_work(new io_service::work(io_service)),
+	socket(io_service),
 	is_destroying(false),
 	tx_in_progress(false),
 	tx_q {},
-	rx_buf {},
-	io_service(),
-	io_work(new io_service::work(io_service)),
-	socket(io_service)
+	rx_buf {}
 {
 	if (!resolve_address_tcp(io_service, conn_id, server_host, server_port, server_ep))
 		throw DeviceError("tcp: resolve", "Bind address resolve failed");
@@ -113,10 +113,10 @@ MAVConnTCPClient::MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 MAVConnTCPClient::MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 		boost::asio::io_service &server_io) :
 	MAVConnInterface(system_id, component_id),
+	socket(server_io),
 	tx_in_progress(false),
 	tx_q {},
-	rx_buf {},
-	socket(server_io)
+	rx_buf {}
 {
 	// waiting when server call client_connected()
 }

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -69,14 +69,14 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 		std::string bind_host, unsigned short bind_port,
 		std::string remote_host, unsigned short remote_port) :
 	MAVConnInterface(system_id, component_id),
-	remote_exists(false),
-	tx_in_progress(false),
-	tx_q {},
-	rx_buf {},
 	io_service(),
 	io_work(new io_service::work(io_service)),
+	permanent_broadcast(false),
+	remote_exists(false),
 	socket(io_service),
-	permanent_broadcast(false)
+	tx_in_progress(false),
+	tx_q {},
+	rx_buf {}
 {
 	using udps = boost::asio::ip::udp::socket;
 

--- a/mavros/include/mavros/frame_tf.h
+++ b/mavros/include/mavros/frame_tf.h
@@ -62,6 +62,12 @@ enum class StaticTF {
 	ENU_TO_NED,		//!< change from expressed WRT ENU frame to WRT NED frame
 	AIRCRAFT_TO_BASELINK,	//!< change from expressed WRT aircraft frame to WRT to baselink frame
 	BASELINK_TO_AIRCRAFT,	//!< change from expressed WRT baselnk to WRT aircraft
+};
+
+/**
+ * @brief Orientation transform options when applying rotations to data, for ECEF.
+ */
+enum class StaticEcefTF {
 	ECEF_TO_ENU,		//!< change from expressed WRT ECEF frame to WRT ENU frame
 	ENU_TO_ECEF		//!< change from expressed WRT ENU frame to WRT ECEF frame
 };
@@ -138,7 +144,7 @@ Covariance9d transform_static_frame(const Covariance9d &cov, const StaticTF tran
  *
  * General function. Please use specialized variants.
  */
-Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const Eigen::Vector3d &map_origin, const StaticTF transform);
+Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const Eigen::Vector3d &map_origin, const StaticEcefTF transform);
 
 }	// namespace detail
 
@@ -224,7 +230,7 @@ inline T transform_frame_baselink_aircraft(const T &in) {
  */
 template<class T>
 inline T transform_frame_ecef_enu(const T &in, const T &map_origin) {
-	return detail::transform_static_frame(in, map_origin, StaticTF::ECEF_TO_ENU);
+	return detail::transform_static_frame(in, map_origin, StaticEcefTF::ECEF_TO_ENU);
 }
 
 /**
@@ -236,7 +242,7 @@ inline T transform_frame_ecef_enu(const T &in, const T &map_origin) {
  */
 template<class T>
 inline T transform_frame_enu_ecef(const T &in, const T &map_origin) {
-	return detail::transform_static_frame(in, map_origin, StaticTF::ENU_TO_ECEF);
+	return detail::transform_static_frame(in, map_origin, StaticEcefTF::ENU_TO_ECEF);
 }
 
 /**

--- a/mavros/src/lib/ftf_frame_conversions.cpp
+++ b/mavros/src/lib/ftf_frame_conversions.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <mavros/frame_tf.h>
+#include <stdexcept>
 
 namespace mavros {
 namespace ftf {
@@ -185,7 +186,7 @@ Covariance9d transform_static_frame(const Covariance9d &cov, const StaticTF tran
 	}
 }
 
-Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const Eigen::Vector3d &map_origin, const StaticTF transform)
+Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const Eigen::Vector3d &map_origin, const StaticEcefTF transform)
 {
 	//! Degrees to radians
 	static constexpr double DEG_TO_RAD = (M_PI / 180.0);
@@ -216,10 +217,10 @@ Eigen::Vector3d transform_static_frame(const Eigen::Vector3d &vec, const Eigen::
 	      cos_lon * cos_lat,  sin_lon * cos_lat, sin_lat;
 
 	switch (transform) {
-	case StaticTF::ECEF_TO_ENU:
+	case StaticEcefTF::ECEF_TO_ENU:
 		return R * vec;
 
-	case StaticTF::ENU_TO_ECEF:
+	case StaticEcefTF::ENU_TO_ECEF:
 		// ENU to ECEF rotation is just an inverse rotation from ECEF to ENU, which means transpose.
 		R.transposeInPlace();
 		return R * vec;

--- a/mavros/src/plugins/3dr_radio.cpp
+++ b/mavros/src/plugins/3dr_radio.cpp
@@ -32,7 +32,7 @@ public:
 		low_rssi(0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -43,7 +43,7 @@ public:
 		enable_connection_cb();
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&TDRRadioPlugin::handle_radio_status),

--- a/mavros/src/plugins/actuator_control.cpp
+++ b/mavros/src/plugins/actuator_control.cpp
@@ -31,7 +31,7 @@ public:
 		nh("~")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -39,7 +39,7 @@ public:
 		actuator_control_sub = nh.subscribe("actuator_control", 10, &ActuatorControlPlugin::actuator_control_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&ActuatorControlPlugin::handle_actuator_control_target),

--- a/mavros/src/plugins/altitude.cpp
+++ b/mavros/src/plugins/altitude.cpp
@@ -32,7 +32,7 @@ public:
 	/**
 	 * Plugin initializer. Constructor should not do this.
 	 */
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -40,7 +40,7 @@ public:
 		altitude_pub = nh.advertise<mavros_msgs::Altitude>("altitude", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&AltitudePlugin::handle_altitude),

--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -61,7 +61,7 @@ public:
 		use_comp_id_system_control(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -83,7 +83,7 @@ public:
 		vtol_transition_srv = cmd_nh.advertiseService("vtol_transition", &CommandPlugin::vtol_transition_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&CommandPlugin::handle_command_ack)

--- a/mavros/src/plugins/dummy.cpp
+++ b/mavros/src/plugins/dummy.cpp
@@ -34,7 +34,7 @@ public:
 	/**
 	 * Plugin initializer. Constructor should not do this.
 	 */
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -49,7 +49,7 @@ public:
 	 *  - With automatic decoding and framing error filtering (see handle_heartbeat)
 	 *  - Raw message with framig status (see handle_systemtext)
 	 */
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			/* automatic message deduction by second argument */
 			make_handler(&DummyPlugin::handle_heartbeat),

--- a/mavros/src/plugins/ftp.cpp
+++ b/mavros/src/plugins/ftp.cpp
@@ -212,7 +212,7 @@ public:
 		checksum_crc32(0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -234,7 +234,7 @@ public:
 		checksum_srv = ftp_nh.advertiseService("checksum", &FTPPlugin::checksum_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&FTPPlugin::handle_file_transfer_protocol),

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -54,7 +54,7 @@ public:
 		is_map_init(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -95,7 +95,7 @@ public:
 		gp_global_offset_pub = gp_nh.advertise<geometry_msgs::PoseStamped>("gp_lp_offset", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 				make_handler(&GlobalPositionPlugin::handle_gps_raw_int),

--- a/mavros/src/plugins/hil.cpp
+++ b/mavros/src/plugins/hil.cpp
@@ -45,7 +45,7 @@ public:
 		hil_nh("~hil")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -59,7 +59,7 @@ public:
 		hil_actuator_controls_pub = hil_nh.advertise<mavros_msgs::HilActuatorControls>("actuator_controls", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&HilPlugin::handle_hil_controls),

--- a/mavros/src/plugins/home_position.cpp
+++ b/mavros/src/plugins/home_position.cpp
@@ -36,7 +36,7 @@ public:
 		REQUEST_POLL_TIME_DT(REQUEST_POLL_TIME_MS / 1000.0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -49,7 +49,7 @@ public:
 		enable_connection_cb();
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&HomePositionPlugin::handle_home_position),

--- a/mavros/src/plugins/imu.cpp
+++ b/mavros/src/plugins/imu.cpp
@@ -58,7 +58,7 @@ public:
 		linear_accel_vec_frd(Eigen::Vector3d::Zero())
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -94,7 +94,7 @@ public:
 		enable_connection_cb();
 	}
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			       make_handler(&IMUPlugin::handle_attitude),
 			       make_handler(&IMUPlugin::handle_attitude_quaternion),

--- a/mavros/src/plugins/local_position.cpp
+++ b/mavros/src/plugins/local_position.cpp
@@ -44,7 +44,7 @@ public:
 		has_local_position_ned_cov(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -66,7 +66,7 @@ public:
 		local_odom = lp_nh.advertise<nav_msgs::Odometry>("odom",10);
 	}
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			       make_handler(&LocalPositionPlugin::handle_local_position_ned),
 			       make_handler(&LocalPositionPlugin::handle_local_position_ned_cov)

--- a/mavros/src/plugins/manual_control.cpp
+++ b/mavros/src/plugins/manual_control.cpp
@@ -29,7 +29,7 @@ public:
 		manual_control_nh("~manual_control")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -37,7 +37,7 @@ public:
 		send_sub = manual_control_nh.subscribe("send", 1, &ManualControlPlugin::send_cb, this);
 	}
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			make_handler(&ManualControlPlugin::handle_manual_control),
 		};

--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -370,7 +370,7 @@ public:
 		PARAM_TIMEOUT_DT(PARAM_TIMEOUT_MS / 1000.0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -388,7 +388,7 @@ public:
 		enable_connection_cb();
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&ParamPlugin::handle_param_value),

--- a/mavros/src/plugins/rc_io.cpp
+++ b/mavros/src/plugins/rc_io.cpp
@@ -34,7 +34,7 @@ public:
 		has_rc_channels_msg(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -45,7 +45,7 @@ public:
 		enable_connection_cb();
 	};
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			       make_handler(&RCIOPlugin::handle_rc_channels_raw),
 			       make_handler(&RCIOPlugin::handle_rc_channels),

--- a/mavros/src/plugins/safety_area.cpp
+++ b/mavros/src/plugins/safety_area.cpp
@@ -32,7 +32,7 @@ public:
 		safety_nh("~safety_area")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -70,7 +70,7 @@ public:
 		safetyarea_pub = safety_nh.advertise<geometry_msgs::PolygonStamped>("get",10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 		       make_handler(&SafetyAreaPlugin::handle_safety_allowed_area)

--- a/mavros/src/plugins/setpoint_accel.cpp
+++ b/mavros/src/plugins/setpoint_accel.cpp
@@ -37,7 +37,7 @@ public:
 		send_force(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -46,7 +46,7 @@ public:
 		accel_sub = sp_nh.subscribe("accel", 10, &SetpointAccelerationPlugin::accel_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -52,7 +52,7 @@ public:
 		tf_listen(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -95,7 +95,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -47,7 +47,7 @@ public:
 		tf_listen(false)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -84,7 +84,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros/src/plugins/setpoint_raw.cpp
+++ b/mavros/src/plugins/setpoint_raw.cpp
@@ -39,7 +39,7 @@ public:
 		sp_nh("~setpoint_raw")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -53,7 +53,7 @@ public:
 		target_attitude_pub = sp_nh.advertise<mavros_msgs::AttitudeTarget>("target_attitude", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 				make_handler(&SetpointRawPlugin::handle_position_target_local_ned),

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -41,7 +41,7 @@ public:
 		sp_nh("~setpoint_trajectory")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -64,7 +64,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros/src/plugins/setpoint_velocity.cpp
+++ b/mavros/src/plugins/setpoint_velocity.cpp
@@ -39,7 +39,7 @@ public:
 		sp_nh("~setpoint_velocity")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -57,7 +57,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -430,7 +430,7 @@ public:
 		conn_heartbeat_mav_type(MAV_TYPE::ONBOARD_CONTROLLER)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -497,7 +497,7 @@ public:
 		enable_connection_cb();
 	}
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			make_handler(&SystemStatusPlugin::handle_heartbeat),
 			make_handler(&SystemStatusPlugin::handle_sys_status),

--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -150,7 +150,7 @@ public:
 
 	using TSM = UAS::timesync_mode;
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -238,7 +238,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&SystemTimePlugin::handle_system_time),

--- a/mavros/src/plugins/vfr_hud.cpp
+++ b/mavros/src/plugins/vfr_hud.cpp
@@ -33,14 +33,14 @@ public:
 	/**
 	 * Plugin initializer. Constructor should not do this.
 	 */
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		vfr_pub = nh.advertise<mavros_msgs::VFR_HUD>("vfr_hud", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&VfrHudPlugin::handle_vfr_hud),

--- a/mavros/src/plugins/waypoint.cpp
+++ b/mavros/src/plugins/waypoint.cpp
@@ -237,7 +237,7 @@ public:
 		RESCHEDULE_DT(RESCHEDULE_MS / 1000.0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -261,7 +261,7 @@ public:
 		enable_capabilities_cb();
 	}
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			       make_handler(&WaypointPlugin::handle_mission_item),
 			       make_handler(&WaypointPlugin::handle_mission_item_int),

--- a/mavros/src/plugins/wind_estimation.cpp
+++ b/mavros/src/plugins/wind_estimation.cpp
@@ -35,14 +35,14 @@ public:
 	/**
 	 * Plugin initializer. Constructor should not do this.
 	 */
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		wind_pub = nh.advertise<geometry_msgs::TwistWithCovarianceStamped>("wind_estimation", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&WindEstimationPlugin::handle_apm_wind),

--- a/mavros_extras/src/plugins/adsb.cpp
+++ b/mavros_extras/src/plugins/adsb.cpp
@@ -34,7 +34,7 @@ public:
 		adsb_nh("~adsb")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -42,7 +42,7 @@ public:
 		adsb_sub = adsb_nh.subscribe("send", 10, &ADSBPlugin::adsb_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&ADSBPlugin::handle_adsb)

--- a/mavros_extras/src/plugins/cam_imu_sync.cpp
+++ b/mavros_extras/src/plugins/cam_imu_sync.cpp
@@ -33,14 +33,14 @@ public:
 		cam_imu_sync_nh("~cam_imu_sync")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		cam_imu_pub = cam_imu_sync_nh.advertise<mavros_msgs::CamIMUStamp>("cam_imu_stamp", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&CamIMUSyncPlugin::handle_cam_trig)

--- a/mavros_extras/src/plugins/companion_process_status.cpp
+++ b/mavros_extras/src/plugins/companion_process_status.cpp
@@ -41,14 +41,14 @@ public:
 	status_nh("~companion_process")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		status_sub = status_nh.subscribe("status", 10, &CompanionProcessStatusPlugin::status_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/debug_value.cpp
+++ b/mavros_extras/src/plugins/debug_value.cpp
@@ -27,7 +27,7 @@ public:
 		debug_nh("~debug_value")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -41,7 +41,7 @@ public:
 		named_value_int_pub = debug_nh.advertise<mavros_msgs::DebugValue>("named_value_int", 10);
 	}
 
-	Subscriptions get_subscriptions() {
+	Subscriptions get_subscriptions() override {
 		return {
 			       make_handler(&DebugValuePlugin::handle_debug),
 			       make_handler(&DebugValuePlugin::handle_debug_vector),

--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -116,7 +116,7 @@ public:
 		dist_nh("~distance_sensor")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -141,7 +141,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&DistanceSensorPlugin::handle_distance_sensor),

--- a/mavros_extras/src/plugins/esc_status.cpp
+++ b/mavros_extras/src/plugins/esc_status.cpp
@@ -35,7 +35,7 @@ public:
 		nh("~")
 	{}
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -45,7 +45,7 @@ public:
 		enable_connection_cb();
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&ESCStatusPlugin::handle_esc_info),

--- a/mavros_extras/src/plugins/esc_status.cpp
+++ b/mavros_extras/src/plugins/esc_status.cpp
@@ -29,10 +29,10 @@ class ESCStatusPlugin : public plugin::PluginBase
 {
 public:
 	ESCStatusPlugin() : PluginBase(),
+		nh("~"),
 		_max_esc_count(0),
 		_max_esc_info_index(0),
-		_max_esc_status_index(0),
-		nh("~")
+		_max_esc_status_index(0)
 	{}
 
 	void initialize(UAS &uas_) override

--- a/mavros_extras/src/plugins/fake_gps.cpp
+++ b/mavros_extras/src/plugins/fake_gps.cpp
@@ -75,7 +75,7 @@ public:
 		earth(GeographicLib::Constants::WGS84_a(), GeographicLib::Constants::WGS84_f())
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -157,7 +157,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/fake_gps.cpp
+++ b/mavros_extras/src/plugins/fake_gps.cpp
@@ -55,24 +55,24 @@ public:
 	FakeGPSPlugin() : PluginBase(),
 		fp_nh("~fake_gps"),
 		gps_rate(5.0),
+		// WGS-84 ellipsoid (a - equatorial radius, f - flattening of ellipsoid)
+		earth(GeographicLib::Constants::WGS84_a(), GeographicLib::Constants::WGS84_f()),
 		use_mocap(true),
-		map_origin(0.0, 0.0, 0.0),
-		mocap_transform(true),
-		mocap_withcovariance(false),
 		use_vision(false),
 		use_hil_gps(true),
-		gps_id(0),
+		mocap_transform(true),
+		mocap_withcovariance(false),
 		tf_listen(false),
-		tf_rate(10.0),
 		eph(2.0),
 		epv(2.0),
 		horiz_accuracy(0.0f),
 		vert_accuracy(0.0f),
 		speed_accuracy(0.0f),
+		gps_id(0),
 		satellites_visible(5),
 		fix_type(GPS_FIX_TYPE::NO_GPS),
-		// WGS-84 ellipsoid (a - equatorial radius, f - flattening of ellipsoid)
-		earth(GeographicLib::Constants::WGS84_a(), GeographicLib::Constants::WGS84_f())
+		tf_rate(10.0),
+		map_origin(0.0, 0.0, 0.0)
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros_extras/src/plugins/gps_rtk.cpp
+++ b/mavros_extras/src/plugins/gps_rtk.cpp
@@ -33,14 +33,14 @@ public:
 		gps_rtk_nh("~gps_rtk")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 		gps_rtk_sub = gps_rtk_nh.subscribe("send_rtcm", 10, &GpsRtkPlugin::rtcm_cb, this);
 		rtk_baseline_pub_ = gps_rtk_nh.advertise<mavros_msgs::RTKBaseline>("rtk_baseline", 1, true);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler( &GpsRtkPlugin::handle_baseline_msg )

--- a/mavros_extras/src/plugins/gps_status.cpp
+++ b/mavros_extras/src/plugins/gps_status.cpp
@@ -33,7 +33,7 @@ public:
 		gpsstatus_nh("~gpsstatus")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -43,7 +43,7 @@ public:
 		gps2_rtk_pub = gpsstatus_nh.advertise<mavros_msgs::GPSRTK>("gps2/rtk", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&GpsStatusPlugin::handle_gps_raw_int),

--- a/mavros_extras/src/plugins/landing_target.cpp
+++ b/mavros_extras/src/plugins/landing_target.cpp
@@ -55,7 +55,7 @@ public:
 		land_target_type("VISION_FIDUCIAL")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -105,7 +105,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&LandingTargetPlugin::handle_landing_target)

--- a/mavros_extras/src/plugins/mocap_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/mocap_pose_estimate.cpp
@@ -36,7 +36,7 @@ public:
 		mp_nh("~mocap")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -60,7 +60,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -42,7 +42,7 @@ public:
 	mount_nh("~mount_control")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -52,7 +52,7 @@ public:
 
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&MountControlPlugin::handle_mount_orientation)

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -39,7 +39,7 @@ public:
 		obstacle_nh("~obstacle")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -50,7 +50,7 @@ public:
 		obstacle_sub = obstacle_nh.subscribe("send", 10, &ObstacleDistancePlugin::obstacle_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -50,7 +50,7 @@ public:
 		fcu_odom_child_id_des("base_link")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -65,7 +65,7 @@ public:
 		odom_sub = odom_nh.subscribe("out", 1, &OdometryPlugin::odom_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&OdometryPlugin::handle_odom)

--- a/mavros_extras/src/plugins/onboard_computer_status.cpp
+++ b/mavros_extras/src/plugins/onboard_computer_status.cpp
@@ -32,14 +32,14 @@ public:
 		status_nh("~onboard_computer")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		status_sub = status_nh.subscribe("status", 10, &OnboardComputerStatusPlugin::status_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -38,7 +38,7 @@ public:
 		ranger_max_range(5.0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -62,7 +62,7 @@ public:
 		flow_rad_sub = flow_nh.subscribe("raw/send", 1, &PX4FlowPlugin::send_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&PX4FlowPlugin::handle_optical_flow_rad)

--- a/mavros_extras/src/plugins/rangefinder.cpp
+++ b/mavros_extras/src/plugins/rangefinder.cpp
@@ -31,14 +31,14 @@ public:
 		rangefinder_nh("~rangefinder")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		rangefinder_pub = rangefinder_nh.advertise<sensor_msgs::Range>("rangefinder", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&RangefinderPlugin::handle_rangefinder)

--- a/mavros_extras/src/plugins/trajectory.cpp
+++ b/mavros_extras/src/plugins/trajectory.cpp
@@ -43,7 +43,7 @@ public:
 		trajectory_nh("~trajectory")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -52,7 +52,7 @@ public:
 		trajectory_desired_pub = trajectory_nh.advertise<mavros_msgs::Trajectory>("desired", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&TrajectoryPlugin::handle_trajectory)

--- a/mavros_extras/src/plugins/vibration.cpp
+++ b/mavros_extras/src/plugins/vibration.cpp
@@ -32,7 +32,7 @@ public:
 		vibe_nh("~vibration")
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -41,7 +41,7 @@ public:
 		vibration_pub = vibe_nh.advertise<mavros_msgs::Vibration>("raw/vibration", 10);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			       make_handler(&VibrationPlugin::handle_vibration)

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -39,7 +39,7 @@ public:
 		tf_rate(10.0)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -62,7 +62,7 @@ public:
 		}
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/vision_speed_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_speed_estimate.cpp
@@ -38,7 +38,7 @@ public:
 		twist_cov(true)
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -55,7 +55,7 @@ public:
 			vision_vector_sub = sp_nh.subscribe("speed_vector", 10, &VisionSpeedEstimatePlugin::vector_cb, this);
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return { /* Rx disabled */ };
 	}

--- a/mavros_extras/src/plugins/wheel_odometry.cpp
+++ b/mavros_extras/src/plugins/wheel_odometry.cpp
@@ -50,7 +50,7 @@ public:
 		rtwist_cov(Eigen::Vector3d::Zero())
 	{ }
 
-	void initialize(UAS &uas_)
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
@@ -154,7 +154,7 @@ public:
 
 	}
 
-	Subscriptions get_subscriptions()
+	Subscriptions get_subscriptions() override
 	{
 		return {
 			make_handler(&WheelOdometryPlugin::handle_rpm),

--- a/mavros_msgs/include/mavros_msgs/mavlink_convert.h
+++ b/mavros_msgs/include/mavros_msgs/mavlink_convert.h
@@ -105,11 +105,11 @@ inline bool convert(const mavlink_message_t &mmsg, mavros_msgs::Mavlink &rmsg, u
 	rmsg.msgid = mmsg.msgid;
 	rmsg.checksum = mmsg.checksum;
 	// [[[end]]] (checksum: 4f0a50d2fcd7eb8823aea3e0806cd698)
-	rmsg.payload64 = std::move(mavros_msgs::Mavlink::_payload64_type(mmsg.payload64, mmsg.payload64 + payload64_len));
+	rmsg.payload64 = mavros_msgs::Mavlink::_payload64_type(mmsg.payload64, mmsg.payload64 + payload64_len);
 
 	// copy signature block only if message is signed
 	if (mmsg.incompat_flags & MAVLINK_IFLAG_SIGNED)
-		rmsg.signature = std::move(mavros_msgs::Mavlink::_signature_type(mmsg.signature, mmsg.signature + sizeof(mmsg.signature)));
+		rmsg.signature = mavros_msgs::Mavlink::_signature_type(mmsg.signature, mmsg.signature + sizeof(mmsg.signature));
 	else
 		rmsg.signature.clear();
 


### PR DESCRIPTION
Hi, I tried building with `-Wall -Wextra -Wpedantic` and resolving the warnings that pop up. I have some clone of mavros in my workspace most of the time, so it's nice to get rid of the them. Most of these should be fairly uncontroversial, but the ECEF TF stuff should probably get some scrutiny.