### PR TITLE
Fix crash in vision_pose plugin

### DIFF
--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -133,12 +133,6 @@ private:
     auto cov_ned = ftf::transform_frame_enu_ned(cov);
     ftf::EigenMapConstCovariance6d cov_map(cov_ned.data());
 
-    RCLCPP_INFO_STREAM(
-      get_logger(),
-      "Listen to vision transform " << tf_frame_id <<
-        " -> " << tf_child_frame_id);
-
-
     mavlink::common::msg::VISION_POSITION_ESTIMATE vp{};
 
     vp.usec = stamp.nanoseconds() / 1000;

--- a/mavros_extras/src/plugins/vision_pose_estimate.cpp
+++ b/mavros_extras/src/plugins/vision_pose_estimate.cpp
@@ -107,7 +107,7 @@ private:
 
   double tf_rate;
 
-  rclcpp::Time last_transform_stamp;
+  rclcpp::Time last_transform_stamp{0, 0, RCL_ROS_TIME};
 
   /* -*- low-level send -*- */
   /**


### PR DESCRIPTION
Fixes #1734 

I removed the call to the `RCLCPP_INFO_STREAM`: it didn't seem to belong in this routine. If there's a reason to keep it perhaps it should be `ONCE` or `DEBUG`.