### PR TITLE
Fix warnings

### DIFF
--- a/mavros/include/mavros/mission_protocol_base.h
+++ b/mavros/include/mavros/mission_protocol_base.h
@@ -237,10 +237,10 @@ public:
 		wp_state(WP::IDLE),
 		wp_type(WP_TYPE::MISSION),
 		wp_count(0),
-		wp_retries(RETRIES_COUNT),
 		wp_cur_id(0),
 		wp_cur_active(0),
 		wp_set_active(0),
+		wp_retries(RETRIES_COUNT),
 		is_timedout(false),
 		do_pull_after_gcs(false),
 		enable_partial_push(false),
@@ -251,7 +251,7 @@ public:
 		RESCHEDULE_DT(RESCHEDULE_MS / 1000.0)
 	{ }
 
-	virtual void initialize(ros::NodeHandle *_wp_nh)
+	virtual void initialize_with_nodehandle(ros::NodeHandle *_wp_nh)
 	{
 		wp_timer = _wp_nh->createTimer(WP_TIMEOUT_DT, &MissionBase::timeout_cb, this, true);
 		wp_timer.stop();

--- a/mavros/src/lib/mavros.cpp
+++ b/mavros/src/lib/mavros.cpp
@@ -33,10 +33,10 @@ using utils::enum_value;
 
 MavRos::MavRos() :
 	mavlink_nh("mavlink"),		// allow to namespace it
+	last_message_received_from_gcs(0),
 	fcu_link_diag("FCU connection"),
 	gcs_link_diag("GCS bridge"),
 	plugin_loader("mavros", "mavros::plugin::PluginBase"),
-	last_message_received_from_gcs(0),
 	plugin_subscriptions{}
 {
 	std::string fcu_url, gcs_url;

--- a/mavros/src/plugins/ftp.cpp
+++ b/mavros/src/plugins/ftp.cpp
@@ -204,11 +204,11 @@ public:
 		is_error(false),
 		r_errno(0),
 		list_offset(0),
-		read_offset(0),
-		write_offset(0),
 		open_size(0),
 		read_size(0),
+		read_offset(0),
 		read_buffer {},
+		write_offset(0),
 		checksum_crc32(0)
 	{ }
 

--- a/mavros/src/plugins/geofence.cpp
+++ b/mavros/src/plugins/geofence.cpp
@@ -31,7 +31,7 @@ public:
 	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
-		MissionBase::initialize(&gf_nh);
+		MissionBase::initialize_with_nodehandle(&gf_nh);
 
 		wp_state = WP::IDLE;
 		wp_type = plugin::WP_TYPE::FENCE;

--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -49,9 +49,9 @@ public:
 	GlobalPositionPlugin() : PluginBase(),
 		gp_nh("~global_position"),
 		tf_send(false),
-		rot_cov(99999.0),
 		use_relative_alt(true),
-		is_map_init(false)
+		is_map_init(false),
+		rot_cov(99999.0)
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -360,14 +360,14 @@ class ParamPlugin : public plugin::PluginBase {
 public:
 	ParamPlugin() : PluginBase(),
 		param_nh("~param"),
-		param_count(-1),
-		param_state(PR::IDLE),
-		is_timedout(false),
-		RETRIES_COUNT(_RETRIES_COUNT),
-		param_rx_retries(RETRIES_COUNT),
 		BOOTUP_TIME_DT(BOOTUP_TIME_MS / 1000.0),
 		LIST_TIMEOUT_DT(LIST_TIMEOUT_MS / 1000.0),
-		PARAM_TIMEOUT_DT(PARAM_TIMEOUT_MS / 1000.0)
+		PARAM_TIMEOUT_DT(PARAM_TIMEOUT_MS / 1000.0),
+		RETRIES_COUNT(_RETRIES_COUNT),
+		param_count(-1),
+		param_state(PR::IDLE),
+		param_rx_retries(RETRIES_COUNT),
+		is_timedout(false)
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros/src/plugins/rallypoint.cpp
+++ b/mavros/src/plugins/rallypoint.cpp
@@ -31,7 +31,7 @@ public:
 	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
-		MissionBase::initialize(&rp_nh);
+		MissionBase::initialize_with_nodehandle(&rp_nh);
 
 		wp_state = WP::IDLE;
 		wp_type = plugin::WP_TYPE::RALLY;

--- a/mavros/src/plugins/setpoint_attitude.cpp
+++ b/mavros/src/plugins/setpoint_attitude.cpp
@@ -46,10 +46,10 @@ class SetpointAttitudePlugin : public plugin::PluginBase,
 public:
 	SetpointAttitudePlugin() : PluginBase(),
 		sp_nh("~setpoint_attitude"),
+		tf_listen(false),
 		tf_rate(50.0),
 		use_quaternion(false),
-		reverse_thrust(false),
-		tf_listen(false)
+		reverse_thrust(false)
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros/src/plugins/setpoint_position.cpp
+++ b/mavros/src/plugins/setpoint_position.cpp
@@ -43,8 +43,8 @@ public:
 	SetpointPositionPlugin() : PluginBase(),
 		sp_nh("~setpoint_position"),
 		spg_nh("~"),
-		tf_rate(50.0),
-		tf_listen(false)
+		tf_listen(false),
+		tf_rate(50.0)
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros/src/plugins/setpoint_trajectory.cpp
+++ b/mavros/src/plugins/setpoint_trajectory.cpp
@@ -147,8 +147,9 @@ private:
 
 		Eigen::Vector3d position, velocity, af;
 		Eigen::Quaterniond attitude = Eigen::Quaterniond::Identity();
-		float yaw, yaw_rate;
-		uint16_t type_mask = 0;
+		float yaw = 0.f;
+		float yaw_rate = 0.f;
+		uint16_t type_mask = 0;		
 		if(!setpoint_target->transforms.empty()){
 			position = ftf::detail::transform_static_frame(ftf::to_eigen(setpoint_target->transforms[0].translation), transform);
 			attitude = ftf::detail::transform_orientation(ftf::to_eigen(setpoint_target->transforms[0].rotation), transform);

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -429,11 +429,11 @@ public:
 		hwst_diag("APM Hardware"),
 		sys_diag("System"),
 		batt_diag("Battery"),
+		conn_heartbeat_mav_type(MAV_TYPE::ONBOARD_CONTROLLER),
 		version_retries(RETRIES_COUNT),
 		disable_diag(false),
 		has_battery_status(false),
-		battery_voltage(0.0),
-		conn_heartbeat_mav_type(MAV_TYPE::ONBOARD_CONTROLLER)
+		battery_voltage(0.0)
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -33,12 +33,12 @@ class TimeSyncStatus : public diagnostic_updater::DiagnosticTask
 public:
 	TimeSyncStatus(const std::string &name, size_t win_size) :
 		diagnostic_updater::DiagnosticTask(name),
+		times_(win_size),
+		seq_nums_(win_size),
 		window_size_(win_size),
 		min_freq_(0.01),
 		max_freq_(10),
 		tolerance_(0.1),
-		times_(win_size),
-		seq_nums_(win_size),
 		last_rtt(0),
 		rtt_sum(0),
 		last_remote_ts(0),

--- a/mavros/src/plugins/waypoint.cpp
+++ b/mavros/src/plugins/waypoint.cpp
@@ -36,7 +36,7 @@ public:
 	void initialize(UAS &uas_) override
 	{
 		PluginBase::initialize(uas_);
-		MissionBase::initialize(&wp_nh);
+		MissionBase::initialize_with_nodehandle(&wp_nh);
 
 		wp_state = WP::IDLE;
 		wp_type = plugin::WP_TYPE::MISSION;

--- a/mavros_extras/src/plugins/distance_sensor.cpp
+++ b/mavros_extras/src/plugins/distance_sensor.cpp
@@ -41,11 +41,11 @@ public:
 		field_of_view(0),
 		orientation(-1),
 		covariance(0),
-		owner(nullptr),
-		data_index(0),
 		horizontal_fov_ratio(1.0),
 		vertical_fov_ratio(1.0),
-		quaternion(0.f, 0.f, 0.f, 0.f)
+		quaternion(0.f, 0.f, 0.f, 0.f),
+		owner(nullptr),
+		data_index(0)
 	{ }
 
 	// params

--- a/mavros_extras/src/plugins/gps_input.cpp
+++ b/mavros_extras/src/plugins/gps_input.cpp
@@ -42,7 +42,7 @@ public:
 
 		last_pos_time = ros::Time(0.0);
 		gps_input_nh.param("gps_rate", _gps_rate, 5.0);		// GPS data rate of 5hz
-		gps_rate : _gps_rate;
+		gps_rate = _gps_rate;
 
 		gps_input_sub = gps_input_nh.subscribe("gps_input", 1, &GpsInputPlugin::send_cb, this);
 	}


### PR DESCRIPTION
I have some build warnings in the mavros and mavros_extras packages when I build locally with Clang, which I've attempted to fix.

I think some of these changes are uncontroversial, such as
* reordering constructor initializer lists to avoid "-Wreorder-ctor",
* initializing yaw and yaw_rate explicitly to zero in the setpoint_trajectory plugin, and
* fixing the probably incorrect gps_rate initialization.

There was also a warning where `MissionBase::initialize(ros::NodeHandle *_wp_nh)` upsets the compiler because it "hides the overloaded virtual function `PluginBase::initialize(UAS &uas)` because MissionBase inherits from PluginBase. I've avoided this by renaming `MissionBase::initialize` but you may want to solve it differently, or give it a different name.

After this, all that remains when I build are unused variable warnings, mostly about `COV_SIZE` which is only used in debug builds. I suppose this could be fixed with the casting to void trick `(void)COV_SIZE` or with `[maybe_unused](https://en.cppreference.com/w/cpp/language/attributes/maybe_unused)` (but that would require C++17). Locally I've silenced this with a few `#pragma GCC diagnostic ignored "-Wunused-variable"`.