### PR TITLE
Make compatible with pymavlink type annotations PR

### DIFF
--- a/mavros/mavros/cmd/checkid.py
+++ b/mavros/mavros/cmd/checkid.py
@@ -101,7 +101,15 @@ class Checker:
                 if msg is None:
                     return f"{msgid}"
                 else:
-                    return f"{msgid} ({msg.name})"
+                    msg_name = ""
+                    # In version 2.4.30 <TODO: replace with actual number>, the class variable name
+                    # was renamed to msgname. Since we don't know the pymavlink version we need to check
+                    # for both.
+                    if hasattr(msg, "msgname"):
+                        msg_name = msg.msgname
+                    else:
+                        msg_name = msg.name
+                    return f"{msgid} ({msg_name})"
 
             str_ids = self.fmt_ids(address)
             click.secho(


### PR DESCRIPTION
In that PR, the attribute name is changed to msgname due to conflicts with message instance variables.

The version number in the comment needs to be updated once <https://github.com/ArduPilot/pymavlink/pull/664> is merged and released.