### PR TITLE
mavros: Fix some warnings

### DIFF
--- a/mavros/include/mavros/mission_protocol_base.h
+++ b/mavros/include/mavros/mission_protocol_base.h
@@ -485,7 +485,7 @@ protected:
 	//! @brief set the FCU current waypoint
 	void set_current_waypoint(size_t seq)
 	{
-		auto i = 0;
+		size_t i = 0;
 		for (auto &it : waypoints) {
 			it.is_current = (i == seq) ? true : false;
 			i++;

--- a/mavros/src/plugins/dummy.cpp
+++ b/mavros/src/plugins/dummy.cpp
@@ -76,7 +76,7 @@ private:
 	}
 
 	void handle_statustext_raw(const mavlink::mavlink_message_t *msg, const mavconn::Framing f) {
-		ROS_INFO_NAMED("dummy", "Dummy::handle_statustext_raw(%p, %d) from %u.%u", msg, utils::enum_value(f), msg->sysid, msg->compid);
+		ROS_INFO_NAMED("dummy", "Dummy::handle_statustext_raw(%p, %d) from %u.%u", (void *)msg, utils::enum_value(f), msg->sysid, msg->compid);
 	}
 };
 

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -528,7 +528,7 @@ public:
 		UAS_DIAG(m_uas).add(hb_diag);
 		if (!disable_diag) {
 			UAS_DIAG(m_uas).add(sys_diag);
-			for (int i = 0; i < MAX_NR_BATTERY_STATUS && i < min_voltage.size(); ++i) {
+			for (size_t i = 0; i < MAX_NR_BATTERY_STATUS && i < min_voltage.size(); ++i) {
 				batt_diag[i].set_min_voltage(min_voltage[i]);
 				UAS_DIAG(m_uas).add(batt_diag[i]);
 			}

--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -55,7 +55,7 @@ public:
 		count_ = 0;
 		rtt_sum = 0;
 
-		for (int i = 0; i < window_size_; i++)
+		for (size_t i = 0; i < window_size_; i++)
 		{
 			times_[i] = curtime;
 			seq_nums_[i] = count_;


### PR DESCRIPTION
This introduces no functional change, but gets rid of a few `-Wsign-compare` warnings and one `-Wformat-pedantic` warning.