### PR TITLE
Add message struct initialisations

### DIFF
--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -25,6 +25,14 @@ using namespace mavconn;
 using mavlink::mavlink_message_t;
 using mavlink::msgid_t;
 
+namespace mavlink {
+	namespace common {
+		using namespace mavlink::minimal;
+		namespace msg {
+			using namespace mavlink::minimal::msg;
+			}
+	}
+}
 
 static void send_heartbeat(MAVConnInterface *ip) {
 	using mavlink::common::MAV_TYPE;

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -32,7 +32,7 @@ static void send_heartbeat(MAVConnInterface *ip) {
 	using mavlink::common::MAV_MODE;
 	using mavlink::common::MAV_STATE;
 
-	mavlink::common::msg::HEARTBEAT hb;
+	mavlink::common::msg::HEARTBEAT hb = {};
 	hb.type = int(MAV_TYPE::ONBOARD_CONTROLLER);
 	hb.autopilot = int(MAV_AUTOPILOT::INVALID);
 	hb.base_mode = int(MAV_MODE::MANUAL_ARMED);

--- a/mavros/include/mavros/setpoint_mixin.h
+++ b/mavros/include/mavros/setpoint_mixin.h
@@ -43,7 +43,7 @@ public:
 			float yaw, float yaw_rate)
 	{
 		mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
-		mavlink::common::msg::SET_POSITION_TARGET_LOCAL_NED sp;
+		mavlink::common::msg::SET_POSITION_TARGET_LOCAL_NED sp = {};
 
 		m_uas_->msg_set_target(sp);
 
@@ -89,7 +89,7 @@ public:
 			float yaw, float yaw_rate)
 	{
 		mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
-		mavlink::common::msg::SET_POSITION_TARGET_GLOBAL_INT sp;
+		mavlink::common::msg::SET_POSITION_TARGET_GLOBAL_INT sp = {};
 
 		m_uas_->msg_set_target(sp);
 
@@ -134,7 +134,7 @@ public:
 			float thrust)
 	{
 		mavros::UAS *m_uas_ = static_cast<D *>(this)->m_uas;
-		mavlink::common::msg::SET_ATTITUDE_TARGET sp;
+		mavlink::common::msg::SET_ATTITUDE_TARGET sp = {};
 
 		m_uas_->msg_set_target(sp);
 		mavros::ftf::quaternion_to_mavlink(orientation, sp.q);

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -494,7 +494,7 @@ private:
 
 	void set_gp_origin_cb(const geographic_msgs::GeoPointStamped::ConstPtr &req)
 	{
-		mavlink::common::msg::SET_GPS_GLOBAL_ORIGIN gpo;
+		mavlink::common::msg::SET_GPS_GLOBAL_ORIGIN gpo = {};
 
 		Eigen::Vector3d global_position;
 

--- a/mavros/src/plugins/hil.cpp
+++ b/mavros/src/plugins/hil.cpp
@@ -127,7 +127,7 @@ private:
 	 * Message specification: @p https://mavlink.io/en/messages/common.html#HIL_STATE_QUATERNION
 	 */
 	void state_quat_cb(const mavros_msgs::HilStateQuaternion::ConstPtr &req) {
-		mavlink::common::msg::HIL_STATE_QUATERNION state_quat;
+		mavlink::common::msg::HIL_STATE_QUATERNION state_quat = {};
 
 		state_quat.time_usec = req->header.stamp.toNSec() / 1000;
 		auto q = ftf::transform_orientation_baselink_aircraft(
@@ -179,7 +179,7 @@ private:
 	 * Message specification: @p https://mavlink.io/en/messages/common.html#HIL_GPS
 	 */
 	void gps_cb(const mavros_msgs::HilGPS::ConstPtr &req) {
-		mavlink::common::msg::HIL_GPS gps;
+		mavlink::common::msg::HIL_GPS gps = {};
 
 		gps.time_usec = req->header.stamp.toNSec() / 1000;
 		gps.fix_type = req->fix_type;
@@ -212,7 +212,7 @@ private:
 	 * Message specification: @p https://mavlink.io/en/messages/common.html#HIL_SENSOR
 	 */
 	void sensor_cb(const mavros_msgs::HilSensor::ConstPtr &req) {
-		mavlink::common::msg::HIL_SENSOR sensor;
+		mavlink::common::msg::HIL_SENSOR sensor = {};
 
 		sensor.time_usec = req->header.stamp.toNSec() / 1000;
 		// WRT world frame
@@ -258,7 +258,7 @@ private:
 	 * Message specification: @p https://mavlink.io/en/messages/common.html#HIL_OPTICAL_FLOW
 	 */
 	void optical_flow_cb(const mavros_msgs::OpticalFlowRad::ConstPtr &req) {
-		mavlink::common::msg::HIL_OPTICAL_FLOW of;
+		mavlink::common::msg::HIL_OPTICAL_FLOW of = {};
 
 		auto int_xy = ftf::transform_frame_aircraft_baselink(
 					Eigen::Vector3d(

--- a/mavros/src/plugins/manual_control.cpp
+++ b/mavros/src/plugins/manual_control.cpp
@@ -69,7 +69,7 @@ private:
 
 	void send_cb(const mavros_msgs::ManualControl::ConstPtr req)
 	{
-		mavlink::common::msg::MANUAL_CONTROL msg;
+		mavlink::common::msg::MANUAL_CONTROL msg = {};
 		msg.target = m_uas->get_tgt_system();
 
 		msg.x = req->x;

--- a/mavros/src/plugins/rc_io.cpp
+++ b/mavros/src/plugins/rc_io.cpp
@@ -231,7 +231,7 @@ private:
 		if (!m_uas->is_ardupilotmega() && !m_uas->is_px4())
 			ROS_WARN_THROTTLE_NAMED(30, "rc", "RC override not supported by this FCU!");
 
-		mavlink::common::msg::RC_CHANNELS_OVERRIDE ovr;
+		mavlink::common::msg::RC_CHANNELS_OVERRIDE ovr = {};
 		ovr.target_system = m_uas->get_tgt_system();
 		ovr.target_component = m_uas->get_tgt_component();
 

--- a/mavros/src/plugins/safety_area.cpp
+++ b/mavros/src/plugins/safety_area.cpp
@@ -126,7 +126,7 @@ private:
 		p1 = ftf::transform_frame_enu_ned(p1);
 		p2 = ftf::transform_frame_enu_ned(p2);
 
-		mavlink::common::msg::SAFETY_SET_ALLOWED_AREA s;
+		mavlink::common::msg::SAFETY_SET_ALLOWED_AREA s = {};
 		m_uas->msg_set_target(s);
 
 		// TODO: use enum from lib

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1072,7 +1072,7 @@ private:
 	bool set_rate_cb(mavros_msgs::StreamRate::Request &req,
 			mavros_msgs::StreamRate::Response &res)
 	{
-		mavlink::common::msg::REQUEST_DATA_STREAM rq;
+		mavlink::common::msg::REQUEST_DATA_STREAM rq = {};
 
 		rq.target_system = m_uas->get_tgt_system();
 		rq.target_component = m_uas->get_tgt_component();
@@ -1108,7 +1108,7 @@ private:
 			base_mode |= enum_value(MAV_MODE_FLAG::CUSTOM_MODE_ENABLED);
 		}
 
-		mavlink::common::msg::SET_MODE sm;
+		mavlink::common::msg::SET_MODE sm = {};
 		sm.target_system = m_uas->get_tgt_system();
 		sm.base_mode = base_mode;
 		sm.custom_mode = custom_mode;

--- a/mavros/test/test_frame_conversions.cpp
+++ b/mavros/test/test_frame_conversions.cpp
@@ -76,7 +76,7 @@ TEST(FRAME_TF, transform_static_frame__ecef_to_enu_123_00)
 	Eigen::Vector3d map_origin(0, 0, 0);
 	Eigen::Vector3d expected(2, 3, 1);
 
-	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticTF::ECEF_TO_ENU);
+	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticEcefTF::ECEF_TO_ENU);
 
 	EXPECT_NEAR(expected.x(), out.x(), epsilon);
 	EXPECT_NEAR(expected.y(), out.y(), epsilon);
@@ -89,7 +89,7 @@ TEST(FRAME_TF, transform_static_frame__enu_to_ecef_123_00)
 	Eigen::Vector3d map_origin(0, 0, 0);
 	Eigen::Vector3d expected(3, 1, 2);
 
-	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticTF::ENU_TO_ECEF);
+	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticEcefTF::ENU_TO_ECEF);
 
 	EXPECT_NEAR(expected.x(), out.x(), epsilon);
 	EXPECT_NEAR(expected.y(), out.y(), epsilon);
@@ -102,7 +102,7 @@ TEST(FRAME_TF, transform_static_frame__ecef_to_enu_123_4030)
 	Eigen::Vector3d map_origin(40, 30, 0);
 	Eigen::Vector3d expected(1.23205080756887, 1.09867532044397, 3.35782122034753);
 
-	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticTF::ECEF_TO_ENU);
+	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticEcefTF::ECEF_TO_ENU);
 
 	EXPECT_NEAR(expected.x(), out.x(), epsilon);
 	EXPECT_NEAR(expected.y(), out.y(), epsilon);
@@ -115,7 +115,7 @@ TEST(FRAME_TF, transform_static_frame__enu_to_ecef_123_4030)
 	Eigen::Vector3d map_origin(40, 30, 0);
 	Eigen::Vector3d expected(0.3769010460539777, 1.37230445877637, 3.46045171529757);
 
-	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticTF::ENU_TO_ECEF);
+	auto out = ftf::detail::transform_static_frame(input, map_origin, ftf::StaticEcefTF::ENU_TO_ECEF);
 
 	EXPECT_NEAR(expected.x(), out.x(), epsilon);
 	EXPECT_NEAR(expected.y(), out.y(), epsilon);

--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -165,7 +165,7 @@ private:
 				uint8_t type, uint8_t id,
 				uint8_t orientation, uint8_t covariance)
 	{
-		mavlink::common::msg::DISTANCE_SENSOR ds;
+		mavlink::common::msg::DISTANCE_SENSOR ds = {};
 
 		// [[[cog:
 		// for f in ('time_boot_ms',

--- a/mavros_extras/src/plugins/gps_rtk.cpp
+++ b/mavros_extras/src/plugins/gps_rtk.cpp
@@ -63,7 +63,7 @@ private:
 	 */
 	void rtcm_cb(const mavros_msgs::RTCM::ConstPtr &msg)
 	{
-		mavlink::common::msg::GPS_RTCM_DATA rtcm_data;
+		mavlink::common::msg::GPS_RTCM_DATA rtcm_data = {};
 		const size_t max_frag_len = rtcm_data.data.size();
 
 		uint8_t seq_u5 = uint8_t(msg->header.seq & 0x1F) << 3;

--- a/mavros_extras/src/plugins/log_transfer.cpp
+++ b/mavros_extras/src/plugins/log_transfer.cpp
@@ -70,7 +70,7 @@ private:
 	bool log_request_list_cb(mavros_msgs::LogRequestList::Request &req,
 				mavros_msgs::LogRequestList::Response &res)
 	{
-		mavlink::common::msg::LOG_REQUEST_LIST msg;
+		mavlink::common::msg::LOG_REQUEST_LIST msg = {};
 		m_uas->msg_set_target(msg);
 		msg.start = req.start;
 		msg.end = req.end;
@@ -87,7 +87,7 @@ private:
 	bool log_request_data_cb(mavros_msgs::LogRequestData::Request &req,
 				mavros_msgs::LogRequestData::Response &res)
 	{
-		mavlink::common::msg::LOG_REQUEST_DATA msg;
+		mavlink::common::msg::LOG_REQUEST_DATA msg = {};
 		m_uas->msg_set_target(msg);
 		msg.id = req.id;
 		msg.ofs = req.offset;
@@ -105,7 +105,7 @@ private:
 	bool log_request_end_cb(mavros_msgs::LogRequestEnd::Request &,
 				mavros_msgs::LogRequestEnd::Response &res)
 	{
-		mavlink::common::msg::LOG_REQUEST_END msg;
+		mavlink::common::msg::LOG_REQUEST_END msg = {};
 		m_uas->msg_set_target(msg);
 		res.success = true;
 		try {

--- a/mavros_extras/src/plugins/mocap_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/mocap_pose_estimate.cpp
@@ -77,7 +77,7 @@ private:
 			Eigen::Quaterniond &q,
 			Eigen::Vector3d &v)
 	{
-		mavlink::common::msg::ATT_POS_MOCAP pos;
+		mavlink::common::msg::ATT_POS_MOCAP pos = {};
 
 		pos.time_usec = usec;
 		ftf::quaternion_to_mavlink(q, pos.q);

--- a/mavros_extras/src/plugins/px4flow.cpp
+++ b/mavros_extras/src/plugins/px4flow.cpp
@@ -155,7 +155,7 @@ private:
 
 	void send_cb(const mavros_msgs::OpticalFlowRad::ConstPtr msg)
 	{
-		mavlink::common::msg::OPTICAL_FLOW_RAD flow_rad_msg;
+		mavlink::common::msg::OPTICAL_FLOW_RAD flow_rad_msg = {};
 
 		auto int_xy = ftf::transform_frame_baselink_aircraft(
 			Eigen::Vector3d(


### PR DESCRIPTION
Uninitialised Mavlink 2 extension fields were sent if the fields were not later set to a value. Initialising the fields to zero is the default value for Mavlink 2 extension fields and appears to the receiver as though sender is unaware of Mavlink 2.

Messages affected by Mavlink 2 extensions found uninitialised:
DISTANCE_SENSOR
SET_GPS_ORIGIN
HIL_GPS
HIL_SENSOR
RC_CHANNELS_OVERRIDE
ATT_POS_MOCAP

Examples here were found with a regex. Further examples may exist of this bug.

Additionally fixes some tests for upstream and in-package changes