### PR TITLE
plugins: ftp: fix null pointer dereference

### DIFF
--- a/mavros/src/plugins/ftp.cpp
+++ b/mavros/src/plugins/ftp.cpp
@@ -71,7 +71,6 @@ public:
     uint8_t req_opcode;         ///< Request opcode returned in kRspAck, kRspNak message
     uint8_t padding[2];         ///< 32 bit aligment padding
     uint32_t offset;            ///< Offsets for List and Read commands
-    uint8_t * data;              ///< command data, varies by Opcode
   };
 
   /// @brief Command opcodes
@@ -141,32 +140,32 @@ public:
 
   inline const uint8_t * data() const
   {
-    return header()->data;
+    return payload.data() + sizeof(PayloadHeader);
   }
 
   inline uint8_t * data()
   {
-    return header()->data;
+    return payload.data() + sizeof(PayloadHeader);
   }
 
   inline const char * data_c() const
   {
-    return reinterpret_cast<const char *>(header()->data);
+    return reinterpret_cast<const char *>(data());
   }
 
   inline char * data_c()
   {
-    return reinterpret_cast<char *>(header()->data);
+    return reinterpret_cast<char *>(data());
   }
 
   inline const uint32_t * data_u32() const
   {
-    return reinterpret_cast<const uint32_t *>(header()->data);
+    return reinterpret_cast<const uint32_t *>(data());
   }
 
   inline uint32_t * data_u32()
   {
-    return reinterpret_cast<uint32_t *>(header()->data);
+    return reinterpret_cast<uint32_t *>(data());
   }
 
   /**


### PR DESCRIPTION
df4e529 mistakenly switched `PayloadHeader::data` from using a non-standards compliant (but accepted by most compilers) flexible array to a pointer. This resulted in an attempt to dereference the uninitialized contents of the array.

This patch eliminates `PayloadHeader::data` and instead makes `FTPRequest::data()` use pointer arithmetic to get the data buffer from within the payload buffer.

This fixes the crash, but the plugin still doesn't work quite right, at least with ArduPilot. The only command I have been able to execute successfully is checksum.

Fixes #1695