### PR TITLE
distance_sensor: Initialize sensor orientation quaternion to zero

### DIFF
--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -45,7 +45,7 @@ public:
 		data_index(0),
 		horizontal_fov_ratio(1.0),
 		vertical_fov_ratio(1.0),
-		quaternion()
+		quaternion(0.f, 0.f, 0.f, 0.f)
 	{ }
 
 	// params


### PR DESCRIPTION
I noticed an issue where distance sensor data I send via from a ROS system via MAVROS to an autopilot gets invalid quaternion values. This turned out to be caused by the (Eigen) quaternion orientation not being initialized in the distance_sensor plugin, so if the default quaternion orientation is used, it's values will be random garbage data.

This is because the default constructor for an Eigen quaternion doesn't initialize it.

Here's an example of `listener distance_sensor` output from PX4 before this fix:

```
Instance 2:
 distance_sensor_s
    timestamp: 77083719  (0.030450 seconds ago)
    min_distance: 0.1000
    max_distance: 100.0000
    current_distance: 1.6700
    variance: 0.0000
    h_fov: 0.0872
    v_fov: 0.0872
    q: [70931685123886100000000.0000, 18058769791168100000000000000.0000, 51190050062336.0000, 72249529606109800000000000000.0000]
    signal_quality: -1
    type: 0
    id: 2
    orientation: 0
```

...and after:

```
Instance 2:
 distance_sensor_s
    timestamp: 76981874  (0.055539 seconds ago)
    min_distance: 0.1000
    max_distance: 100.0000
    current_distance: 0.1300
    variance: 0.0000
    h_fov: 0.0872
    v_fov: 0.0872
    q: [0.0000, 0.0000, 0.0000, 0.0000]
    signal_quality: -1
    type: 0
    id: 2
    orientation: 0
```

Note that if you set orientation = ROTATION_CUSTOM, then the quaternion field is set to your configured custom orientation value, and this issue won't appear.