### PR TITLE
[camera plugin] Fix image_index and capture_result not properly filled

### DIFF
--- a/mavros_extras/src/plugins/camera.cpp
+++ b/mavros_extras/src/plugins/camera.cpp
@@ -76,6 +76,8 @@ private:
 		ic->relative_alt = mo.relative_alt / 1E3;
 		auto q = ftf::mavlink_to_quaternion(mo.q);
 		tf::quaternionEigenToMsg(q, ic->orientation);
+		ic->image_index = mo.image_index;
+		ic->capture_result = mo.capture_result;
 		ic->file_url = mavlink::to_string(mo.file_url);
 
 		camera_image_captured_pub.publish(ic);


### PR DESCRIPTION
## Problem Solved
Both `image_index` and `capture_result` fields of the `mavros_msgs::CameraImageCaptured` were left unassigned.

## Proposed Solution
Assign the proper values to them according to the `CAMERA_IMAGE_CAPTURED` message