### PR TITLE
Fix compile error when compiling with gcc 13

### DIFF
--- a/mavros_extras/src/plugins/mag_calibration_status.cpp
+++ b/mavros_extras/src/plugins/mag_calibration_status.cpp
@@ -11,6 +11,8 @@
 #include <mavros/mavros_plugin.h>
 #include <std_msgs/UInt8.h>
 #include <mavros_msgs/MagnetometerReporter.h>
+#include <bitset>
+
 namespace mavros {
 namespace std_plugins {
 /**


### PR DESCRIPTION
The error is:

    src/plugins/mag_calibration_status.cpp:64:22: error: ‘bitset’ is not a member of ‘std’