### PR TITLE
Maybe fix sys status callbacks

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -171,18 +171,9 @@ private:
   {
     lock_guard lock(mutex);
 
-    RCLCPP_ERROR_STREAM(get_logger(), "[handle_command_ack] ACK received. Current thread: " << std::this_thread::get_id());
-    RCLCPP_ERROR_STREAM(get_logger(), "[handle_command_ack] ACK Waiting list: [");
-    for ( auto & tr : ack_waiting_list ) {
-      RCLCPP_ERROR_STREAM(get_logger(), "[handle_command_ack]    " << tr.expected_command);
-    }
-    RCLCPP_ERROR_STREAM(get_logger(), "[handle_command_ack]     ]");
-
     for (auto & tr : ack_waiting_list) {
       if (tr.expected_command == ack.command) {
-        RCLCPP_ERROR_STREAM(get_logger(), "[handle_command_ack] Found match, will set. Thread: " << std::this_thread::get_id());
         tr.promise.set_value(ack.result);
-        RCLCPP_ERROR_STREAM(get_logger(), "[handle_command_ack] Promise value set. Thread: " << std::this_thread::get_id());
         return;
       }
     }
@@ -199,7 +190,6 @@ private:
   {
     auto future = tr.promise.get_future();
 
-    RCLCPP_ERROR_STREAM(get_logger(), "[wait_ack_for] Will wait for ACK on " << tr.expected_command << ". Current thread: " << std::this_thread::get_id());
     auto wres = future.wait_for(command_ack_timeout_dt.to_chrono<std::chrono::nanoseconds>());
     if (wres != std::future_status::ready) {
       RCLCPP_WARN(get_logger(), "CMD: Command %u -- ack timeout", tr.expected_command);
@@ -260,18 +250,13 @@ private:
 
     if (is_ack_required) {
       lock.unlock();
-      RCLCPP_ERROR_STREAM(get_logger(), "[send_command_long_and_wait] Will wait for ACK. Current thread: " << std::this_thread::get_id());
       bool is_not_timeout = wait_ack_for(*ack_it, result);
-      RCLCPP_ERROR_STREAM(get_logger(), "[send_command_long_and_wait] Wait for ACK done. Current thread: " << std::this_thread::get_id());
       lock.lock();
 
       success = is_not_timeout && result == enum_value(MAV_RESULT::ACCEPTED);
 
       ack_waiting_list.erase(ack_it);
     } else {
-      RCLCPP_ERROR_STREAM(get_logger(), "[send_command_long_and_wait] No ACK required. Current thread: " << std::this_thread::get_id());
-      lock.unlock();
-      sleep(5);
       success = true;
       result = enum_value(MAV_RESULT::ACCEPTED);
     }
@@ -342,7 +327,6 @@ private:
     cmd.param6 = param6;
     cmd.param7 = param7;
 
-    RCLCPP_ERROR_STREAM(get_logger(), "[command_long] Calling send_message. Current thread: " << std::this_thread::get_id());
     uas->send_message(cmd);
   }
 
@@ -380,7 +364,6 @@ private:
     const mavros_msgs::srv::CommandLong::Request::SharedPtr req,
     mavros_msgs::srv::CommandLong::Response::SharedPtr res)
   {
-    RCLCPP_ERROR_STREAM(get_logger(), "[command_long_cb] Entered. Current thread: " << std::this_thread::get_id());
     // TODO(vooon): rewrite to use async service server
     send_command_long_and_wait(
       req->broadcast,
@@ -390,7 +373,6 @@ private:
       req->param5, req->param6,
       req->param7,
       res->success, res->result);
-    RCLCPP_ERROR_STREAM(get_logger(), "[command_long_cb] Done! Current thread: " << std::this_thread::get_id());
   }
 
   void command_int_cb(

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -530,6 +530,10 @@ public:
         &SystemStatusPlugin::vehicle_info_get_cb, this, _1,
         _2), rmw_qos_profile_services_default, srv_cg);
 
+    command_client = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command");
+    //command_client.service_is_ready();
+    //command_client.wait_for_service();
+
     uas->diagnostic_updater.add(hb_diag);
 
     autopilot_version_timer =

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -533,7 +533,9 @@ public:
     uas->diagnostic_updater.add(hb_diag);
 
     autopilot_version_timer =
