### PR TITLE
mavros_extras: Fix a comparison that shouldn't be bitwise

### DIFF
--- a/mavros_extras/src/plugins/guided_target.cpp
+++ b/mavros_extras/src/plugins/guided_target.cpp
@@ -183,7 +183,7 @@ private:
 
 		/* publish target */
 
-		if (pose->pose.position.x != arr[0] | pose->pose.position.y != arr[1]) {
+		if (pose->pose.position.x != arr[0] || pose->pose.position.y != arr[1]) {
 			setpointg_pub.publish(pose);
 		}
 


### PR DESCRIPTION
Hi all, I think this is a bug. This expression is written with a bitwise OR `|`, but it seems like it should have been written with a logical OR `||`.