### PR TITLE
Add OrbitStatus plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributing
 9. Commit with description like "uncrustify" or "code style fix". Please avoid changes in program logic (separate commit are better than mix of style and bug fix);
 10. Run tests:
    - with `catkin_make`, issue `catkin_make tests` and then `catkin_make run_tests`;
-   - with `catkin tools`, issue `catkin run_tests`;
+   - with `catkin tools`, issue `catkin run_tests mavros`;
 11. If everything goes as planned, push the changes (`git push -u <remote_repo> <feature_branch>`) and issue a pull request.
 
 

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(mavros_extras
   src/plugins/mocap_pose_estimate.cpp
   src/plugins/obstacle_distance.cpp
   src/plugins/odom.cpp
+  src/plugins/orbit_status.cpp
   src/plugins/play_tune.cpp
   src/plugins/px4flow.cpp
   src/plugins/rangefinder.cpp

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -71,4 +71,7 @@
 	<class name="mount_control" type="mavros::extra_plugins::MountControlPlugin" base_class_type="mavros::plugin::PluginBase">
 		<description>Send Mission command to control a camera or a antenna mount.</description>
 	</class>
+	<class name="orbit_status" type="mavros::extra_plugins::OrbitStatusPlugin" base_class_type="mavros::plugin::PluginBase">
+    <description>Publish OrbitExecutionStatus message data from FCU.</description>
+	</class>
 </library>

--- a/mavros_extras/src/plugins/orbit_status.cpp
+++ b/mavros_extras/src/plugins/orbit_status.cpp
@@ -5,46 +5,45 @@
 
 namespace mavros {
 namespace extra_plugins {
-
 class OrbitStatusPlugin : public plugin::PluginBase {
 public:
-  OrbitStatusPlugin() : PluginBase(), orbit_status_nh("~orbit_status") {}
-  void initialize(UAS &uas_) override
+	OrbitStatusPlugin() : PluginBase(), orbit_status_nh("~orbit_status") {}
+	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
 
 		orbit_execution_status = orbit_status_nh.advertise<mavros_msgs::OrbitStatus>("execution", 10);
-  }
+	}
 
-  Subscriptions get_subscriptions() override {
-    return {make_handler(&OrbitStatusPlugin::handle_orbit_execution_status)};
-  }
+	Subscriptions get_subscriptions() override {
+		return {make_handler(&OrbitStatusPlugin::handle_orbit_execution_status)};
+	}
 
 private:
-  ros::NodeHandle orbit_status_nh;
+	ros::NodeHandle orbit_status_nh;
 
-  ros::Publisher orbit_execution_status;
+	ros::Publisher orbit_execution_status;
 
-  /**
-   * @brief Publish <a
-   * href="https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS">mavlink
-   * ORBIT_EXECUTION_STATUS message</a> into the  orbit_status/execution topic.
-   */
-  void handle_orbit_execution_status(const mavlink::mavlink_message_t *msg,
-                       mavlink::common::msg::ORBIT_EXECUTION_STATUS &mav_msg) {
-    auto ros_msg = boost::make_shared<mavros_msgs::OrbitStatus>();
-    ros_msg->timestamp = mav_msg.time_usec;
-    ros_msg->radius = mav_msg.radius;
-    ros_msg->x = mav_msg.x;
-    ros_msg->y = mav_msg.y;
-    ros_msg->z = mav_msg.z;
-    ros_msg->frame = mav_msg.frame;
-    ros_msg->state = mav_msg.state;
-    orbit_execution_status.publish(ros_msg);
+	/**
+	 * @brief Publish <a
+	 * href="https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS">mavlink
+	 * ORBIT_EXECUTION_STATUS message</a> into the  orbit_status/execution topic.
+	 */
+	void handle_orbit_execution_status(const mavlink::mavlink_message_t *msg,
+		mavlink::common::msg::ORBIT_EXECUTION_STATUS &mav_msg) {
+		auto ros_msg = boost::make_shared<mavros_msgs::OrbitStatus>();
+		ros_msg->timestamp = mav_msg.time_usec;
+		ros_msg->radius = mav_msg.radius;
+		ros_msg->x = mav_msg.x;
+		ros_msg->y = mav_msg.y;
+		ros_msg->z = mav_msg.z;
+		ros_msg->frame = mav_msg.frame;
+		ros_msg->state = mav_msg.state;
+		orbit_execution_status.publish(ros_msg);
 	}
 };
-} // namespace extra_plugins
-} // namespace mavros
+}	// namespace extra_plugins
+}	// namespace mavros
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::OrbitStatusPlugin,
-                       mavros::plugin::PluginBase)
+	mavros::plugin::PluginBase)

