### PR TITLE
WIP Don't throw an exception if there is an overflow in TCP link

### DIFF
--- a/libmavconn/include/mavconn/tcp.h
+++ b/libmavconn/include/mavconn/tcp.h
@@ -84,6 +84,8 @@ private:
 
 	void do_recv();
 	void do_send(bool check_tx_state);
+
+	void enqueue_message(const MsgBuffer &msg);
 };
 
 /**


### PR DESCRIPTION
Previously in case of overflowing, an exception was thrown, and current message was dropped.

Since we are interested to keep the latest messages, and not to resend out-dated ones.
Proposing to clear the queue, log an error and don't drop current/latest message,
and try to send it.

Also clearing all messages in queue preserves old behavior, when the exception was thrown and the process was restarted. 
Now it is not restarted but need to do something with the queue, since new messages are dropped due to overflow.

In case of loosing connection link to GCS, there will be a lot of `DROPPED Message-Id: TX queue overflow` messages, since the size of the queue is not being changed and exceeded the limit.