### PR TITLE
gps_global_origin: remove LLA to ECEF conversion

### DIFF
--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -233,22 +233,7 @@ private:
 		g_origin->position.longitude = glob_orig.longitude / 1E7;
 		g_origin->position.altitude = glob_orig.altitude / 1E3 + m_uas->geoid_to_ellipsoid_height(&g_origin->position);	// convert height amsl to height above the ellipsoid
 
-		try {
-			/**
-			 * @brief Conversion from geodetic coordinates (LLA) to ECEF (Earth-Centered, Earth-Fixed)
-			 * Note: "earth" frame, in ECEF, of the global origin
-			 */
-			GeographicLib::Geocentric earth(GeographicLib::Constants::WGS84_a(),
-				GeographicLib::Constants::WGS84_f());
-
-			earth.Forward(g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude,
-				g_origin->position.latitude, g_origin->position.longitude, g_origin->position.altitude);
-
-			gp_global_origin_pub.publish(g_origin);
-		}
-		catch (const std::exception& e) {
-			ROS_INFO_STREAM("GP: Caught exception: " << e.what() << std::endl);
-		}
+		gp_global_origin_pub.publish(g_origin);
 	}
 
 	/** @todo Handler for GLOBAL_POSITION_INT_COV */


### PR DESCRIPTION
GPS_GLOBAL_ORIGIN MAVLink message is published in ROS on the topic `mavros/global_position/gp_origin` with type [geographic_msgs::GeoPointStamped](https://docs.ros.org/en/api/geographic_msgs/html/msg/GeoPointStamped.html).
This message contains https://docs.ros.org/en/api/geographic_msgs/html/msg/GeoPoint.html and expects
> Geographic point, using the WGS 84 reference ellipsoid.

However the messages are published in ECEF coordinates.

This PR removes such conversion matching message requirements and message contents.

FIX https://github.com/mavlink/mavros/issues/1381