### PR TITLE
Fix spurious bug because class field was uninitialized.

### DIFF
--- a/mavros/src/lib/mavros_uas.cpp
+++ b/mavros/src/lib/mavros_uas.cpp
@@ -58,7 +58,8 @@ UAS::UAS(
   fcu_capabilities(0),
   connected(false),
   time_offset(0),
-  tsync_mode(timesync_mode::NONE)
+  tsync_mode(timesync_mode::NONE),
+  mavlink_status({})
 {
   // XXX TODO(vooon): should i use LifecycleNode?
 


### PR DESCRIPTION
This bug caused mavros to crash randomly. Is there maybe a check that can be enabled in g++ to catch these kind of bugs?

Rationale:
For basic types, fields get initialized with there default value, but struct types get garbled memory, unless passed an initializer list.

See also: https://en.cppreference.com/w/cpp/language/default_initialization