### PR TITLE
Pr cellular status

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(mavros_extras
   src/plugins/adsb.cpp
   src/plugins/cam_imu_sync.cpp
   src/plugins/camera.cpp
+  src/plugins/cellular_status.cpp
   src/plugins/companion_process_status.cpp
   src/plugins/onboard_computer_status.cpp
   src/plugins/debug_value.cpp

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -9,6 +9,9 @@
   <class name="camera" type="mavros::extra_plugins::CameraPlugin" base_class_type="mavros::plugin::PluginBase">
     <description>Plugin for the mavlink camera protocol.</description>
   </class>
+  <class name="cellular_status" type="mavros::extra_plugins::CellularStatusPlugin" base_class_type="mavros::plugin::PluginBase">
+    <description>Send Cellular status via ROS.</description>
+  </class>
   <class name="companion_process_status" type="mavros::extra_plugins::CompanionProcessStatusPlugin" base_class_type="mavros::plugin::PluginBase">
     <description>Send companion process status report to the FCU.</description>
   </class>

--- a/mavros_extras/src/plugins/cellular_status.cpp
+++ b/mavros_extras/src/plugins/cellular_status.cpp
@@ -27,8 +27,8 @@ namespace extra_plugins {
  */
 class CellularStatusPlugin : public plugin::PluginBase {
 public:
-  CellularStatusPlugin() : PluginBase(),
-    cc_nh("~cellular_status")
+	CellularStatusPlugin() : PluginBase(),
+		cc_nh("~cellular_status")
 	{ }
 
 	/**
@@ -53,8 +53,8 @@ public:
 	}
 
 private:
-  	ros::NodeHandle cc_nh;
-  	ros::Subscriber subCellularStatus;
+	ros::NodeHandle cc_nh;
+	ros::Subscriber subCellularStatus;
 
 	/**
 	 * @brief Send Cellular Status messages to mavlink system
@@ -73,7 +73,7 @@ private:
 		cs.mcc = msg.mcc;
 		cs.mnc = msg.mnc;
 		cs.lac = msg.lac;
-		
+
 		UAS_FCU(m_uas)->send_message_ignore_drop(cs);
 	}
 };

--- a/mavros_extras/src/plugins/cellular_status.cpp
+++ b/mavros_extras/src/plugins/cellular_status.cpp
@@ -1,0 +1,84 @@
+/**
+ * @brief Cellular status plugin
+ * @file cellular_status.cpp
+ * @author Rui Mendes <rui.mendes@beyond-vision.pt>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+/*
+ * Copyright 2021 Jaeyoung Lim.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+
+#include <mavros/mavros_plugin.h>
+#include <mavros_msgs/CellularStatus.h>
+
+namespace mavros {
+namespace extra_plugins {
+/**
+ * @brief Cellular status plugin.
+ *
+ * Users must publish to the topic the CellularStatus message and it
+ * will be relayed to the mavlink components.
+ */
+class CellularStatusPlugin : public plugin::PluginBase {
+public:
+  CellularStatusPlugin() : PluginBase(),
+    cc_nh("~cellular_status")
+	{ }
+
+	/**
+	 * Plugin initializer. Constructor should not do this.
+	 */
+	void initialize(UAS &uas_)
+	{
+		PluginBase::initialize(uas_);
+		subCellularStatus = cc_nh.subscribe("status", 1, &CellularStatusPlugin::cellularStatusCb, this);
+	}
+
+	/**
+	 * This function returns message subscriptions.
+	 *
+	 * Each subscription made by PluginBase::make_handler() template.
+	 * Two variations:
+	 *  - With automatic decoding and framing error filtering (see handle_heartbeat)
+	 *  - Raw message with framig status (see handle_systemtext)
+	 */
+	Subscriptions get_subscriptions() {
+		return {};
+	}
+
+private:
+  	ros::NodeHandle cc_nh;
+  	ros::Subscriber subCellularStatus;
+
+	/**
+	 * @brief Send Cellular Status messages to mavlink system
+	 *
+	 * Message specification: https://mavlink.io/en/messages/common.html#CELLULAR_STATUS
+	 * @param msg	received CellularStatus msg
+	 */
+	void cellularStatusCb(const mavros_msgs::CellularStatus &msg)
+	{
+		mavlink::common::msg::CELLULAR_STATUS cs{};
+
+		cs.status = msg.status;
+		cs.failure_reason = msg.failure_reason;
+		cs.type = msg.type;
+		cs.quality = msg.quality;
+		cs.mcc = msg.mcc;
+		cs.mnc = msg.mnc;
+		cs.lac = msg.lac;
+		
+		UAS_FCU(m_uas)->send_message_ignore_drop(cs);
+	}
+};
+}	// namespace std_plugins
+}	// namespace mavros
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mavros::extra_plugins::CellularStatusPlugin, mavros::plugin::PluginBase)

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -14,6 +14,7 @@ add_message_files(
   AttitudeTarget.msg
   BatteryStatus.msg
   CamIMUStamp.msg
+  CellularStatus.msg
   CameraImageCaptured.msg
   CommandCode.msg
   CompanionProcessStatus.msg

--- a/mavros_msgs/msg/CellularStatus.msg
+++ b/mavros_msgs/msg/CellularStatus.msg
@@ -1,0 +1,9 @@
+#Follows https://mavlink.io/en/messages/common.html#CELLULAR_STATUS specification
+
+uint8 status
+uint8 failure_reason
+uint8 type
+uint8 quality
+uint16 mcc
+uint16 mnc
+uint16 lac


### PR DESCRIPTION
This addition allows the onboard computer (OBC) to send the MAVlink message [Celular status](https://mavlink.io/en/messages/common.html#CELLULAR_STATUS) via ROS.

It's used when the OBC has a cellular connection and it's reported to the ground station or any other components compatible with MAVlink.