### PR TITLE
Fix multiple bugs

### DIFF
--- a/libmavconn/include/mavconn/interface.h
+++ b/libmavconn/include/mavconn/interface.h
@@ -119,6 +119,13 @@ public:
 	MAVConnInterface(uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE);
 
 	/**
+	 * @brief Establish connection, automatically called by open_url()
+	 */
+	virtual void connect(
+			const ReceivedCb &cb_handle_message,
+			const ClosedCb &cb_handle_closed_port = ClosedCb()) = 0;
+
+	/**
 	 * @brief Close connection.
 	 */
 	virtual void close() = 0;
@@ -234,8 +241,12 @@ public:
 	 * @return @a Ptr to constructed interface class,
 	 *         or throw @a DeviceError if error occured.
 	 */
-	static Ptr open_url(std::string url,
-			uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE);
+	static Ptr open_url(
+			std::string url,
+			uint8_t system_id = 1,
+			uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
+			const ReceivedCb &cb_handle_message = ReceivedCb(),
+			const ClosedCb &cb_handle_closed_port = ClosedCb());
 
 	static std::vector<std::string> get_known_dialects();
 

--- a/libmavconn/include/mavconn/serial.h
+++ b/libmavconn/include/mavconn/serial.h
@@ -42,6 +42,9 @@ public:
 			std::string device = DEFAULT_DEVICE, unsigned baudrate = DEFAULT_BAUDRATE, bool hwflow = false);
 	virtual ~MAVConnSerial();
 
+	void connect(
+			const ReceivedCb &cb_handle_message,
+			const ClosedCb &cb_handle_closed_port = ClosedCb()) override;
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;

--- a/libmavconn/include/mavconn/tcp.h
+++ b/libmavconn/include/mavconn/tcp.h
@@ -51,6 +51,9 @@ public:
 			boost::asio::io_service &server_io);
 	virtual ~MAVConnTCPClient();
 
+	void connect(
+			const ReceivedCb &cb_handle_message,
+			const ClosedCb &cb_handle_closed_port = ClosedCb()) override;
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;
@@ -105,6 +108,9 @@ public:
 			std::string bind_host = DEFAULT_BIND_HOST, unsigned short bind_port = DEFAULT_BIND_PORT);
 	virtual ~MAVConnTCPServer();
 
+	void connect(
+			const ReceivedCb &cb_handle_message,
+			const ClosedCb &cb_handle_closed_port = ClosedCb()) override;
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;
@@ -134,6 +140,5 @@ private:
 
 	// client slots
 	void client_closed(std::weak_ptr<MAVConnTCPClient> weak_instp);
-	void recv_message(const mavlink::mavlink_message_t *message, const Framing framing);
 };
 }	// namespace mavconn

--- a/libmavconn/include/mavconn/udp.h
+++ b/libmavconn/include/mavconn/udp.h
@@ -50,6 +50,9 @@ public:
 			std::string remote_host = DEFAULT_REMOTE_HOST, unsigned short remote_port = DEFAULT_REMOTE_PORT);
 	virtual ~MAVConnUDP();
 
+	void connect(
+			const ReceivedCb &cb_handle_message,
+			const ClosedCb &cb_handle_closed_port = ClosedCb()) override;
 	void close() override;
 
 	void send_message(const mavlink::mavlink_message_t *message) override;

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -331,8 +331,12 @@ static MAVConnInterface::Ptr url_parse_tcp_server(
 			bind_host, bind_port);
 }
 
