### PR TITLE
libmavconn: fix deadlock when call close()

### DIFF
--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -156,18 +156,20 @@ void MAVConnTCPClient::connect(
 
 void MAVConnTCPClient::close()
 {
-  lock_guard lock(mutex);
-  if (!is_open()) {
-    return;
-  }
+  {
+    lock_guard lock(mutex);
+    if (!is_open()) {
+      return;
+    }
 
-  std::error_code ec;
-  socket.shutdown(asio::ip::tcp::socket::shutdown_send, ec);
-  if (ec) {
-    CONSOLE_BRIDGE_logError(PFXd "shutdown: %s", conn_id, ec.message().c_str());
+    std::error_code ec;
+    socket.shutdown(asio::ip::tcp::socket::shutdown_send, ec);
+    if (ec) {
+      CONSOLE_BRIDGE_logError(PFXd "shutdown: %s", conn_id, ec.message().c_str());
+    }
+    socket.cancel();
+    socket.close();
   }
-  socket.cancel();
-  socket.close();
 
   io_work.reset();
   io_service.stop();


### PR DESCRIPTION
  MavconnTCPClient: When calling the `close()` function (by a different thread), a mutex is taken at
  the start of this function which closes the socket and waits the end of io_service thread.

  Closing the socket causes the `Operation aborted` error in `do_recv()` function called by
  io_service thread which in turn calls the `close()` function.

  This causes a 'deadlock'.

  fix: Reduce the scope of the mutex in the `close()` function so that it is released before
  waiting the end of io_service thread.