### PR TITLE
Bug fixes in translating from Mavlink to ROS-Mavlink

### DIFF
--- a/mavros/mavros/mavlink.py
+++ b/mavros/mavros/mavlink.py
@@ -127,7 +127,7 @@ def convert_to_rosmsg(
             msgid=hdr.msgId,
             checksum=mavmsg.get_crc(),
             payload64=convert_to_payload64(mavmsg.get_payload()),
-            signature=[],
+            signature=[],  # FIXME #569
         )
 
     else:

--- a/mavros/mavros/mavlink.py
+++ b/mavros/mavros/mavlink.py
@@ -121,12 +121,13 @@ def convert_to_rosmsg(
             len=hdr.mlen,
             incompat_flags=hdr.incompat_flags,
             compat_flags=hdr.compat_flags,
+            seq=mavmsg.get_seq(),
             sysid=hdr.srcSystem,
             compid=hdr.srcComponent,
             msgid=hdr.msgId,
             checksum=mavmsg.get_crc(),
             payload64=convert_to_payload64(mavmsg.get_payload()),
-            signature=None,  # FIXME #569
+            signature=[],
         )
 
     else:


### PR DESCRIPTION
The None in the signing field (bug #569) made the code throw exceptions while decoding. There is still no signing support, but the empty array is working better than the None value. Fixed another bug in the building of the ROS Mavlink message- the seq field was not added to the ROS Mavlink message, causing a CRC error while decoding the message.