### PR TITLE
Fix apm_pluginlist.yaml and apm.launch

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -18,7 +18,6 @@
 		<arg name="gcs_url" value="$(var gcs_url)" />
 		<arg name="tgt_system" value="$(var tgt_system)" />
 		<arg name="tgt_component" value="$(var tgt_component)" />
-		<arg name="log_output" value="$(var log_output)" />
 		<arg name="fcu_protocol" value="$(var fcu_protocol)" />
 		<arg name="respawn_mavros" value="$(var respawn_mavros)" />
 	</include>

--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -1,6 +1,6 @@
 /mavros:
   ros__parameters:
-    plugin_denylist:
+    plugin_blacklist:
       # common
       - actuator_control
       - ftp
@@ -14,5 +14,5 @@
       - vision_speed_estimate
       - wheel_odometry
 
-#    plugin_allowlist:
+#    plugin_whitelist:
 #      - 'sys_*'

--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -1,6 +1,6 @@
 /mavros:
   ros__parameters:
-    plugin_blacklist:
+    plugin_denylist:
       # common
       - actuator_control
       - ftp
@@ -14,6 +14,5 @@
       - vision_speed_estimate
       - wheel_odometry
 
-    plugin_whitelist:
-      []
-      # - 'sys_*'
+#    plugin_allowlist:
+#      - 'sys_*'

--- a/mavros/launch/node.launch
+++ b/mavros/launch/node.launch
@@ -12,7 +12,7 @@
 	<arg name="fcu_protocol" default="v2.0" />
 	<arg name="respawn_mavros" default="false" />
 
-	<node pkg="mavros" exec="mavros_node" namespace="mavros" output="$(var log_output)">
+	<node pkg="mavros" exec="mavros_node" namespace="mavros" output="screen">
 		<param name="fcu_url" value="$(var fcu_url)" />
 		<param name="gcs_url" value="$(var gcs_url)" />
 		<param name="target_system_id" value="$(var tgt_system)" />


### PR DESCRIPTION
If these changes are not made, there are several errors when trying to launch `apm.launch` . ROS2 Foxy.

1. error:
```
[ERROR] [mavros_node-1]: process has died [pid 59547, exit code -6, cmd '/home/dcs_user/ros2_ws/install/mavros/lib/mavros/mavros_node --ros-args -r __ns:=/mavros --params-file /tmp/launch_params_u3s_gn73 --params-file /tmp/launch_params_l0ol9u7q --params-file /tmp/launch_params_9v2uyjt4 --params-file /tmp/launch_params_p_qmy_03 --params-file /tmp/launch_params_pslty43k --params-file /home/dcs_user/ros2_ws/install/mavros/share/mavros/launch/apm_pluginlists.yaml --params-file /home/dcs_user/ros2_ws/install/mavros/share/mavros/launch/apm_config.yaml'].
```

2. error:
```
ValueError: $(var log_output) is not a valid standard output config i.e. "screen", "log" or "both"
```

EDIT: add info