### PR TITLE
libmavconn: fix UDP deadlocks

### DIFF
--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -82,6 +82,7 @@ private:
   asio::io_service io_service;
   std::unique_ptr<asio::io_service::work> io_work;
   std::thread io_thread;
+  std::atomic<bool> is_running;  //!< io_thread running
   bool permanent_broadcast;
 
   std::atomic<bool> remote_exists;
@@ -98,6 +99,11 @@ private:
 
   void do_recvfrom();
   void do_sendto(bool check_tx_state);
+
+  /**
+   * Stop io_service.
+   */
+  void stop();
 };
 
 }  // namespace mavconn


### PR DESCRIPTION
Same problems as for the TCP:
  - #1682: fix std::system_error when tcp interface loses connection
  - #1679: fix deadlock when call close()