### PR TITLE
Fix obstacle distance

### DIFF
--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -88,16 +88,14 @@ private:
 			obstacle.increment_f = increment_deg;
 		} else {
 			// all distances from sensor will not fit so we combine adjacent distances always taking the shortest distance
-			size_t scale_factor = ceil(double(req->ranges.size()) / obstacle.distances.size());
+			const float scale_factor = double(req->ranges.size()) / obstacle.distances.size();
 			for (size_t i = 0; i < obstacle.distances.size(); i++) {
 				obstacle.distances[i] = UINT16_MAX;
 				for (size_t j = 0; j < scale_factor; j++) {
-					size_t req_index = i * scale_factor + j;
-					if (req_index < req->ranges.size()) {
-						float distance_cm = req->ranges[req_index] * 1e2;
-						if (!std::isnan(distance_cm) && distance_cm < UINT16_MAX && distance_cm > 0) {
-							obstacle.distances[i] = std::min(obstacle.distances[i], static_cast<uint16_t>(distance_cm));
-						}
+					size_t req_index = floor(i * scale_factor + j);
+					float distance_cm = req->ranges[req_index] * 1e2;
+					if (!std::isnan(distance_cm) && distance_cm < UINT16_MAX && distance_cm > 0) {
+						obstacle.distances[i] = std::min(obstacle.distances[i], static_cast<uint16_t>(distance_cm));
 					}
 				}
 			}

--- a/mavros_extras/src/plugins/obstacle_distance.cpp
+++ b/mavros_extras/src/plugins/obstacle_distance.cpp
@@ -99,7 +99,10 @@ private:
 					}
 				}
 			}
-			obstacle.increment = ceil(req->angle_increment * RAD_TO_DEG * scale_factor);	//!< [degrees]
+			const float increment_deg = req->angle_increment * RAD_TO_DEG * scale_factor;
+			obstacle.increment = static_cast<uint8_t>(increment_deg + 0.5f);	//!< Round to nearest integer.
+			obstacle.increment_f = increment_deg;
+
 		}
 
 		obstacle.time_usec = req->header.stamp.toNSec() / 1000;					//!< [microsecs]


### PR DESCRIPTION
Hi!

This PR contains two bugfix in the /mavros_extras/src/plugins/obstacle_distance.cpp file.

**The first one** corrects the way the reduction of size of the LaserScan is done. 
The code should redux the resolution of the array to adjust to the mavlink OBSTACLE_DISTANCE message (72 values) taking the minimum value as aggregation function of the interpolation.

The scale_factor was taken as integer, so the interpolation worked wrong.

This image shows the error and the fix:

![interpolarion bugfix explained](https://user-images.githubusercontent.com/33803328/152854845-069ceb36-a2f6-4c14-b152-7ff89a58950c.png)

**The second bugfix** assigns a value to increment_f in case the size of the input LaserScan is bigger than the mavlink OBSTACLE_DISTANCE message.
This was missing, so ardupilot was usgin the value of increment (and NOT increment_f), showing wrong objects.