### PR TITLE
Update esc_status plugin with datatype change on MAVLink.

### DIFF
--- a/mavros_extras/src/plugins/esc_status.cpp
+++ b/mavros_extras/src/plugins/esc_status.cpp
@@ -96,7 +96,7 @@ private:
 			_esc_info.esc_info[esc_index + i].header = _esc_info.header;
 			_esc_info.esc_info[esc_index + i].failure_flags = esc_info.failure_flags[i];
 			_esc_info.esc_info[esc_index + i].error_count = esc_info.error_count[i];
-			_esc_info.esc_info[esc_index + i].temperature = esc_info.temperature[i];
+			_esc_info.esc_info[esc_index + i].temperature = esc_info.temperature[i] * 1E2;	//!<  [degreesC]
 		}
 
 		_max_esc_info_index = std::max(_max_esc_info_index, esc_info.index);

--- a/mavros_msgs/msg/ESCInfoItem.msg
+++ b/mavros_msgs/msg/ESCInfoItem.msg
@@ -8,5 +8,5 @@ std_msgs/Header header
 
 uint16 failure_flags
 uint32 error_count
-uint8 temperature
+int32 temperature
 


### PR DESCRIPTION
ESC_INFO MAVLink message was updated to have negative temperates and also at a different resolution on PR https://github.com/mavlink/mavlink/pull/1663 

This PR updates those changes on this side.