### PR TITLE
Add camera plugin for interfacing with mavlink camera protocol

### DIFF
--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -265,4 +265,8 @@ wheel_odometry:
     frame_id: "odom"
     child_frame_id: "base_link"
 
+# camera
+camera:
+  frame_id: "base_link"
+
 # vim:set ts=2 sw=2 et:

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -67,6 +67,7 @@ include_directories(
 add_library(mavros_extras
   src/plugins/adsb.cpp
   src/plugins/cam_imu_sync.cpp
+  src/plugins/camera.cpp
   src/plugins/companion_process_status.cpp
   src/plugins/onboard_computer_status.cpp
   src/plugins/debug_value.cpp

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -6,6 +6,9 @@
   <class name="cam_imu_sync" type="mavros::extra_plugins::CamIMUSyncPlugin" base_class_type="mavros::plugin::PluginBase">
     <description>Publish camera trigger data for synchronisation of IMU and camera frames.</description>
   </class>
+  <class name="camera" type="mavros::extra_plugins::CameraPlugin" base_class_type="mavros::plugin::PluginBase">
+    <description>Plugin for the mavlink camera protocol.</description>
+  </class>
   <class name="companion_process_status" type="mavros::extra_plugins::CompanionProcessStatusPlugin" base_class_type="mavros::plugin::PluginBase">
     <description>Send companion process status report to the FCU.</description>
   </class>

--- a/mavros_extras/src/plugins/camera.cpp
+++ b/mavros_extras/src/plugins/camera.cpp
@@ -1,0 +1,86 @@
+/**
+ * @brief Mouny Control plugin
+ * @file mount_control.cpp
+ * @author Jaeyoung Lim <jalim@ethz.ch>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2021 Jaeyoung Lim.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+
+#include <mavros_msgs/CameraImageCaptured.h>
+
+namespace mavros {
+namespace extra_plugins {
+
+//! Mavlink enumerations
+using mavlink::common::MAV_CMD;
+using utils::enum_value;
+
+/**
+ * @brief Camera plugin plugin
+ *
+ * Plugin for interfacing on the mavlink camera protocol
+ * @see command_cb()
+ */
+class CameraPlugin : public plugin::PluginBase {
+public:
+	CameraPlugin() : PluginBase(),
+	nh("~"),
+	camera_nh("~camera")
+	{ }
+
+	void initialize(UAS &uas_) override
+	{
+		PluginBase::initialize(uas_);
+
+		camera_image_captured_pub = camera_nh.advertise<mavros_msgs::CameraImageCaptured>("image_captured", 10);
+
+	}
+
+	Subscriptions get_subscriptions() override
+	{
+		return {
+			make_handler(&CameraPlugin::handle_camera_image_captured)
+		};
+	}
+
+private:
+	ros::NodeHandle nh;
+	ros::NodeHandle camera_nh;
+	ros::Publisher camera_image_captured_pub;
+
+	/**
+	 * @brief Publish camera image capture information
+	 *
+	 * Message specification: https://mavlink.io/en/messages/common.html#CAMERA_IMAGE_CAPTURED
+	 * @param msg   the mavlink message
+	 * @param mo	received CAMERA_IMAGE_CAPTURED msg
+	 */
+	void handle_camera_image_captured(const mavlink::mavlink_message_t *msg, mavlink::common::msg::CAMERA_IMAGE_CAPTURED &mo)
+	{
+		mavros_msgs::CameraImageCaptured image_captured_msg;
+		image_captured_msg.header.stamp = ros::Time::now();
+		image_captured_msg.latitude = mo.lat;
+		image_captured_msg.longitude = mo.lon;
+		image_captured_msg.altitude = mo.alt;
+		image_captured_msg.relative_alt = mo.relative_alt;
+		image_captured_msg.file_url = std::string(std::begin(mo.file_url), std::end(mo.file_url));
+
+		camera_image_captured_pub.publish(image_captured_msg);
+	}
+
+};
+}	// namespace extra_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::CameraPlugin, mavros::plugin::PluginBase)

--- a/mavros_extras/src/plugins/camera.cpp
+++ b/mavros_extras/src/plugins/camera.cpp
@@ -1,6 +1,6 @@
 /**
- * @brief Mouny Control plugin
- * @file mount_control.cpp
+ * @brief Camera plugin
+ * @file camera.cpp
  * @author Jaeyoung Lim <jalim@ethz.ch>
  *
  * @addtogroup plugin
@@ -73,7 +73,7 @@ private:
 		ic->geo.latitude = mo.lat/ 1E7;
 		ic->geo.longitude = mo.lon / 1E7;		// deg
 		ic->geo.altitude = mo.alt / 1E3 + m_uas->geoid_to_ellipsoid_height(&ic->geo);	// in meters
-		ic->relative_alt = mo.relative_alt;
+		ic->relative_alt = mo.relative_alt / 1E3;
 		auto q = ftf::mavlink_to_quaternion(mo.q);
 		tf::quaternionEigenToMsg(q, ic->orientation);
 		ic->file_url = mavlink::to_string(mo.file_url);

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -14,6 +14,7 @@ add_message_files(
   AttitudeTarget.msg
   BatteryStatus.msg
   CamIMUStamp.msg
+  CameraImageCaptured.msg
   CommandCode.msg
   CompanionProcessStatus.msg
   OnboardComputerStatus.msg

--- a/mavros_msgs/msg/CameraImageCaptured.msg
+++ b/mavros_msgs/msg/CameraImageCaptured.msg
@@ -1,0 +1,13 @@
+# MAVLink message: CAMERA_IMAGE_CAPTURED
+# https://mavlink.io/en/messages/common.html#CAMERA_IMAGE_CAPTURED
+
+std_msgs/Header header
+
+geometry_msgs/Quaternion orientation	# Quaternion of camera orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+float32 altitude  # altitude (MSL) where image was taken.
+float32 latitude # latitude in degrees * 1E7 where image was taken.
+float32 longitude # longitude in degrees * 1E7 where image was taken.
+float32 relative_alt	# mm	Altitude above ground
+int32 image_index # Zero based index of this image (i.e. a new image will have index CAMERA_CAPTURE_STATUS.image count -1)
+int8 capture_result # Boolean indicating success (1) or failure (0) while capturing this image.
+string file_url #URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.

--- a/mavros_msgs/msg/CameraImageCaptured.msg
+++ b/mavros_msgs/msg/CameraImageCaptured.msg
@@ -4,9 +4,7 @@
 std_msgs/Header header
 
 geometry_msgs/Quaternion orientation	# Quaternion of camera orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
-float32 altitude  # altitude (MSL) where image was taken.
-float32 latitude # latitude in degrees * 1E7 where image was taken.
-float32 longitude # longitude in degrees * 1E7 where image was taken.
+geographic_msgs/GeoPoint geo
 float32 relative_alt	# mm	Altitude above ground
 int32 image_index # Zero based index of this image (i.e. a new image will have index CAMERA_CAPTURE_STATUS.image count -1)
 int8 capture_result # Boolean indicating success (1) or failure (0) while capturing this image.


### PR DESCRIPTION
**Problem Description**
This PR adds a camera plugin, which captures the `CAMERA_IMAGE_CAPTURED` message which contains viewpoint information when an image is triggered. This information is very useful for robotic applications involving viewpoint tracking.

This is different from the camera trigger messages coming from `cam_imu_sync`, which is used to sync camera and imu timing since this is related to the actual mavlink camera protocol: https://mavlink.io/en/services/camera.html


**Testing**
Tested with PX4 Software-In-The-Loop Gazebo simulation with camera enabled vehicles such as `plane_cam`

**Additional Context**
- We may further extend this to comply with the mavlink protocol, but not sure if there is a good enough general camera framework in ROS that is worth integrating into
