### PR TITLE
mavros_extras: Ported landing target plugin to ROS2

### DIFF
--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -3,13 +3,15 @@ project(mavros)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages
   # because the Python C extensions dont comply with it
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcomment")
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -69,7 +69,7 @@ class Router;
 class Endpoint : public std::enable_shared_from_this<Endpoint>
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(Endpoint);
+  RCLCPP_SMART_PTR_DEFINITIONS(Endpoint)
 
   enum class Type
   {
@@ -134,7 +134,7 @@ public:
 class Router : public rclcpp::Node
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(Router);
+  RCLCPP_SMART_PTR_DEFINITIONS(Router)
 
   using StrV = std::vector<std::string>;
 

--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -230,7 +230,7 @@ private:
 class UAS : public rclcpp::Node
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(UAS);
+  RCLCPP_SMART_PTR_DEFINITIONS(UAS)
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   // other UAS aliases

--- a/mavros/include/mavros/plugin.hpp
+++ b/mavros/include/mavros/plugin.hpp
@@ -65,7 +65,7 @@ private:
   explicit Plugin(const Plugin &) = delete;
 
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(Plugin);
+  RCLCPP_SMART_PTR_DEFINITIONS(Plugin)
 
   //! generic message handler callback
   using HandlerCb = mavconn::MAVConnInterface::ReceivedCb;

--- a/mavros/include/mavros/px4_custom_mode.hpp
+++ b/mavros/include/mavros/px4_custom_mode.hpp
@@ -82,12 +82,12 @@ union custom_mode {
     SUB_MODE_AUTO_PRECLAND
   };
 
-  struct
+  struct mode_type
   {
     uint16_t reserved;
     uint8_t main_mode;
     uint8_t sub_mode;
-  };
+  } mode;
   uint32_t data;
   float data_float;
 
@@ -100,9 +100,7 @@ union custom_mode {
   }
 
   constexpr custom_mode(uint8_t mm, uint8_t sm)
-    : reserved(0),
-    main_mode(mm),
-    sub_mode(sm)
+    : mode{0, mm, sm}
   {
   }
 };

--- a/mavros/include/mavros/setpoint_mixin.hpp
+++ b/mavros/include/mavros/setpoint_mixin.hpp
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <string>
+#include <chrono>
 
 #include "rcpputils/asserts.hpp"
 #include "mavros/mavros_uas.hpp"
@@ -182,7 +183,6 @@ public:
   }
 };
 
-#if 0  // XXX TODO(vooon): port me pls
 /**
  * @brief This mixin adds TF2 listener thread to plugin
  *
@@ -193,8 +193,8 @@ template<class D>
 class TF2ListenerMixin
 {
 public:
-  std::thread tf_thread;
   std::string tf_thd_name;
+  rclcpp::TimerBase::SharedPtr timer_;
 
   /**
    * @brief start tf listener
@@ -202,39 +202,34 @@ public:
    * @param _thd_name  listener thread name
    * @param cbp        plugin callback function
    */
