### PR TITLE
Fix / suppress some build warnings

### DIFF
--- a/libmavconn/CMakeLists.txt
+++ b/libmavconn/CMakeLists.txt
@@ -35,6 +35,7 @@ catkin_package(
 
 include_directories(
   include
+  SYSTEM
   ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/include
   ${Boost_INCLUDE_DIRS}
   ${mavlink_INCLUDE_DIRS}

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -87,6 +87,7 @@ catkin_package(
 
 include_directories(
   include
+  SYSTEM
   ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
   ${mavlink_INCLUDE_DIRS}

--- a/mavros/include/mavros/mavlink_diag.h
+++ b/mavros/include/mavros/mavlink_diag.h
@@ -40,5 +40,5 @@ private:
 	unsigned int last_drop_count;
 	std::atomic<bool> is_connected;
 };
-};	// namespace mavros
+}	// namespace mavros
 

--- a/mavros/src/lib/mavlink_diag.cpp
+++ b/mavros/src/lib/mavlink_diag.cpp
@@ -19,7 +19,7 @@ MavlinkDiag::MavlinkDiag(std::string name) :
 	diagnostic_updater::DiagnosticTask(name),
 	last_drop_count(0),
 	is_connected(false)
-{ };
+{ }
 
 void MavlinkDiag::run(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -60,6 +60,7 @@ catkin_package(
 ###########
 
 include_directories(
+  SYSTEM
   ${catkin_INCLUDE_DIRS}
   ${mavlink_INCLUDE_DIRS}
 )

--- a/mavros_extras/src/plugins/landing_target.cpp
+++ b/mavros_extras/src/plugins/landing_target.cpp
@@ -40,18 +40,18 @@ class LandingTargetPlugin : public plugin::PluginBase,
 public:
 	LandingTargetPlugin() :
 		nh("~landing_target"),
-		tf_rate(10.0),
 		send_tf(true),
 		listen_tf(false),
+		tf_rate(10.0),
 		listen_lt(false),
-		mav_frame("LOCAL_NED"),
 		target_size_x(1.0),
 		target_size_y(1.0),
-		image_width(640),
-		image_height(480),
 		fov_x(2.0071286398),
 		fov_y(2.0071286398),
 		focal_length(2.8),
+		image_width(640),
+		image_height(480),
+		mav_frame("LOCAL_NED"),
 		land_target_type("VISION_FIDUCIAL")
 	{ }
 

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -166,8 +166,8 @@ class MountControlPlugin : public plugin::PluginBase {
 public:
 	MountControlPlugin() : PluginBase(),
 		nh("~"),
-		mount_diag("Mount"),
-		mount_nh("~mount_control")
+		mount_nh("~mount_control"),
+		mount_diag("Mount")
 	{ }
 
 	void initialize(UAS &uas_) override

--- a/mavros_extras/src/plugins/wheel_odometry.cpp
+++ b/mavros_extras/src/plugins/wheel_odometry.cpp
@@ -38,8 +38,8 @@ public:
 
 	WheelOdometryPlugin() : PluginBase(),
 		wo_nh("~wheel_odometry"),
-		count(0),
 		odom_mode(OM::NONE),
+		count(0),
 		raw_send(false),
 		twist_send(false),
 		tf_send(false),

--- a/test_mavros/CMakeLists.txt
+++ b/test_mavros/CMakeLists.txt
@@ -66,6 +66,7 @@ catkin_package(
 
 include_directories(
   include
+  SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}


### PR DESCRIPTION
Hi all, this does three things:

* Use the [cmake SYSTEM option](https://cmake.org/cmake/help/latest/command/include_directories.html) to have it consider 3rd party library headers as system headers, and thus not emit build warnings from them.
* Fix some build warnings in mavros_extras.
* Remove unneeded trailing semicolon on some namespace declarations.

Feel free to use this if it's useful for you.