--- a/mavros_extras/src/plugins/orbit_status.cpp
+++ b/mavros_extras/src/plugins/orbit_status.cpp
@@ -1,0 +1,50 @@
+#include <mavros/mavros_plugin.h>
+#include <pluginlib/class_list_macros.h>
+
+#include <mavros_msgs/OrbitStatus.h>
+
+namespace mavros {
+namespace extra_plugins {
+
+class OrbitStatusPlugin : public plugin::PluginBase {
+public:
+  OrbitStatusPlugin() : PluginBase(), orbit_status_nh("~orbit_status") {}
+  void initialize(UAS &uas_) override
+	{
+		PluginBase::initialize(uas_);
+
+		orbit_execution_status = orbit_status_nh.advertise<mavros_msgs::OrbitStatus>("execution", 10);
+  }
+
+  Subscriptions get_subscriptions() override {
+    return {make_handler(&OrbitStatusPlugin::handle_orbit_execution_status)};
+  }
+
+private:
+  ros::NodeHandle orbit_status_nh;
+
+  ros::Publisher orbit_execution_status;
+
+  /**
+   * @brief Publish <a
+   * href="https://mavlink.io/en/messages/common.html#ORBIT_EXECUTION_STATUS">mavlink
+   * ORBIT_EXECUTION_STATUS message</a> into the  orbit_status/execution topic.
+   */
+  void handle_orbit_execution_status(const mavlink::mavlink_message_t *msg,
+                       mavlink::common::msg::ORBIT_EXECUTION_STATUS &mav_msg) {
+    auto ros_msg = boost::make_shared<mavros_msgs::OrbitStatus>();
+    ros_msg->timestamp = mav_msg.time_usec;
+    ros_msg->radius = mav_msg.radius;
+    ros_msg->x = mav_msg.x;
+    ros_msg->y = mav_msg.y;
+    ros_msg->z = mav_msg.z;
+    ros_msg->frame = mav_msg.frame;
+    ros_msg->state = mav_msg.state;
+    orbit_execution_status.publish(ros_msg);
+	}
+};
+} // namespace extra_plugins
+} // namespace mavros
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::OrbitStatusPlugin,
+                       mavros::plugin::PluginBase)

--- a/mavros_extras/src/plugins/orbit_status.cpp
+++ b/mavros_extras/src/plugins/orbit_status.cpp
@@ -32,12 +32,12 @@ private:
 	void handle_orbit_execution_status(const mavlink::mavlink_message_t *msg,
 		mavlink::common::msg::ORBIT_EXECUTION_STATUS &mav_msg) {
 		auto ros_msg = boost::make_shared<mavros_msgs::OrbitStatus>();
-		ros_msg->timestamp = mav_msg.time_usec;
+		ros_msg->header.stamp.fromNSec(mav_msg.time_usec * 1e3);
+		ros_msg->header.frame_id = mav_msg.frame;
 		ros_msg->radius = mav_msg.radius;
 		ros_msg->x = mav_msg.x;
 		ros_msg->y = mav_msg.y;
 		ros_msg->z = mav_msg.z;
-		ros_msg->frame = mav_msg.frame;
 		ros_msg->state = mav_msg.state;
 		orbit_execution_status.publish(ros_msg);
 	}

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -40,6 +40,7 @@ add_message_files(
   ManualControl.msg
   Mavlink.msg
   MountControl.msg
+  OrbitStatus.msg
   OpticalFlowRad.msg
   OverrideRCIn.msg
   Param.msg

--- a/mavros_msgs/msg/OrbitStatus.msg
+++ b/mavros_msgs/msg/OrbitStatus.msg
@@ -1,0 +1,10 @@
+uint64 timestamp # time since system start (microseconds)
+float32 radius   # Radius of the orbit circle. Positive values orbit clockwise, negative values orbit counter-clockwise. [m]
+uint8 frame      # The coordinate system of the fields: x, y, z.
+float64 x        # X coordinate of center point. Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.
+float64 y        # Y coordinate of center point. Coordinate system depends on frame field: local = y position in meters * 1e4, global = latitude in degrees * 1e7.
+float32 z        # Altitude of center point. Coordinate system depends on frame field.
+uint8 state # See enum ORBIT_EXECUTION_STATE.
+uint8 ORBIT_EXECUTION_STATE_APPROACH_TO_CIRCLE = 0
+uint8 ORBIT_EXECUTION_STATE_STARTED = 1
+uint8 ORBIT_EXECUTION_STATE_FINISHED = 2  # Meaningless for infinite orbits.

--- a/mavros_msgs/msg/OrbitStatus.msg
+++ b/mavros_msgs/msg/OrbitStatus.msg
@@ -1,10 +1,11 @@
-uint64 timestamp # time since system start (microseconds)
+uint8 ORBIT_EXECUTION_STATE_UNKNOWN = 0 # For back-compatibility.
+uint8 ORBIT_EXECUTION_STATE_APPROACH_TO_CIRCLE = 1
+uint8 ORBIT_EXECUTION_STATE_STARTED = 2
+uint8 ORBIT_EXECUTION_STATE_FINISHED = 3  # Meaningless for infinite orbits.
+
+std_msgs/Header header # involves time since system start (microseconds) and coordinate system of the fields: x, y, z
 float32 radius   # Radius of the orbit circle. Positive values orbit clockwise, negative values orbit counter-clockwise. [m]
-uint8 frame      # The coordinate system of the fields: x, y, z.
 float64 x        # X coordinate of center point. Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.
 float64 y        # Y coordinate of center point. Coordinate system depends on frame field: local = y position in meters * 1e4, global = latitude in degrees * 1e7.
 float32 z        # Altitude of center point. Coordinate system depends on frame field.
 uint8 state # See enum ORBIT_EXECUTION_STATE.
-uint8 ORBIT_EXECUTION_STATE_APPROACH_TO_CIRCLE = 0
-uint8 ORBIT_EXECUTION_STATE_STARTED = 1
-uint8 ORBIT_EXECUTION_STATE_FINISHED = 2  # Meaningless for infinite orbits.


### PR DESCRIPTION
Depends on https://github.com/mavlink/mavlink/pull/1622.

This plugin simply allows the publication of data received from FCU over ROS topic  `~orbit_status/execution`.