### PR TITLE
Define parameters for the frame names of the static transforms

### DIFF
--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -570,6 +570,10 @@ private:
 
   std::string uas_url;
 
+  std::string base_link_frame_id;
+  std::string odom_frame_id;
+  std::string map_frame_id;
+
   StrV plugin_allowlist;
   StrV plugin_denylist;
 

--- a/mavros/src/mavros_node.cpp
+++ b/mavros/src/mavros_node.cpp
@@ -32,6 +32,7 @@ int main(int argc, char * argv[])
   // options.use_intra_process_comms(true);
 
   std::string fcu_url, gcs_url, uas_url;
+  std::string base_link_frame_id, odom_frame_id, map_frame_id;
   int tgt_system = 1, tgt_component = 1;
 
   auto node = std::make_shared<rclcpp::Node>("mavros_node", options);
@@ -41,11 +42,17 @@ int main(int argc, char * argv[])
   node->declare_parameter("gcs_url", gcs_url);
   node->declare_parameter("tgt_system", tgt_system);
   node->declare_parameter("tgt_component", tgt_component);
+  node->declare_parameter("base_link_frame_id", base_link_frame_id);
+  node->declare_parameter("map_frame_id", map_frame_id);
+  node->declare_parameter("odom_frame_id", odom_frame_id);
 
   node->get_parameter("fcu_url", fcu_url);
   node->get_parameter("gcs_url", gcs_url);
   node->get_parameter("tgt_system", tgt_system);
   node->get_parameter("tgt_component", tgt_component);
+  node->get_parameter("base_link_frame_id", base_link_frame_id);
+  node->get_parameter("map_frame_id", map_frame_id);
+  node->get_parameter("odom_frame_id", odom_frame_id);
 
   uas_url = mavros::utils::format("/uas%d", tgt_system);
 
@@ -77,6 +84,24 @@ int main(int argc, char * argv[])
     options, "mavros", uas_url, tgt_system,
     tgt_component);
   exec.add_node(uas_node);
+
+  {
+    std::vector<rclcpp::Parameter> uas_params{};
+
+    if (base_link_frame_id != "") {
+      uas_params.emplace_back("base_link_frame_id", base_link_frame_id);
+    }
+
+    if (odom_frame_id != "") {
+      uas_params.emplace_back("odom_frame_id", odom_frame_id);
+    }
+
+    if (map_frame_id != "") {
+      uas_params.emplace_back("map_frame_id", map_frame_id);
+    }
+    uas_node->set_parameters(uas_params);
+    
+  }
 
   exec.spin();
   rclcpp::shutdown();

--- a/mavros/src/mavros_node.cpp
+++ b/mavros/src/mavros_node.cpp
@@ -42,17 +42,17 @@ int main(int argc, char * argv[])
   node->declare_parameter("gcs_url", gcs_url);
   node->declare_parameter("tgt_system", tgt_system);
   node->declare_parameter("tgt_component", tgt_component);
-  node->declare_parameter("base_link_frame_id", base_link_frame_id);
-  node->declare_parameter("map_frame_id", map_frame_id);
-  node->declare_parameter("odom_frame_id", odom_frame_id);
+  node->declare_parameter("base_link_frame", base_link_frame_id);
+  node->declare_parameter("map_frame", map_frame_id);
+  node->declare_parameter("odom_frame", odom_frame_id);
 
   node->get_parameter("fcu_url", fcu_url);
   node->get_parameter("gcs_url", gcs_url);
   node->get_parameter("tgt_system", tgt_system);
   node->get_parameter("tgt_component", tgt_component);
-  node->get_parameter("base_link_frame_id", base_link_frame_id);
-  node->get_parameter("map_frame_id", map_frame_id);
-  node->get_parameter("odom_frame_id", odom_frame_id);
+  node->get_parameter("base_link_frame", base_link_frame_id);
+  node->get_parameter("map_frame", map_frame_id);
+  node->get_parameter("odom_frame", odom_frame_id);
 
   uas_url = mavros::utils::format("/uas%d", tgt_system);
 

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -144,8 +144,8 @@ private:
     Eigen::Affine3d tf_parent2parent_des;
     Eigen::Affine3d tf_child2child_des;
 
-    lookup_static_transform(fcu_odom_parent_id_des, "map_ned", tf_parent2parent_des);
-    lookup_static_transform(fcu_odom_child_id_des, "base_link_frd", tf_child2child_des);
+    lookup_static_transform(fcu_odom_parent_id_des, fcu_odom_parent_id_des+"_ned", tf_parent2parent_des);
+    lookup_static_transform(fcu_odom_child_id_des, fcu_odom_child_id_des+"_frd", tf_child2child_des);
 
     //! Build 6x6 pose covariance matrix to be transformed and sent
     Matrix6d cov_pose = Matrix6d::Zero();
@@ -235,8 +235,8 @@ private:
     Eigen::Affine3d tf_parent2parent_des;
     Eigen::Affine3d tf_child2child_des;
 
-    lookup_static_transform("odom_ned", odom->header.frame_id, tf_parent2parent_des);
-    lookup_static_transform("base_link_frd", odom->child_frame_id, tf_child2child_des);
+    lookup_static_transform(odom->header.frame_id+"_ned", odom->header.frame_id, tf_parent2parent_des);
+    lookup_static_transform(odom->child_frame_id+"_frd", odom->child_frame_id, tf_child2child_des);
 
     //! Build 6x6 pose covariance matrix to be transformed and sent
     ftf::Covariance6d cov_pose = odom->pose.covariance;


### PR DESCRIPTION
This PR solves the issue of duplicate (non unique) static transforms when mavros is used in multi-vehicle SITL setup.
Before this PR, it was not possible to have a proper TF tree where each vehicle has its unique base_link(base_link_frd and odom (odome_ned) frames as it was hard-coded in `mavros_uas` node. Also the `odom` plugin would keep throwing an error because of disconnected trees.

With this PR, the user can define the statice transform frames (base_link, odom, map) as node parameters of the `mavros_node` which is the passed to the `mavros_uas` node. In addition, the `odom` plugin is modified to infer the `_frd` frames directly from the odom/map base_link (or simply the parent and the child frames)m which are defined in the config.yaml file.

With this PR, I am able to have a proper and connected trees in multi-vehicle simulation.