-  void tf2_start(const char * _thd_name, void (D::* cbp)(const geometry_msgs::TransformStamped &) )
+  void tf2_start(const char * _thd_name, void (D::* cbp)(const geometry_msgs::msg::TransformStamped &) )
   {
     tf_thd_name = _thd_name;
-    auto tf_transform_cb = std::bind(cbp, static_cast<D *>(this), std::placeholders::_1);
+    D * base = static_cast<D *>(this);
+    auto tf_transform_cb = std::bind(cbp, base, std::placeholders::_1);
 
-    tf_thread = std::thread(
-      [this, tf_transform_cb]() {
-        mavconn::utils::set_this_thread_name("%s", tf_thd_name.c_str());
-
-        mavros::UAS * m_uas_ = static_cast<D *>(this)->m_uas;
-        std::string & _frame_id = static_cast<D *>(this)->tf_frame_id;
-        std::string & _child_frame_id = static_cast<D *>(this)->tf_child_frame_id;
-
-        ros::Rate rate(static_cast<D *>(this)->tf_rate);
-        while (ros::ok()) {
-          // Wait up to 3s for transform
-          if (m_uas_->tf2_buffer.canTransform(
-            _frame_id, _child_frame_id, ros::Time(0),
-            ros::Duration(3.0)))
-          {
-            try {
-              auto transform = m_uas_->tf2_buffer.lookupTransform(
-                _frame_id, _child_frame_id, ros::Time(0), ros::Duration(3.0));
-              tf_transform_cb(transform);
-            } catch (tf2::LookupException & ex) {
-              ROS_ERROR_NAMED("tf2_buffer", "%s: %s", tf_thd_name.c_str(), ex.what());
-            }
-          }
-          rate.sleep();
+    auto timer_callback = [this, base, tf_transform_cb]() -> void {
+      plugin::UASPtr _uas = base->uas;
+      std::string & _frame_id = base->tf_frame_id;
+      std::string & _child_frame_id = base->tf_child_frame_id;
+      if (_uas->tf2_buffer.canTransform(
+        _frame_id, _child_frame_id, tf2::TimePoint(),
+        tf2::durationFromSec(3.0)))
+      {
+        try {
+          auto transform = _uas->tf2_buffer.lookupTransform(
+            _frame_id, _child_frame_id, tf2::TimePoint(), tf2::durationFromSec(3.0));
+          tf_transform_cb(transform);
+        } catch (tf2::LookupException & ex) {
+          RCLCPP_ERROR(_uas->get_logger(), "tf2_buffer", "%s: %s", tf_thd_name.c_str(), ex.what());
         }
-      });
+      }
+    };
+
+    timer_ = create_timer(base->node, base->uas->get_clock(), rclcpp::Duration::from_seconds(1.0 / base->tf_rate), timer_callback);
   }
 
+#if 0  // XXX TODO(vooon): port me pls
   /**
    * @brief start tf listener syncronized with another topic
    *
@@ -252,14 +247,14 @@ public:
       [this, cbp, &topic_sub]() {
         mavconn::utils::set_this_thread_name("%s", tf_thd_name.c_str());
 
-        mavros::UAS * m_uas_ = static_cast<D *>(this)->m_uas;
-        ros::NodeHandle & _sp_nh = static_cast<D *>(this)->sp_nh;
+        mavros::UAS * _uas = static_cast<D *>(this)->uas;
+        auto & _node = static_cast<D *>(this)->node;
         std::string & _frame_id = static_cast<D *>(this)->tf_frame_id;
         std::string & _child_frame_id = static_cast<D *>(this)->tf_child_frame_id;
 
-        tf2_ros::MessageFilter<T> tf2_filter(topic_sub, m_uas_->tf2_buffer, _frame_id, 10, _sp_nh);
+        tf2_ros::MessageFilter<T> tf2_filter(topic_sub, m_uas_->tf2_buffer, _frame_id, 10, _node);
 
-        ros::Rate rate(static_cast<D *>(this)->tf_rate);
+        rate = ros::Rate(static_cast<D *>(this)->tf_rate);
         while (ros::ok()) {
           // Wait up to 3s for transform
           if (m_uas_->tf2_buffer.canTransform(
@@ -270,17 +265,17 @@ public:
               auto transform = m_uas_->tf2_buffer.lookupTransform(
                 _frame_id, _child_frame_id, ros::Time(0), ros::Duration(3.0));
 
-              tf2_filter.registerCallback(boost::bind(cbp, static_cast<D *>(this), transform, _1));
+              tf2_filter.registerCallback(std::bind(cbp, static_cast<D *>(this), transform, std::placeholders::_1));
             } catch (tf2::LookupException & ex) {
-              ROS_ERROR_NAMED("tf2_buffer", "%s: %s", tf_thd_name.c_str(), ex.what());
+              RCLCPP_ERROR("tf2_buffer", "%s: %s", tf_thd_name.c_str(), ex.what());
             }
           }
           rate.sleep();
         }
       });
   }
-};
 #endif
+};
 
 }       // namespace plugin
 }       // namespace mavros

--- a/mavros/src/lib/enum_to_string.cpp
+++ b/mavros/src/lib/enum_to_string.cpp
@@ -74,14 +74,14 @@ static auto logger = rclcpp::get_logger("uas.enum");
 //
 // def array_outl(name, enum, suffix=None):
 //     array = ename_array_name(name, suffix)
-//     cog.outl(f"""\
+//     cog.outl(f"""
 // //! {name} values
 // static const std::array<const std::string, {len(enum)}> {array}{{{{""")
 //
 //
 // def to_string_outl(ename, funcname='to_string', suffix=None):
 //     array = ename_array_name(ename, suffix)
-//     cog.outl(f"""\
+//     cog.outl(f"""
 // std::string {funcname}({ename} e)
 // {{
 //   size_t idx = enum_value(e);
@@ -124,7 +124,6 @@ static auto logger = rclcpp::get_logger("uas.enum");
 //             cog.outl(f"""/* {k:>2} */ "{name_short}",""")
 //
 //     cog.outl("}};")
-//     cog.outl()
 //     to_string_outl(ename, funcname, suffix)
 // ]]]
 // [[[end]]] (checksum: d41d8cd98f00b204e9800998ecf8427e)
@@ -133,6 +132,7 @@ static auto logger = rclcpp::get_logger("uas.enum");
 // ename = 'MAV_AUTOPILOT'
 // enum_value_is_description_outl(ename)
 // ]]]
+
 //! MAV_AUTOPILOT values
 static const std::array<const std::string, 20> mav_autopilot_strings{{
 /*  0 */ "Generic autopilot",
@@ -157,6 +157,7 @@ static const std::array<const std::string, 20> mav_autopilot_strings{{
 /* 19 */ "AirRails",
 }};
 
+
 std::string to_string(MAV_AUTOPILOT e)
 {
   size_t idx = enum_value(e);
@@ -166,14 +167,15 @@ std::string to_string(MAV_AUTOPILOT e)
 
   return mav_autopilot_strings[idx];
 }
-// [[[end]]] (checksum: 387a860b046aee21d511e60e364688ba)
+// [[[end]]] (checksum: ca6693afe1ced57fa7eb4b5d2f895550)
 
 // [[[cog:
 // ename = 'MAV_TYPE'
 // enum_value_is_description_outl(ename)
 // ]]]
+
 //! MAV_TYPE values
-static const std::array<const std::string, 37> mav_type_strings{{
+static const std::array<const std::string, 38> mav_type_strings{{
 /*  0 */ "Generic micro air vehicle",
 /*  1 */ "Fixed wing aircraft",
 /*  2 */ "Quadrotor",
@@ -211,7 +213,9 @@ static const std::array<const std::string, 37> mav_type_strings{{
 /* 34 */ "Open Drone ID. See https:",
 /* 35 */ "Decarotor",
 /* 36 */ "Battery",
+/* 37 */ "Parachute",
 }};
+
 
 std::string to_string(MAV_TYPE e)
 {
@@ -222,14 +226,15 @@ std::string to_string(MAV_TYPE e)
 
   return mav_type_strings[idx];
 }
-// [[[end]]] (checksum: 2beb0ad0074f54374b49a0654be4c2ac)
+// [[[end]]] (checksum: 376064ea1578250d182ab62a85b06a41)
 
 // [[[cog:
 // ename = 'MAV_TYPE'
 // enum_value_is_name_outl(ename, funcname='enum_to_name', suffix='_names')
 // ]]]
+
 //! MAV_TYPE values
-static const std::array<const std::string, 37> mav_type_names{{
+static const std::array<const std::string, 38> mav_type_names{{
 /*  0 */ "GENERIC",
 /*  1 */ "FIXED_WING",
 /*  2 */ "QUADROTOR",
@@ -267,6 +272,7 @@ static const std::array<const std::string, 37> mav_type_names{{
 /* 34 */ "ODID",
 /* 35 */ "DECAROTOR",
 /* 36 */ "BATTERY",
+/* 37 */ "PARACHUTE",
 }};
 
 std::string enum_to_name(MAV_TYPE e)
@@ -278,12 +284,13 @@ std::string enum_to_name(MAV_TYPE e)
 
   return mav_type_names[idx];
 }
-// [[[end]]] (checksum: 58dbf88b346c0f2aa68917b71643b2f2)
+// [[[end]]] (checksum: 5e58c6b1f7868c26f570b97fa4389feb)
 
 // [[[cog:
 // ename = 'MAV_STATE'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! MAV_STATE values
 static const std::array<const std::string, 9> mav_state_strings{{
 /*  0 */ "UNINIT",
@@ -306,7 +313,7 @@ std::string to_string(MAV_STATE e)
 
   return mav_state_strings[idx];
 }
-// [[[end]]] (checksum: 170b518da48f77c54ea2681fdff01951)
+// [[[end]]] (checksum: e953b14d18e31abb45db4fe72ebb749f)
 
 // [[[cog:
 // ename = "timesync_mode"
@@ -320,6 +327,7 @@ std::string to_string(MAV_STATE e)
 // cog.outl()
 // to_string_outl(ename)
 // ]]]
+
 //! timesync_mode values
 static const std::array<const std::string, 4> timesync_mode_strings{{
 /*  0 */ "NONE",
@@ -327,6 +335,7 @@ static const std::array<const std::string, 4> timesync_mode_strings{{
 /*  2 */ "ONBOARD",
 /*  3 */ "PASSTHROUGH",
 }};
+
 
 std::string to_string(timesync_mode e)
 {
@@ -337,7 +346,7 @@ std::string to_string(timesync_mode e)
 
   return timesync_mode_strings[idx];
 }
-// [[[end]]] (checksum: 3dfd2acb938e62ee606f93aeb7c5b086)
+// [[[end]]] (checksum: 7a286bcf12006fdeff1bd9fca8ce4176)
 
 timesync_mode timesync_mode_from_str(const std::string & mode)
 {
@@ -356,6 +365,7 @@ timesync_mode timesync_mode_from_str(const std::string & mode)
 // ename = 'ADSB_ALTITUDE_TYPE'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! ADSB_ALTITUDE_TYPE values
 static const std::array<const std::string, 2> adsb_altitude_type_strings{{
 /*  0 */ "PRESSURE_QNH",
@@ -371,12 +381,13 @@ std::string to_string(ADSB_ALTITUDE_TYPE e)
 
   return adsb_altitude_type_strings[idx];
 }
-// [[[end]]] (checksum: 72e4ce5bc5cf2e2c351869433e644667)
+// [[[end]]] (checksum: 2e8d87a6e603b105ded642f34978fd55)
 
 // [[[cog:
 // ename = 'ADSB_EMITTER_TYPE'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! ADSB_EMITTER_TYPE values
 static const std::array<const std::string, 20> adsb_emitter_type_strings{{
 /*  0 */ "NO_INFO",
@@ -410,12 +421,13 @@ std::string to_string(ADSB_EMITTER_TYPE e)
 
   return adsb_emitter_type_strings[idx];
 }
-// [[[end]]] (checksum: 784076231225119b1c07a3bc8cc0e4af)
+// [[[end]]] (checksum: 342e71a579408cf35a4dbf8b42bd099a)
 
 // [[[cog:
 // ename = 'MAV_ESTIMATOR_TYPE'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! MAV_ESTIMATOR_TYPE values
 static const std::array<const std::string, 9> mav_estimator_type_strings{{
 /*  0 */ "UNKNOWN",
@@ -438,12 +450,13 @@ std::string to_string(MAV_ESTIMATOR_TYPE e)
 
   return mav_estimator_type_strings[idx];
 }
-// [[[end]]] (checksum: 8e80791aa874e22d81ae16061d36b009)
+// [[[end]]] (checksum: 451e5fe0a2c760a5c9d4efed0f97553d)
 
 // [[[cog:
 // ename = 'GPS_FIX_TYPE'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! GPS_FIX_TYPE values
 static const std::array<const std::string, 9> gps_fix_type_strings{{
 /*  0 */ "NO_GPS",
@@ -466,12 +479,13 @@ std::string to_string(GPS_FIX_TYPE e)
 
   return gps_fix_type_strings[idx];
 }
-// [[[end]]] (checksum: 9cdb29f44c89bf9d2c8d2ff1edf259a9)
+// [[[end]]] (checksum: 260b7022824b9717be95db4e4e28a8d5)
 
 // [[[cog:
 // ename = 'MAV_MISSION_RESULT'
 // enum_value_is_description_outl(ename, split_by_delim='')
 // ]]]
+
 //! MAV_MISSION_RESULT values
 static const std::array<const std::string, 16> mav_mission_result_strings{{
 /*  0 */ "mission accepted OK",
@@ -492,6 +506,7 @@ static const std::array<const std::string, 16> mav_mission_result_strings{{
 /* 15 */ "Current mission operation cancelled (e.g. mission upload, mission download).",
 }};
 
+
 std::string to_string(MAV_MISSION_RESULT e)
 {
   size_t idx = enum_value(e);
@@ -501,12 +516,13 @@ std::string to_string(MAV_MISSION_RESULT e)
 
   return mav_mission_result_strings[idx];
 }
-// [[[end]]] (checksum: dd50fe6b84e206d1451eef5de0caf7e2)
+// [[[end]]] (checksum: ddddde7cdf04ebd988f019d5b93eadbe)
 
 // [[[cog:
 // ename = 'MAV_FRAME'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! MAV_FRAME values
 static const std::array<const std::string, 22> mav_frame_strings{{
 /*  0 */ "GLOBAL",
@@ -542,7 +558,7 @@ std::string to_string(MAV_FRAME e)
 
   return mav_frame_strings[idx];
 }
-// [[[end]]] (checksum: b1c9fb7f66bf65a157962e30f6572a4e)
+// [[[end]]] (checksum: 9e2018e38b2c586263f10adba00d2ca6)
 
 // [[[cog:
 // ename = 'MAV_COMPONENT'
@@ -667,6 +683,7 @@ static const std::unordered_map<size_t, const std::string> mav_comp_id_strings{{
   {158, "PERIPHERAL"},
   {159, "QX1_GIMBAL"},
   {160, "FLARM"},
+  {161, "PARACHUTE"},
   {171, "GIMBAL2"},
   {172, "GIMBAL3"},
   {173, "GIMBAL4"},
@@ -676,6 +693,9 @@ static const std::unordered_map<size_t, const std::string> mav_comp_id_strings{{
   {181, "BATTERY2"},
   {190, "MISSIONPLANNER"},
   {191, "ONBOARD_COMPUTER"},
+  {192, "ONBOARD_COMPUTER2"},
+  {193, "ONBOARD_COMPUTER3"},
+  {194, "ONBOARD_COMPUTER4"},
   {195, "PATHPLANNER"},
   {196, "OBSTACLE_AVOIDANCE"},
   {197, "VISUAL_INERTIAL_ODOMETRY"},
@@ -693,7 +713,7 @@ static const std::unordered_map<size_t, const std::string> mav_comp_id_strings{{
   {242, "TUNNEL_NODE"},
   {250, "SYSTEM_CONTROL"},
 }};
-// [[[end]]] (checksum: c0c9e6b7645f3c80f00cb6a9da293722)
+// [[[end]]] (checksum: bdc7916b48d45154a0b164047b45edf7)
 
 std::string to_string(MAV_COMPONENT e)
 {
@@ -736,6 +756,7 @@ MAV_TYPE mav_type_from_str(const std::string & mav_type)
 // ename = 'MAV_DISTANCE_SENSOR'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! MAV_DISTANCE_SENSOR values
 static const std::array<const std::string, 5> mav_distance_sensor_strings{{
 /*  0 */ "LASER",
@@ -754,12 +775,13 @@ std::string to_string(MAV_DISTANCE_SENSOR e)
 
   return mav_distance_sensor_strings[idx];
 }
-// [[[end]]] (checksum: 21f7c2c585aa0140ed900032689dbfd8)
+// [[[end]]] (checksum: dda871f638e51a30d2ecd3b0d063c0de)
 
 // [[[cog:
 // ename = 'LANDING_TARGET_TYPE'
 // enum_value_is_name_outl(ename)
 // ]]]
+
 //! LANDING_TARGET_TYPE values
 static const std::array<const std::string, 4> landing_target_type_strings{{
 /*  0 */ "LIGHT_BEACON",
@@ -777,7 +799,7 @@ std::string to_string(LANDING_TARGET_TYPE e)
 
   return landing_target_type_strings[idx];
 }
-// [[[end]]] (checksum: c8f41c140ea9c3119e4c2bec3772c666)
+// [[[end]]] (checksum: f582577481c6b17014ed9925665f7634)
 
 LANDING_TARGET_TYPE landing_target_type_from_str(const std::string & landing_target_type)
 {

--- a/mavros/src/lib/uas_ap.cpp
+++ b/mavros/src/lib/uas_ap.cpp
@@ -53,7 +53,7 @@ void UAS::add_connection_change_handler(UAS::ConnectionCb cb)
 
 /* -*- autopilot version -*- */
 
-static uint64_t get_default_caps(uas::MAV_AUTOPILOT ap_type)
+static uint64_t get_default_caps([[maybe_unused]] uas::MAV_AUTOPILOT ap_type)
 {
   // TODO(vooon): return default caps mask for known FCU's
   return 0;

--- a/mavros/src/lib/uas_stringify.cpp
+++ b/mavros/src/lib/uas_stringify.cpp
@@ -174,13 +174,13 @@ static inline std::string str_mode_px4(uint32_t custom_mode_int)
   px4::custom_mode custom_mode(custom_mode_int);
 
   // clear fields
-  custom_mode.reserved = 0;
-  if (custom_mode.main_mode != px4::custom_mode::MAIN_MODE_AUTO) {
+  custom_mode.mode.reserved = 0;
+  if (custom_mode.mode.main_mode != px4::custom_mode::MAIN_MODE_AUTO) {
     RCLCPP_WARN_EXPRESSION(
       rclcpp::get_logger("uas"),
-      custom_mode.sub_mode != 0, "PX4: Unknown sub-mode %d.%d",
-      custom_mode.main_mode, custom_mode.sub_mode);
-    custom_mode.sub_mode = 0;
+      custom_mode.mode.sub_mode != 0, "PX4: Unknown sub-mode %d.%d",
+      custom_mode.mode.main_mode, custom_mode.mode.sub_mode);
+    custom_mode.mode.sub_mode = 0;
   }
 
   return str_mode_cmap(px4_cmode_map, custom_mode.data);

--- a/mavros/src/plugins/ftp.cpp
+++ b/mavros/src/plugins/ftp.cpp
@@ -71,7 +71,7 @@ public:
     uint8_t req_opcode;         ///< Request opcode returned in kRspAck, kRspNak message
     uint8_t padding[2];         ///< 32 bit aligment padding
     uint32_t offset;            ///< Offsets for List and Read commands
-    uint8_t data[];             ///< command data, varies by Opcode
+    uint8_t* data;              ///< command data, varies by Opcode
   };
 
   /// @brief Command opcodes
@@ -193,7 +193,7 @@ public:
   /**
    * @brief Decode and check target system
    */
-  bool decode_valid(plugin::UASPtr uas)
+  bool decode_valid([[maybe_unused]] plugin::UASPtr uas)
   {
 #ifdef FTP_LL_DEBUG
     auto hdr = header();
@@ -257,11 +257,13 @@ public:
     is_error(false),
     r_errno(0),
     list_offset(0),
-    read_offset(0),
-    write_offset(0),
     open_size(0),
     read_size(0),
+    read_offset(0),
     read_buffer{},
+    write_offset(0),
+    write_buffer{},
+    write_it{},
     checksum_crc32(0)
   {
     // since C++ generator do not produce field length defs make check explicit.

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -59,9 +59,9 @@ public:
   explicit GlobalPositionPlugin(plugin::UASPtr uas_)
   : Plugin(uas_, "global_position"),
     tf_send(false),
-    rot_cov(99999.0),
     use_relative_alt(true),
-    is_map_init(false)
+    is_map_init(false),
+    rot_cov(99999.0)
   {
     enable_node_watch_parameters();
 

--- a/mavros/src/plugins/imu.cpp
+++ b/mavros/src/plugins/imu.cpp
@@ -632,7 +632,7 @@ private:
   }
 
   // Checks for connection and overrides variable values
-  void connection_cb(bool connected) override
+  void connection_cb([[maybe_unused]] bool connected) override
   {
     has_hr_imu = false;
     has_raw_imu = false;

--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -426,8 +426,8 @@ public:
     RETRIES_COUNT(3),
     param_count(-1),
     param_state(PR::IDLE),
-    is_timedout(false),
-    param_rx_retries(RETRIES_COUNT)
+    param_rx_retries(RETRIES_COUNT),
+    is_timedout(false)
   {
     auto event_qos = rclcpp::ParameterEventsQoS();
     auto qos = rclcpp::ParametersQoS().get_rmw_qos_profile();

--- a/mavros/src/plugins/rc_io.cpp
+++ b/mavros/src/plugins/rc_io.cpp
@@ -240,7 +240,7 @@ private:
 
   /* -*- callbacks -*- */
 
-  void connection_cb(bool connected) override
+  void connection_cb([[maybe_unused]] bool connected) override
   {
     lock_guard lock(mutex);
     raw_rc_in.clear();

--- a/mavros/src/plugins/setpoint_raw.cpp
+++ b/mavros/src/plugins/setpoint_raw.cpp
@@ -270,7 +270,7 @@ private:
 
   void attitude_cb(const mavros_msgs::msg::AttitudeTarget::SharedPtr req)
   {
-    double thrust_scaling;
+    double thrust_scaling = 1.0f;
     Eigen::Quaterniond desired_orientation;
     Eigen::Vector3d baselink_angular_rate;
     Eigen::Vector3d body_rate;
@@ -296,25 +296,25 @@ private:
           "thrust_scaling parameter is set to zero.");
       }
       thrust = std::min(1.0, std::max(0.0, req->thrust * thrust_scaling));
+
+      // Take care of attitude setpoint
+      desired_orientation = ftf::to_eigen(req->orientation);
+
+      // Transform desired orientation to represent aircraft->NED,
+      // MAVROS operates on orientation of base_link->ENU
+      auto ned_desired_orientation = ftf::transform_orientation_enu_ned(
+        ftf::transform_orientation_baselink_aircraft(desired_orientation));
+
+      body_rate = ftf::transform_frame_baselink_aircraft(
+        ftf::to_eigen(req->body_rate));
+
+      set_attitude_target(
+        get_time_boot_ms(req->header.stamp),
+        req->type_mask,
+        ned_desired_orientation,
+        body_rate,
+        thrust);
     }
-
-    // Take care of attitude setpoint
-    desired_orientation = ftf::to_eigen(req->orientation);
-
-    // Transform desired orientation to represent aircraft->NED,
-    // MAVROS operates on orientation of base_link->ENU
-    auto ned_desired_orientation = ftf::transform_orientation_enu_ned(
-      ftf::transform_orientation_baselink_aircraft(desired_orientation));
-
-    body_rate = ftf::transform_frame_baselink_aircraft(
-      ftf::to_eigen(req->body_rate));
-
-    set_attitude_target(
-      get_time_boot_ms(req->header.stamp),
-      req->type_mask,
-      ned_desired_orientation,
-      body_rate,
-      thrust);
   }
 };
 

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1006,9 +1006,7 @@ private:
     // enum.pop() # -> remove ENUM_END
     //
     // for k, e in enum:
-    //     desc = e.description.split(' ', 1)[1] \
-    //         if e.description.startswith('0x') \
-    //         else e.description
+    //     desc = e.description.split(' ', 1)[1] if e.description.startswith('0x') else e.description
     //     esf = e.name
     //
     //     if esf.startswith(ename + '_'):

--- a/mavros_cog.py
+++ b/mavros_cog.py
@@ -28,6 +28,10 @@ REGISTER_PLUGIN_RE = re.compile(
 PLUGIN_NAME_RE = re.compile(r'@plugin\ (?P<name>[a-z_]+)')
 PLUGIN_BRIEF_RE = re.compile(r'^@brief\ (?P<brief>.+)$')
 
+plugins_without_macro = {
+    "mavros/src/plugins/mission_protocol_base.cpp"
+}
+
 if _cog_present:
 
     def dbg(s):
@@ -123,7 +127,8 @@ class PluginInfo:
 def load_all_plugin_infos(dir: pathlib.Path) -> typing.Iterator[PluginInfo]:
     for fl in dir.glob('*.cpp'):
         try:
-            yield PluginInfo.parse_file(fl)
+            if str(fl) not in plugins_without_macro:
+                yield PluginInfo.parse_file(fl)
         except NoPluginRegister as ex:
             dbg(f"skipping file: {ex}")
 

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -85,7 +85,7 @@ add_library(mavros_extras_plugins SHARED
   #src/plugins/gps_rtk.cpp
   #src/plugins/gps_status.cpp
   #src/plugins/hil.cpp
-  #src/plugins/landing_target.cpp
+  src/plugins/landing_target.cpp
   #src/plugins/log_transfer.cpp
   #src/plugins/mocap_pose_estimate.cpp
   #src/plugins/mount_control.cpp

--- a/mavros_extras/src/plugins/landing_target.cpp
+++ b/mavros_extras/src/plugins/landing_target.cpp
@@ -146,11 +146,9 @@ public:
     node_declate_and_watch_parameter(
       "tf.listen", false, [&](const rclcpp::Parameter & p) {
         tf_listen = p.as_bool();
-	/* TODO:
-        ROS_INFO_STREAM_NAMED(
-          "landing_target", "Listen to landing_target transform " << tf_frame_id <<
+        RCLCPP_INFO_STREAM(get_logger(),
+          "LT: Listen to landing_target transform " << tf_frame_id <<
             " -> " << tf_child_frame_id);
-	*/
         tf2_start("LandingTargetTF", &LandingTargetPlugin::transform_cb);
       });
 
@@ -335,7 +333,7 @@ private:
     }
 
     if (last_transform_stamp == stamp) {
-      //TODO: ROS_DEBUG_THROTTLE_NAMED(10, "landing_target", "LT: Same transform as last one, dropped.");
+      RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), 10, "LT: Same transform as last one, dropped.");
       return;
     }
     last_transform_stamp = stamp;
@@ -343,22 +341,6 @@ private:
 
     // the last char of frame_id is considered the number of the target
     uint8_t id = static_cast<uint8_t>(frame_id.back());
-
-    // TODO:
-    /*
-    auto rpy = ftf::quaternion_to_rpy(q);
-
-    ROS_DEBUG_THROTTLE_NAMED(
-      10, "landing_target", "Tx landing target: "
-      "ID: %d frame: %s angular offset: X:%1.3frad, Y:%1.3frad) "
-      "distance: %1.3fm position: X:%1.3fm, Y:%1.3fm, Z:%1.3fm) "
-      "orientation: roll:%1.4frad pitch:%1.4frad yaw:%1.4frad "
-      "size: X:%1.3frad by Y:%1.3frad type: %s",
-      id, utils::to_string(static_cast<MAV_FRAME>(frame)).c_str(),
-      angle.x(), angle.y(), distance, pos.x(), pos.y(), pos.z(),
-      rpy.x(), rpy.y(), rpy.z(), size_rad.x(), size_rad.y(),
-      utils::to_string(static_cast<LANDING_TARGET_TYPE>(type)).c_str());
-    */
 
     landing_target(
       stamp.nanoseconds() / 1000,
@@ -397,24 +379,10 @@ private:
     auto rpy = ftf::quaternion_to_rpy(orientation);
 
     RCLCPP_DEBUG_STREAM_THROTTLE(
-      uas->get_logger(),
-      *uas->get_clock(), 10,
+      get_logger(),
+      *get_clock(), 10,
       "landing_target:\n" <<
-      "\tRx landing target:" <<
-      "\n\t\tID: " << land_target.target_num <<
-      "\n\t\tframe: " << utils::to_string(static_cast<MAV_FRAME>(land_target.frame)).c_str() <<
-      "\n\t\tangular offset: X: " << land_target.angle_x << "rad, Y: " << land_target.angle_y << "rad" <<
-      "\n\t\tdistance: " << land_target.distance << "m" <<
-      "\n\t\tposition:" <<
-      "\n\t\t\tX: " << position.x() << "m" <<
-      "\n\t\t\tY: " << position.y() << "m" <<
-      "\n\t\t\tZ: " << position.z() << "m" <<
-      "\n\t\torientation:" <<
-      "\n\t\t\troll:  " << rpy.x() << "rad" <<
-      "\n\t\t\tpitch: " << rpy.y() << "rad" <<
-      "\n\t\t\tyaw:   " << rpy.z() << "rad" <<
-      "\n\t\tsize: X: " << land_target.size_x << "rad, Y: " << land_target.size_y << "rad" <<
-      "\n\t\ttype: " << utils::to_string(static_cast<LANDING_TARGET_TYPE>(land_target.type)).c_str() << std::endl);
+      land_target.to_yaml());
 
     geometry_msgs::msg::PoseStamped pose;
     pose.header = uas->synchronized_header(frame_id, land_target.time_usec);


### PR DESCRIPTION
(This PR also contains the work from https://github.com/mavlink/mavros/pull/1603, so make sure to merge that first :))

It's not 100% tested yet. Planning on testing raw landing target input with this as soon as I have a good source for landing targets and their tfs in ros2.

I am publishing this PR as it ported parts of the `TF2ListenerMixin` which might be helpful elsewhere.

```
$ colcon build --packages-up-to mavros_extras
Starting >>> libmavconn
Starting >>> mavros_msgs
Finished <<< libmavconn [0.40s]                                                             
Finished <<< mavros_msgs [12.0s]                     
Starting >>> mavros   
Finished <<< mavros [1.56s]                      
Starting >>> mavros_extras
Finished <<< mavros_extras [0.79s]                      

Summary: 4 packages finished [14.5s]
```