### PR TITLE
libmavconn: fix MAVLink v1.0 output selection

### DIFF
--- a/libmavconn/include/mavconn/interface.h
+++ b/libmavconn/include/mavconn/interface.h
@@ -274,7 +274,7 @@ protected:
 	size_t conn_id;
 
 	inline mavlink::mavlink_status_t *get_status_p() {
-		return &m_mavlink_status;
+		return &m_parse_status;
 	}
 
 	inline mavlink::mavlink_message_t *get_buffer_p() {

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -172,10 +172,15 @@ void MAVConnInterface::send_message_ignore_drop(const mavlink::Message &msg, uin
 
 void MAVConnInterface::set_protocol_version(Protocol pver)
 {
-	if (pver == Protocol::V10)
+	if (pver == Protocol::V10) {
 		m_mavlink_status.flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-	else
+		m_parse_status.flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+	
+	}
+	else {
 		m_mavlink_status.flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+		m_parse_status.flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+	}
 }
 
 Protocol MAVConnInterface::get_protocol_version()


### PR DESCRIPTION
Fix #1787