### PR TITLE
Add support for EVENT messages 

### DIFF
--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -785,7 +785,7 @@ private:
       case enum_value(MAV_SEVERITY::DEBUG):
         RCLCPP_DEBUG_STREAM(node->get_logger(), "FCU: EVENT " << px4_id << " with args " << arg_str);
         break;
-      // [[[end]]] (checksum: d05760afbeece46673c8f73f89b63f3d)
+      // [[[end]]] (checksum: 83f5eab6a8989f95de46d2a95387304c)
       default:
         RCLCPP_WARN_STREAM(node->get_logger(), "FCU: UNK(" << +severity << "): EVENT " << px4_id << " with args " << arg_str);
         break;

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1010,8 +1010,7 @@ private:
     process_event_normal(severity, px4_id, eventm.arguments);
 
     auto evt_msg = mavros_msgs::msg::StatusEvent();
-    evt_msg.header.stamp.sec = event_time_boot_ms / 1000;
-    evt_msg.header.stamp.nanosec = (event_time_boot_ms % 1000) * 1000000;
+    evt_msg.header.stamp = uas->synchronise_stamp(event_time_boot_ms);
     evt_msg.severity = severity;
     evt_msg.px4_id = px4_id;
     evt_msg.arguments = eventm.arguments;

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1010,10 +1010,10 @@ private:
     process_event_normal(severity, px4_id, eventm.arguments);
 
     auto evt_msg = mavros_msgs::msg::StatusEvent();
-    evt_msg.header.stamp = node->now();
+    evt_msg.header.stamp.sec = event_time_boot_ms / 1000;
+    evt_msg.header.stamp.nanosec = (event_time_boot_ms % 1000) * 1000000;
     evt_msg.severity = severity;
     evt_msg.px4_id = px4_id;
-    evt_msg.event_time_boot_ms = eventm.event_time_boot_ms;
     evt_msg.arguments = eventm.arguments;
     evt_msg.sequence = eventm.sequence;
 

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -97,7 +97,7 @@ set(msg_files
   msg/WaypointList.msg
   msg/WaypointReached.msg
   msg/WheelOdomStamped.msg
-  # [[[end]]] (checksum: 85146eea3330278f18b4434a23e257f0)
+  # [[[end]]] (checksum: d43b903630fd3ce3856c8484a2d1b709)
 )
 
 set(srv_files

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -83,6 +83,7 @@ set(msg_files
   msg/RTKBaseline.msg
   msg/RadioStatus.msg
   msg/State.msg
+  msg/StatusEvent.msg
   msg/StatusText.msg
   msg/TerrainReport.msg
   msg/Thrust.msg

--- a/mavros_msgs/msg/StatusEvent.msg
+++ b/mavros_msgs/msg/StatusEvent.msg
@@ -15,6 +15,5 @@ uint8 DEBUG = 7
 std_msgs/Header header
 uint8 severity
 uint32 px4_id
-uint32 event_time_boot_ms
 uint8[40] arguments
 uint16 sequence

--- a/mavros_msgs/msg/StatusEvent.msg
+++ b/mavros_msgs/msg/StatusEvent.msg
@@ -1,0 +1,20 @@
+# EVENT message representation
+# https://mavlink.io/en/messages/common.html#EVENT
+
+# Severity levels
+uint8 EMERGENCY = 0
+uint8 ALERT = 1
+uint8 CRITICAL = 2
+uint8 ERROR = 3
+uint8 WARNING = 4
+uint8 NOTICE = 5
+uint8 INFO = 6
+uint8 DEBUG = 7
+
+# Fields
+std_msgs/Header header
+uint8 severity
+uint32 px4_id
+uint32 event_time_boot_ms
+uint8[40] arguments
+uint16 sequence


### PR DESCRIPTION
Hello all, working with PX4 we are starting to use EVENT instead of STATUS_TEXT for more details over the status of the autopilot. For this we needed to have the EVENT messages bridged to ROS2. This is my implementation, taking input from other people to have it merged in upstream mavros