### PR TITLE
Show ENOTCONN error instead of crash on socket's shutdown

### DIFF
--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -142,7 +142,10 @@ void MAVConnTCPClient::close()
 	if (!is_open())
 		return;
 
-	socket.shutdown(boost::asio::ip::tcp::socket::shutdown_send);
+	boost::system::error_code ec;
+	socket.shutdown(boost::asio::ip::tcp::socket::shutdown_send, ec);
+	if (ec)
+		CONSOLE_BRIDGE_logError(PFXd "shutdown: %s", conn_id, ec.message().c_str());
 	socket.cancel();
 	socket.close();
 

--- a/mavros/src/gcs_bridge.cpp
+++ b/mavros/src/gcs_bridge.cpp
@@ -40,7 +40,7 @@ void mavlink_sub_cb(const mavros_msgs::Mavlink::ConstPtr &rmsg)
 	mavlink::mavlink_message_t mmsg;
 
 	if (mavros_msgs::mavlink::convert(*rmsg, mmsg))
-		gcs_link->send_message(&mmsg);	// !!! queue exception -> fall of gcs_bridge. intentional.
+		gcs_link->send_message_ignore_drop(&mmsg);
 	else
 		ROS_ERROR("Packet drop: convert error.");
 }


### PR DESCRIPTION
When a client suddenly drops the connection,
socket.shutdown() will throw an exception:
boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >
  what():  shutdown: Transport endpoint is not connected

Showing an error in this common case looks more reasonable than crashing.