### PR TITLE
Report custom firmware version

### DIFF
--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -836,6 +836,7 @@ private:
 		it->second.middleware_sw_version = apv.middleware_sw_version;
 		it->second.os_sw_version = apv.os_sw_version;
 		it->second.board_version = apv.board_version;
+		it->second.flight_custom_version = custom_version_to_hex_string(apv.flight_custom_version);
 		it->second.vendor_id = apv.vendor_id;
 		it->second.product_id = apv.product_id;
 		it->second.uid = apv.uid;

--- a/mavros_msgs/msg/VehicleInfo.msg
+++ b/mavros_msgs/msg/VehicleInfo.msg
@@ -25,6 +25,7 @@ uint32 flight_sw_version        # Firmware version number
 uint32 middleware_sw_version    # Middleware version number
 uint32 os_sw_version            # Operating system version number
 uint32 board_version            # HW / board version (last 8 bytes should be silicon ID, if any)
+string flight_custom_version    # Custom version field, commonly from the first 8 bytes of the git hash
 uint16 vendor_id                # ID of the board vendor
 uint16 product_id               # ID of the product
 uint64 uid                      # UID if provided by hardware


### PR DESCRIPTION
Hi! I thought it might be useful to some to include the custom firmware version info in the vehicle info. This adds a string type field `flight_custom_version` to the VehicleInfo message, which corresponds to the field of the same name in MAVLink [AUTOPILOT_VERSION](https://mavlink.io/en/messages/common.html#AUTOPILOT_VERSION). Then it takes the custom version from the autopilot, which is an array of 8 bytes, converts it to hex string with the existing method, and sends it.