### PR TITLE
Fill out the rangefinder properties from the rangefinder message

### DIFF
--- a/mavros_extras/src/plugins/rangefinder.cpp
+++ b/mavros_extras/src/plugins/rangefinder.cpp
@@ -55,9 +55,9 @@ private:
 		rangefinder_msg->header.stamp = ros::Time::now();
 		rangefinder_msg->header.frame_id = "/rangefinder";
 		rangefinder_msg->radiation_type = sensor_msgs::Range::INFRARED;
-		rangefinder_msg->field_of_view = 0;
-		rangefinder_msg->min_range = 0;
-		rangefinder_msg->max_range = 1000;
+		rangefinder_msg->field_of_view = rangefinder.horizontal_fov;
+		rangefinder_msg->min_range = rangefinder.min_distance;
+		rangefinder_msg->max_range = rangefinder.max_distance;
 		rangefinder_msg->range = rangefinder.distance;
 
 		rangefinder_pub.publish(rangefinder_msg);


### PR DESCRIPTION
Fills out the rangefinder properties (`field of view`, `min_range`, and `max_range`) in the `rangefinder_msg` from the mavlink message.  

I haven't updated the `radiation_type` field as the enums in the [sensors_mgs::Range](http://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/Range.html) don't match the [MAV_DISTANCE_SENSOR](https://mavlink.io/en/messages/common.html#MAV_DISTANCE_SENSOR) enums.