-      node->create_wall_timer(1s, std::bind(&SystemStatusPlugin::autopilot_version_cb, this), srv_cg);
+      node->create_wall_timer(
+      1s, std::bind(&SystemStatusPlugin::autopilot_version_cb, this),
+      srv_cg);
 
     // init state topic
     publish_disconnection();

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -530,14 +530,10 @@ public:
         &SystemStatusPlugin::vehicle_info_get_cb, this, _1,
         _2), rmw_qos_profile_services_default, srv_cg);
 
-    command_client = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command");
-    //command_client.service_is_ready();
-    //command_client.wait_for_service();
-
     uas->diagnostic_updater.add(hb_diag);
 
     autopilot_version_timer =
-      node->create_wall_timer(1s, std::bind(&SystemStatusPlugin::autopilot_version_cb, this));
+      node->create_wall_timer(1s, std::bind(&SystemStatusPlugin::autopilot_version_cb, this), srv_cg);
 
     // init state topic
     publish_disconnection();
@@ -583,8 +579,6 @@ private:
   rclcpp::Service<mavros_msgs::srv::MessageInterval>::SharedPtr message_interval_srv;
   rclcpp::Service<mavros_msgs::srv::SetMode>::SharedPtr mode_srv;
   rclcpp::Service<mavros_msgs::srv::VehicleInfoGet>::SharedPtr vehicle_info_get_srv;
-
-  rclcpp::Client<mavros_msgs::srv::CommandLong>::SharedPtr command_client;
 
   MAV_TYPE conn_heartbeat_mav_type;
   static constexpr int RETRIES_COUNT = 6;
@@ -1082,7 +1076,7 @@ private:
     bool do_broadcast = version_retries > RETRIES_COUNT / 2;
 
     try {
-      //auto client = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command");
+      auto client = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command");
 
       auto cmdrq = std::make_shared<mavros_msgs::srv::CommandLong::Request>();
       cmdrq->broadcast = do_broadcast;
@@ -1094,17 +1088,12 @@ private:
         lg, "VER: Sending %s request.",
         (do_broadcast) ? "broadcast" : "unicast");
 
-      RCLCPP_ERROR_STREAM(lg, "[autopilot_version_cb] Current thread: " << std::this_thread::get_id());
-
-      auto future = command_client->async_send_request(cmdrq);
+      auto future = client->async_send_request(cmdrq);
       // NOTE(vooon): temporary hack from @Michel1968
       // See: https://github.com/mavlink/mavros/issues/1588#issuecomment-1027699924
       const auto future_status = future.wait_for(1s);
       if (future_status == std::future_status::ready) {
         auto response = future.get();
-      
-      RCLCPP_ERROR_STREAM(lg, "[autopilot_version_cb] Future got. Thread: " << std::this_thread::get_id());
-      
         ret = response->success;
       } else {
         RCLCPP_ERROR(lg, "VER: autopilot version service timeout");
@@ -1204,7 +1193,7 @@ private:
     auto lg = get_logger();
 
     try {
-      //auto client = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command");
+      auto client = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command");
 
       // calculate interval
       float interval_us;
@@ -1227,19 +1216,16 @@ private:
         lg,
         "SYS: Request msgid %u at %f hz",
         req->message_id, req->message_rate);
-      
-      RCLCPP_ERROR_STREAM(lg, "[set_msg_interval_cb] Sending Request. Current thread: " << std::this_thread::get_id());
 
-      auto future = command_client->async_send_request(cmdrq);
-      // // NOTE(vooon): same hack as for VER
-      // const auto future_status = future.wait_for(1s);
-      // if (future_status == std::future_status::ready) {
+      auto future = client->async_send_request(cmdrq);
+      // NOTE(vooon): same hack as for VER
+      const auto future_status = future.wait_for(1s);
+      if (future_status == std::future_status::ready) {
         auto response = future.get();
-        RCLCPP_ERROR_STREAM(lg, "[set_msg_interval_cb] Future got. Current thread: " << std::this_thread::get_id());
         res->success = response->success;
-      // } else {
-      //   RCLCPP_ERROR(lg, "SYS: set_message_interval service timeout");
-      // }
+      } else {
+        RCLCPP_ERROR(lg, "SYS: set_message_interval service timeout");
+      }
     } catch (std::exception & ex) {
       RCLCPP_ERROR_STREAM(lg, "SYS: " << ex.what());
     }


### PR DESCRIPTION
Tentative fix for #1588 

Adding the timer to the `srv_cg` callback group appears to resolve the issue. Not entirely sure why that is. Potentially rclcpp/rmw internals causing a deadlock.