### PR TITLE
fix std::system_error when tcp interface loses connection

### DIFF
--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -83,6 +83,7 @@ private:
   asio::io_service io_service;
   std::unique_ptr<asio::io_service::work> io_work;
   std::thread io_thread;
+  std::atomic<bool> is_running; //!< io_thread running
 
   asio::ip::tcp::socket socket;
   asio::ip::tcp::endpoint server_ep;
@@ -101,6 +102,11 @@ private:
 
   void do_recv();
   void do_send(bool check_tx_state);
+
+  /**
+   * Stop io_service.
+   */
+  void stop();
 };
 
 /**

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -83,7 +83,7 @@ private:
   asio::io_service io_service;
   std::unique_ptr<asio::io_service::work> io_work;
   std::thread io_thread;
-  std::atomic<bool> is_running; //!< io_thread running
+  std::atomic<bool> is_running;  //!< io_thread running
 
   asio::ip::tcp::socket socket;
   asio::ip::tcp::endpoint server_ep;

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -136,7 +136,7 @@ MAVConnTCPClient::~MAVConnTCPClient()
 {
   is_destroying = true;
   close();
-  
+
   // If the client is already disconnected on error (By the io_service thread)
   // and io_service running
   if (is_running) {
@@ -161,7 +161,7 @@ void MAVConnTCPClient::connect(
       utils::set_this_thread_name("mtcp%zu", conn_id);
       try {
         io_service.run();
-      } catch (std::exception &ex) {
+      } catch (std::exception & ex) {
         CONSOLE_BRIDGE_logError(PFXd "io_service execption: %s", conn_id, ex.what());
       }
       is_running = false;


### PR DESCRIPTION
  When the tcp connection is lost (remote TCP server stopped), an `End of file` error is caught
  by the `io_thread` in the `do_recv()` that calls the `close()` function.

  In the `close()` function, we stop the io_service and wait the end of the io_thread which
  causes an `std::system_error exception` _(cause: Resource deadlock avoided)_.

```
  Error:   mavconn: tcp0: receive: End of file at line 250 in libmavconn/src/tcp.cpp
           terminate called after throwing an instance of 'std::system_error'
           what():  Resource deadlock avoided
           Aborted (core dumped)
```

  fix:
    - close() function: stop io_service if current thread id != io_thread id
    - ~MAVConnTCPClient(): stop io_service and io_thread if thread is running