### PR TITLE
Disable startup_px4_usb_quirk in px4_config.yaml

### DIFF
--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -1,7 +1,7 @@
 # Common configuration for PX4 autopilot
 #
 # node:
-startup_px4_usb_quirk: true
+startup_px4_usb_quirk: false
 
 # --- system plugins ---
 


### PR DESCRIPTION
I guess this feature is not needed any more. 

Moreover it breaks connection with the most recent PX4 build, as it autostarts either MAVLink or shell on USB based on traffic it sees.