### PR TITLE
mavros_extras: Fix a sequence point warning

### DIFF
--- a/mavros_extras/src/visualization.cpp
+++ b/mavros_extras/src/visualization.cpp
@@ -74,7 +74,7 @@ static void publish_track_marker(const geometry_msgs::PoseStamped::ConstPtr &pos
 		track_marker->points.push_back(pose->pose.position);
 	else track_marker->points[marker_idx] = pose->pose.position;
 
-	marker_idx = ++marker_idx % max_track_size;
+	marker_idx = (marker_idx + 1) % max_track_size;
 
 	track_marker->header = pose->header;
 	track_marker_pub.publish(track_marker);


### PR DESCRIPTION
This line triggers a `-Wsequence-point` warning. You can read about it here: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

It seems to be that doing `++` (which modifies a variable) and assigning the result back to the same variable can be undefined behaviour.

In this case, we don't need to pre-increment, we can just add one, and then save the result back to the variable. This makes the warning go away, and seems to make sense.