### PR TITLE
Update for GeographicLib 2.0

### DIFF
--- a/libmavconn/cmake/Modules/FindGeographicLib.cmake
+++ b/libmavconn/cmake/Modules/FindGeographicLib.cmake
@@ -8,7 +8,10 @@
 
 find_path (GeographicLib_INCLUDE_DIRS NAMES GeographicLib/Config.h)
 
-find_library (GeographicLib_LIBRARIES NAMES GeographicLib)
+if(GeographicLib_VERSION_MAJOR LESS 2)
+    find_library (GeographicLib_LIBRARIES NAMES Geographic)
+else()
+    find_library (GeographicLib_LIBRARIES NAMES GeographicLib)
 
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (GeographicLib DEFAULT_MSG

--- a/libmavconn/cmake/Modules/FindGeographicLib.cmake
+++ b/libmavconn/cmake/Modules/FindGeographicLib.cmake
@@ -8,7 +8,7 @@
 
 find_path (GeographicLib_INCLUDE_DIRS NAMES GeographicLib/Config.h)
 
-find_library (GeographicLib_LIBRARIES NAMES Geographic)
+find_library (GeographicLib_LIBRARIES NAMES GeographicLib)
 
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args (GeographicLib DEFAULT_MSG


### PR DESCRIPTION
Library file now called libGeographicLib.so, etc., instead of libGeographic.so.