-MAVConnInterface::Ptr MAVConnInterface::open_url(std::string url,
-		uint8_t system_id, uint8_t component_id)
+MAVConnInterface::Ptr MAVConnInterface::open_url(
+		std::string url,
+		uint8_t system_id,
+		uint8_t component_id,
+		const ReceivedCb &cb_handle_message,
+		const ClosedCb &cb_handle_closed_port)
 {
 	/* Based on code found here:
 	 * http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
@@ -377,21 +381,34 @@ MAVConnInterface::Ptr MAVConnInterface::open_url(std::string url,
 			url.c_str(), proto.c_str(), host.c_str(),
 			path.c_str(), query.c_str());
 
+	MAVConnInterface::Ptr interface_ptr;
+
 	if (proto == "udp")
-		return url_parse_udp(host, query, system_id, component_id, false, false);
+		interface_ptr = url_parse_udp(host, query, system_id, component_id, false, false);
 	else if (proto == "udp-b")
-		return url_parse_udp(host, query, system_id, component_id, true, false);
+		interface_ptr = url_parse_udp(host, query, system_id, component_id, true, false);
 	else if (proto == "udp-pb")
-		return url_parse_udp(host, query, system_id, component_id, true, true);
+		interface_ptr = url_parse_udp(host, query, system_id, component_id, true, true);
 	else if (proto == "tcp")
-		return url_parse_tcp_client(host, query, system_id, component_id);
+		interface_ptr = url_parse_tcp_client(host, query, system_id, component_id);
 	else if (proto == "tcp-l")
-		return url_parse_tcp_server(host, query, system_id, component_id);
+		interface_ptr = url_parse_tcp_server(host, query, system_id, component_id);
 	else if (proto == "serial")
-		return url_parse_serial(path, query, system_id, component_id, false);
+		interface_ptr = url_parse_serial(path, query, system_id, component_id, false);
 	else if (proto == "serial-hwfc")
-		return url_parse_serial(path, query, system_id, component_id, true);
+		interface_ptr = url_parse_serial(path, query, system_id, component_id, true);
 	else
 		throw DeviceError("url", "Unknown URL type");
+
+	if (interface_ptr)
+	{
+		if (not cb_handle_message)
+		{
+			CONSOLE_BRIDGE_logWarn(PFX "You did not provide message handling callback to open_url(), it is unsafe to set it later.");
+		}
+		interface_ptr->connect(cb_handle_message, cb_handle_closed_port);
+	}
+
+	return (interface_ptr);
 }
 }	// namespace mavconn

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -106,8 +106,19 @@ MAVConnSerial::MAVConnSerial(uint8_t system_id, uint8_t component_id,
 	catch (boost::system::system_error &err) {
 		throw DeviceError("serial", err);
 	}
+}
 
-	// NOTE: shared_from_this() should not be used in constructors
+MAVConnSerial::~MAVConnSerial()
+{
+	close();
+}
+
+void MAVConnSerial::connect(
+		const ReceivedCb &cb_handle_message,
+		const ClosedCb &cb_handle_closed_port)
+{
+	message_received_cb = cb_handle_message;
+	port_closed_cb = cb_handle_closed_port;
 
 	// give some work to io_service before start
 	io_service.post(std::bind(&MAVConnSerial::do_read, this));
@@ -117,11 +128,6 @@ MAVConnSerial::MAVConnSerial(uint8_t system_id, uint8_t component_id,
 				utils::set_this_thread_name("mserial%zu", conn_id);
 				io_service.run();
 			});
-}
-
-MAVConnSerial::~MAVConnSerial()
-{
-	close();
 }
 
 void MAVConnSerial::close()

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -97,23 +97,13 @@ MAVConnTCPClient::MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 	catch (boost::system::system_error &err) {
 		throw DeviceError("tcp", err);
 	}
-
-	// NOTE: shared_from_this() should not be used in constructors
-
-	// give some work to io_service before start
-	io_service.post(std::bind(&MAVConnTCPClient::do_recv, this));
-
-	// run io_service for async io
-	io_thread = std::thread([this] () {
-				utils::set_this_thread_name("mtcp%zu", conn_id);
-				io_service.run();
-			});
 }
 
 MAVConnTCPClient::MAVConnTCPClient(uint8_t system_id, uint8_t component_id,
 		boost::asio::io_service &server_io) :
 	MAVConnInterface(system_id, component_id),
 	socket(server_io),
+	is_destroying(false),
 	tx_in_progress(false),
 	tx_q {},
 	rx_buf {}
@@ -134,6 +124,23 @@ MAVConnTCPClient::~MAVConnTCPClient()
 {
 	is_destroying = true;
 	close();
+}
+
+void MAVConnTCPClient::connect(
+		const ReceivedCb &cb_handle_message,
+		const ClosedCb &cb_handle_closed_port)
+{
+	message_received_cb = cb_handle_message;
+	port_closed_cb = cb_handle_closed_port;
+
+	// give some work to io_service before start
+	io_service.post(std::bind(&MAVConnTCPClient::do_recv, this));
+
+	// run io_service for async io
+	io_thread = std::thread([this] () {
+				utils::set_this_thread_name("mtcp%zu", conn_id);
+				io_service.run();
+			});
 }
 
 void MAVConnTCPClient::close()
@@ -308,6 +315,20 @@ MAVConnTCPServer::MAVConnTCPServer(uint8_t system_id, uint8_t component_id,
 	catch (boost::system::system_error &err) {
 		throw DeviceError("tcp-l", err);
 	}
+}
+
+MAVConnTCPServer::~MAVConnTCPServer()
+{
+	is_destroying = true;
+	close();
+}
+
+void MAVConnTCPServer::connect(
+		const ReceivedCb &cb_handle_message,
+		const ClosedCb &cb_handle_closed_port)
+{
+	message_received_cb = cb_handle_message;
+	port_closed_cb = cb_handle_closed_port;
 
 	// give some work to io_service before start
 	io_service.post(std::bind(&MAVConnTCPServer::do_accept, this));
@@ -317,12 +338,6 @@ MAVConnTCPServer::MAVConnTCPServer(uint8_t system_id, uint8_t component_id,
 				utils::set_this_thread_name("mtcps%zu", conn_id);
 				io_service.run();
 			});
-}
-
-MAVConnTCPServer::~MAVConnTCPServer()
-{
-	is_destroying = true;
-	close();
 }
 
 void MAVConnTCPServer::close()
@@ -432,35 +447,30 @@ void MAVConnTCPServer::do_accept()
 					return;
 				}
 
-				lock_guard lock(sthis->mutex);
+				{
+					lock_guard lock(sthis->mutex);
 
-				std::weak_ptr<MAVConnTCPClient> weak_client{acceptor_client};
-				acceptor_client->client_connected(sthis->conn_id);
-				acceptor_client->message_received_cb = std::bind(&MAVConnTCPServer::recv_message, sthis, std::placeholders::_1, std::placeholders::_2);
-				acceptor_client->port_closed_cb = [weak_client, sthis] () { sthis->client_closed(weak_client); };
+					std::weak_ptr<MAVConnTCPClient> weak_client{acceptor_client};
+					acceptor_client->message_received_cb = sthis->message_received_cb;
+					acceptor_client->port_closed_cb = [weak_client, sthis] () { sthis->client_closed(weak_client); };
+					acceptor_client->client_connected(sthis->conn_id);
 
-				sthis->client_list.push_back(acceptor_client);
-				sthis->do_accept();
+					sthis->client_list.push_back(acceptor_client);
+					sthis->do_accept();
+				}
 			});
 }
 
 void MAVConnTCPServer::client_closed(std::weak_ptr<MAVConnTCPClient> weak_instp)
 {
 	if (auto instp = weak_instp.lock()) {
-		bool locked = mutex.try_lock();
 		CONSOLE_BRIDGE_logInform(PFXd "Client connection closed, id: %p, address: %s",
 				conn_id, instp.get(), to_string_ss(instp->server_ep).c_str());
 
-		client_list.remove(instp);
-
-		if (locked)
-			mutex.unlock();
+		{
+			lock_guard lock(mutex);
+			client_list.remove(instp);
+		}
 	}
-}
-
-void MAVConnTCPServer::recv_message(const mavlink_message_t *message, const Framing framing)
-{
-	if (message_received_cb)
-		message_received_cb(message, framing);
 }
 }	// namespace mavconn

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -119,8 +119,19 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 	catch (boost::system::system_error &err) {
 		throw DeviceError("udp", err);
 	}
+}
 
-	// NOTE: shared_from_this() should not be used in constructors
+MAVConnUDP::~MAVConnUDP()
+{
+	close();
+}
+
+void MAVConnUDP::connect(
+		const ReceivedCb &cb_handle_message,
+		const ClosedCb &cb_handle_closed_port)
+{
+	message_received_cb = cb_handle_message;
+	port_closed_cb = cb_handle_closed_port;
 
 	// give some work to io_service before start
 	io_service.post(std::bind(&MAVConnUDP::do_recvfrom, this));
@@ -130,11 +141,6 @@ MAVConnUDP::MAVConnUDP(uint8_t system_id, uint8_t component_id,
 				utils::set_this_thread_name("mudp%zu", conn_id);
 				io_service.run();
 			});
-}
-
-MAVConnUDP::~MAVConnUDP()
-{
-	close();
 }
 
 void MAVConnUDP::close()

--- a/libmavconn/test/test_hang.cpp
+++ b/libmavconn/test/test_hang.cpp
@@ -67,18 +67,18 @@ int main(int argc, char **argv){
 	MAVConnInterface::Ptr client;
 
 	// create echo server
-	server = MAVConnInterface::open_url("udp://:45000@", 42, 200);
-	server->message_received_cb = [&](const mavlink_message_t * msg, const Framing framing) {
-		server->send_message_ignore_drop(msg);
-		send_sys_status(server.get());
-	};
+	server = MAVConnInterface::open_url("udp://:45000@", 42, 200,
+		[&](const mavlink_message_t * msg, const Framing framing) {
+			server->send_message_ignore_drop(msg);
+			send_sys_status(server.get());
+		});
 
 	// create client
-	client = MAVConnInterface::open_url("udp://:45001@localhost:45000", 44, 200);
-	client->message_received_cb = [&](const mavlink_message_t * msg, const Framing framing) {
-		//std::cout << "C:RECV: " << msg->msgid << std::endl;
-		ROS_INFO("RECV: MsgID: %4u St: %d", msg->msgid, int(framing));
-	};
+	client = MAVConnInterface::open_url("udp://:45001@localhost:45000", 44, 200,
+		[&](const mavlink_message_t * msg, const Framing framing) {
+			//std::cout << "C:RECV: " << msg->msgid << std::endl;
+			ROS_INFO("RECV: MsgID: %4u St: %d", msg->msgid, int(framing));
+		});
 
 	while (ros::ok()) {
 		send_heartbeat(client.get());

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -89,13 +89,13 @@ TEST_F(UDP, send_message)
 
 	// create echo server
 	echo = std::make_shared<MAVConnUDP>(42, 200, "0.0.0.0", 45002);
-	echo->message_received_cb = [&](const mavlink_message_t * msg, const Framing framing) {
+	echo->connect([&](const mavlink_message_t * msg, const Framing framing) {
 		echo->send_message(msg);
-	};
+	});
 
 	// create client
 	client = std::make_shared<MAVConnUDP>(44, 200, "0.0.0.0", 45003, "localhost", 45002);
-	client->message_received_cb = std::bind(&UDP::recv_message, this, std::placeholders::_1, std::placeholders::_2);
+	client->connect(std::bind(&UDP::recv_message, this, std::placeholders::_1, std::placeholders::_2));
 
 	// wait echo
 	send_heartbeat(client.get());
@@ -111,6 +111,7 @@ TEST_F(TCP, bind_error)
 	MAVConnInterface::Ptr conns[2];
 
 	conns[0] = std::make_shared<MAVConnTCPServer>(42, 200, "localhost", 57600);
+	conns[0]->connect(MAVConnInterface::ReceivedCb());
 	ASSERT_THROW(conns[1] = std::make_shared<MAVConnTCPServer>(42, 200, "localhost", 57600), DeviceError);
 }
 
@@ -129,13 +130,13 @@ TEST_F(TCP, send_message)
 
 	// create echo server
 	echo_server = std::make_shared<MAVConnTCPServer>(42, 200, "0.0.0.0", 57602);
-	echo_server->message_received_cb = [&](const mavlink_message_t * msg, const Framing framing) {
+	echo_server->connect([&](const mavlink_message_t * msg, const Framing framing) {
 		echo_server->send_message(msg);
-	};
+	});
 
 	// create client
 	client = std::make_shared<MAVConnTCPClient>(44, 200, "localhost", 57602);
-	client->message_received_cb = std::bind(&TCP::recv_message, this, std::placeholders::_1, std::placeholders::_2);
+	client->connect(std::bind(&TCP::recv_message, this, std::placeholders::_1, std::placeholders::_2));
 
 	// wait echo
 	send_heartbeat(client.get());
@@ -151,9 +152,9 @@ TEST_F(TCP, client_reconnect)
 
 	// create echo server
 	echo_server = std::make_shared<MAVConnTCPServer>(42, 200, "0.0.0.0", 57604);
-	echo_server->message_received_cb = [&](const mavlink_message_t * msg, const Framing framing) {
+	echo_server->connect([&](const mavlink_message_t * msg, const Framing framing) {
 		echo_server->send_message(msg);
-	};
+	});
 
 	EXPECT_NO_THROW({
 			client1 = std::make_shared<MAVConnTCPClient>(44, 200, "localhost", 57604);

--- a/mavros/src/gcs_bridge.cpp
+++ b/mavros/src/gcs_bridge.cpp
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
 	priv_nh.param<std::string>("gcs_url", gcs_url, "udp://@");
 
 	try {
-		gcs_link = MAVConnInterface::open_url(gcs_url);
+		mavlink_pub = mavlink_nh.advertise<mavros_msgs::Mavlink>("to", 10);
+		gcs_link = MAVConnInterface::open_url(gcs_url, 1, MAV_COMP_ID_UDP_BRIDGE, mavlink_pub_cb);
 		gcs_link_diag.set_mavconn(gcs_link);
 		gcs_link_diag.set_connection_status(true);
 	}
@@ -65,9 +66,6 @@ int main(int argc, char *argv[])
 		ROS_FATAL("GCS: %s", ex.what());
 		return 1;
 	}
-
-	mavlink_pub = mavlink_nh.advertise<mavros_msgs::Mavlink>("to", 10);
-	gcs_link->message_received_cb = mavlink_pub_cb;
 
 	// prefer UDPROS, but allow TCPROS too
 	mavlink_sub = mavlink_nh.subscribe("from", 10, mavlink_sub_cb,


### PR DESCRIPTION
- fix bad_weak_ptr on connect and disconnect
- introduce new API to avoid thread race when assigning callbacks
- fix uninitialized variable in TCP client constructor which would
randomly block TCP server

This is an API breaking change: if client code creates connections using
make_shared<>() instead of open_url(), it is now necessary to call new
connect() method explicitly.

Related:                                                                                                                                                                                       
https://github.com/mavlink/mavros/issues/1597                                                                                                                                                  
https://github.com/mavlink/mavros/issues/937                                                                                                                                                   
https://github.com/mavlink/mavros/issues/1478