### PR TITLE
Control TimeReference source

### DIFF
--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -345,15 +345,27 @@ private:
     if (fcu_time_valid) {
       // continious publish for ntpd
       auto time_unix = sensor_msgs::msg::TimeReference();
-      rclcpp::Time time_ref(
-        mtime.time_unix_usec / 1000000,                 // t_sec
-        (mtime.time_unix_usec % 1000000) * 1000);       // t_nsec
+      if (time_ref_source == "epoc")
+          {
+            // time_unix_usec: us
+            rclcpp::Time time_ref(
+                mtime.time_unix_usec / 1000000,           // t_sec
+                (mtime.time_unix_usec % 1000000) * 1000); // t_nsec
+            time_unix.time_ref = time_ref;
+          }
+          else
+          {
+            // time_unix_usec: ms
+            rclcpp::Time time_ref(
+                mtime.time_boot_ms / 1000,              // t_sec
+                (mtime.time_boot_ms % 1000) * 1000000); // t_nsec
+            time_unix.time_ref = time_ref;
+          }
+          time_unix.header.stamp = node->now();
+          time_unix.header.frame_id = "";
+          time_unix.source = time_ref_source;
 
-      time_unix.header.stamp = node->now();
-      time_unix.time_ref = time_ref;
-      time_unix.source = time_ref_source;
-
-      time_ref_pub->publish(time_unix);
+          time_ref_pub->publish(time_unix);
     } else {
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 60000, "TM: Wrong FCU time.");
     }


### PR DESCRIPTION
mavros/time_reference topic using SYSTEM_TIME (#2) mavlink message to return **time_unix_usec** as time_reference

SYSTEM_TIME has two fields
- time_unix_usec return epoc time (usec)
- time_boot_ms: time from boot (msec)

The current version return only the epoc time as time reference
I using the **time_ref_source** parameter to control witch field to use.
if the parameter set as "epoc" value it's return the time_unix_usec/epoc time otherwise it's return the boot time

We can add other parameter but I think the idea of the control option is important