### PR TITLE
Mavlink v2.0 specs for RC_CHANNELS_OVERRIDE accepts upto 18 channels.…

### DIFF
--- a/mavros/src/plugins/rc_io.cpp
+++ b/mavros/src/plugins/rc_io.cpp
@@ -247,6 +247,18 @@ private:
 		ovr.chan6_raw = req->channels[5];
 		ovr.chan7_raw = req->channels[6];
 		ovr.chan8_raw = req->channels[7];
+		if (m_uas->fcu_link->get_protocol_version() == mavconn::Protocol::V20) {
+			ovr.chan9_raw = req->channels[8];
+			ovr.chan10_raw = req->channels[9];
+			ovr.chan11_raw = req->channels[10];
+			ovr.chan12_raw = req->channels[11];
+			ovr.chan13_raw = req->channels[12];
+			ovr.chan14_raw = req->channels[13];
+			ovr.chan15_raw = req->channels[14];
+			ovr.chan16_raw = req->channels[15];
+			ovr.chan17_raw = req->channels[16];
+			ovr.chan18_raw = req->channels[17];
+		}
 		// [[[end]]] (checksum: bd27f3e85f5ab614ce1332ae3f4c6ebd)
 
 		UAS_FCU(m_uas)->send_message_ignore_drop(ovr);

--- a/mavros/src/plugins/rc_io.cpp
+++ b/mavros/src/plugins/rc_io.cpp
@@ -236,7 +236,7 @@ private:
 		ovr.target_component = m_uas->get_tgt_component();
 
 		// [[[cog:
-		// for i in range(1, 9):
+		// for i in range(1, 19):
 		//     cog.outl("ovr.chan%d_raw = req->channels[%d];" % (i, i - 1))
 		// ]]]
 		ovr.chan1_raw = req->channels[0];
@@ -247,20 +247,17 @@ private:
 		ovr.chan6_raw = req->channels[5];
 		ovr.chan7_raw = req->channels[6];
 		ovr.chan8_raw = req->channels[7];
-		if (m_uas->fcu_link->get_protocol_version() == mavconn::Protocol::V20) {
-			ovr.chan9_raw = req->channels[8];
-			ovr.chan10_raw = req->channels[9];
-			ovr.chan11_raw = req->channels[10];
-			ovr.chan12_raw = req->channels[11];
-			ovr.chan13_raw = req->channels[12];
-			ovr.chan14_raw = req->channels[13];
-			ovr.chan15_raw = req->channels[14];
-			ovr.chan16_raw = req->channels[15];
-			ovr.chan17_raw = req->channels[16];
-			ovr.chan18_raw = req->channels[17];
-		}
-		// [[[end]]] (checksum: bd27f3e85f5ab614ce1332ae3f4c6ebd)
-
+		ovr.chan9_raw = req->channels[8];
+		ovr.chan10_raw = req->channels[9];
+		ovr.chan11_raw = req->channels[10];
+		ovr.chan12_raw = req->channels[11];
+		ovr.chan13_raw = req->channels[12];
+		ovr.chan14_raw = req->channels[13];
+		ovr.chan15_raw = req->channels[14];
+		ovr.chan16_raw = req->channels[15];
+		ovr.chan17_raw = req->channels[16];
+		ovr.chan18_raw = req->channels[17];
+		// [[[end]]] (checksum: 3c9f7f1ce77a49651345daab995ea70e)
 		UAS_FCU(m_uas)->send_message_ignore_drop(ovr);
 	}
 };

--- a/mavros_msgs/msg/OverrideRCIn.msg
+++ b/mavros_msgs/msg/OverrideRCIn.msg
@@ -1,7 +1,10 @@
 # Override RC Input
 # Currently MAVLink defines override for 8 channel
 
+# Mavlink 2.0 now supports upto 18 channels
+# https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE
+
 uint16 CHAN_RELEASE=0
 uint16 CHAN_NOCHANGE=65535
 
-uint16[8] channels
+uint16[] channels

--- a/mavros_msgs/msg/OverrideRCIn.msg
+++ b/mavros_msgs/msg/OverrideRCIn.msg
@@ -1,10 +1,9 @@
 # Override RC Input
-# Currently MAVLink defines override for 8 channel
+# Currently MAVLink defines override for 18 channels
 
-# Mavlink 2.0 now supports upto 18 channels
 # https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE
 
 uint16 CHAN_RELEASE=0
 uint16 CHAN_NOCHANGE=65535
 
-uint16[] channels
+uint16[18] channels


### PR DESCRIPTION
… The plugin publishes channels 9 to 18 if the FCU protocol version is 2.0