### PR TITLE
Set time/publish_sim_time to false by default

### DIFF
--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -217,7 +217,7 @@ public:
 		m_uas->set_timesync_mode(ts_mode);
 		ROS_INFO_STREAM_NAMED("time", "TM: Timesync mode: " << utils::to_string(ts_mode));
 
-		nh.getParam("time/publish_sim_time", publish_sim_time);
+		nh.param("time/publish_sim_time", publish_sim_time, false);
 		if (publish_sim_time) {
 			sim_time_pub = nh.advertise<rosgraph_msgs::Clock>("/clock", 10);
 			ROS_INFO_STREAM_NAMED("time", "TM: Publishing sim time");


### PR DESCRIPTION
Problem: parameter `time/publish_sim_time = true` pretty much breaks the simulation.

As I understand using `getParam` without checking the return value keeps `publish_sim_time` variable random. So `param` with the default value must be used here.