### PR TITLE
Made it such that the gp_origin topic publisher is latched.

### DIFF
--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -84,7 +84,7 @@ public:
 		gp_hdg_pub = gp_nh.advertise<std_msgs::Float64>("compass_hdg", 10);
 
 		// global origin
-		gp_global_origin_pub = gp_nh.advertise<geographic_msgs::GeoPointStamped>("gp_origin", 10);
+		gp_global_origin_pub = gp_nh.advertise<geographic_msgs::GeoPointStamped>("gp_origin", 10, true);
 		gp_set_global_origin_sub = gp_nh.subscribe("set_gp_origin", 10, &GlobalPositionPlugin::set_gp_origin_cb, this);
 
 		// home position subscriber to set "map" origin


### PR DESCRIPTION
Sometimes when a subscriber subs to "gp_origin" topic it doesn't receive a message in time leading to race conditions. Made it such that the publisher is latched so subscribers always gets the gp_origin on demand.