### PR TITLE
Add parameters for frame_id of static transforms for multi-vehicle systems

### DIFF
--- a/mavros/include/mavros/mavros_uas.h
+++ b/mavros/include/mavros/mavros_uas.h
@@ -444,6 +444,26 @@ public:
 	 */
 	bool cmode_from_str(std::string cmode_str, uint32_t &custom_mode);
 
+	inline void set_base_link_frame_id(const std::string frame_id) {
+		base_link_frame_id = frame_id;
+	}
+	inline void set_odom_frame_id(const std::string frame_id) {
+		odom_frame_id = frame_id;
+	}
+	inline void set_map_frame_id(const std::string frame_id) {
+		map_frame_id = frame_id;
+	}
+	inline std::string get_base_link_frame_id() {
+		return base_link_frame_id;
+	}
+	inline std::string get_odom_frame_id() {
+		return odom_frame_id;
+	}
+	inline std::string get_map_frame_id() {
+		return map_frame_id;
+	}
+	void setup_static_tf();
+
 private:
 	std::recursive_mutex mutex;
 
@@ -472,5 +492,7 @@ private:
 
 	std::atomic<bool> fcu_caps_known;
 	std::atomic<uint64_t> fcu_capabilities;
+
+	std::string base_link_frame_id, odom_frame_id, map_frame_id;
 };
 }	// namespace mavros

--- a/mavros/launch/px4_config.yaml
+++ b/mavros/launch/px4_config.yaml
@@ -231,8 +231,9 @@ mount:
 # odom
 odometry:
   fcu:
-    odom_parent_id_des: "map"    # desired parent frame rotation of the FCU's odometry
+    odom_parent_id_des: "odom"        # desired parent frame rotation of the FCU's odometry
     odom_child_id_des: "base_link"    # desired child frame rotation of the FCU's odometry
+    map_id_des: "map"
 
 # px4flow
 px4flow:

--- a/mavros/src/lib/mavros.cpp
+++ b/mavros/src/lib/mavros.cpp
@@ -64,6 +64,19 @@ MavRos::MavRos() :
 	nh.getParam("plugin_blacklist", plugin_blacklist);
 	nh.getParam("plugin_whitelist", plugin_whitelist);
 
+	// Get frame_id
+	std::string base_link_frame_id, odom_frame_id, map_frame_id;
+	if (nh.param<std::string>("base_link_frame_id", base_link_frame_id, "base_link"))
+		ROS_INFO("Find param base_link_frame_id: %s", base_link_frame_id.c_str());
+	if (nh.param<std::string>("odom_frame_id", odom_frame_id, "odom"))
+		ROS_INFO("Find param odom_frame_id: %s", odom_frame_id.c_str());
+	if (nh.param<std::string>("map_frame_id", map_frame_id, "map"))
+		ROS_INFO("Find param map_frame_id: %s", map_frame_id.c_str());
+	mav_uas.set_base_link_frame_id(base_link_frame_id);
+	mav_uas.set_odom_frame_id(odom_frame_id);
+	mav_uas.set_map_frame_id(map_frame_id);
+	mav_uas.setup_static_tf();
+
 	conn_timeout = ros::Duration(conn_timeout_d);
 
 	// Now we use FCU URL as a hardware Id

--- a/mavros/src/lib/uas_data.cpp
+++ b/mavros/src/lib/uas_data.cpp
@@ -36,7 +36,10 @@ UAS::UAS() :
 	time_offset(0),
 	tsync_mode(UAS::timesync_mode::NONE),
 	fcu_caps_known(false),
-	fcu_capabilities(0)
+	fcu_capabilities(0),
+	base_link_frame_id("base_link"),
+	odom_frame_id("odom"),
+	map_frame_id("map")
 {
 	try {
 		// Using smallest dataset with 5' grid,
@@ -50,14 +53,6 @@ UAS::UAS() :
 				" | Run install_geographiclib_dataset.sh script in order to install Geoid Model dataset!");
 		ros::shutdown();
 	}
-
-	// Publish helper TFs used for frame transformation in the odometry plugin
-	std::vector<geometry_msgs::TransformStamped> transform_vector;
-	add_static_transform("map", "map_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transform_vector);
-	add_static_transform("odom", "odom_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transform_vector);
-	add_static_transform("base_link", "base_link_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),transform_vector);
-
-	tf2_static_broadcaster.sendTransform(transform_vector);
 }
 
 /* -*- heartbeat handlers -*- */
@@ -274,4 +269,14 @@ void UAS::publish_static_transform(const std::string &frame_id, const std::strin
 	tf::transformEigenToMsg(tr, static_transformStamped.transform);
 
 	tf2_static_broadcaster.sendTransform(static_transformStamped);
+}
+
+//! Publish helper TFs used for frame transformation in the odometry plugin
+void UAS::setup_static_tf()
+{
+	std::vector<geometry_msgs::TransformStamped> transform_vector;
+	add_static_transform(map_frame_id, map_frame_id+"_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transform_vector);
+	add_static_transform(odom_frame_id, odom_frame_id+"_ned", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),transform_vector);
+	add_static_transform(base_link_frame_id, base_link_frame_id+"_frd", Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),transform_vector);
+	tf2_static_broadcaster.sendTransform(transform_vector);
 }

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -57,9 +57,9 @@ public:
 		PluginBase::initialize(uas_);
 
 		// frame params:
-		odom_nh.param<std::string>("fcu/odom_parent_id_des", fcu_map_id_des, uas_.get_map_frame_id());
+		odom_nh.param<std::string>("fcu/odom_parent_id_des", fcu_odom_parent_id_des, uas_.get_odom_frame_id());
 		odom_nh.param<std::string>("fcu/odom_child_id_des", fcu_odom_child_id_des, uas_.get_base_link_frame_id());
-		fcu_odom_parent_id_des = uas_.get_odom_frame_id();
+		odom_nh.param<std::string>("fcu/map_id_des", fcu_map_id_des, uas_.get_map_frame_id());
 
 		// publishers
 		odom_pub = odom_nh.advertise<nav_msgs::Odometry>("in", 10);

--- a/mavros_extras/src/plugins/wheel_odometry.cpp
+++ b/mavros_extras/src/plugins/wheel_odometry.cpp
@@ -69,14 +69,14 @@ public:
 
 		// Odometry params
 		wo_nh.param("send_twist", twist_send, false);
-		wo_nh.param<std::string>("frame_id", frame_id, "odom");
-		wo_nh.param<std::string>("child_frame_id", child_frame_id, "base_link");
+		wo_nh.param<std::string>("frame_id", frame_id, uas_.get_odom_frame_id());
+		wo_nh.param<std::string>("child_frame_id", child_frame_id, uas_.get_base_link_frame_id());
 		wo_nh.param("vel_error", vel_cov, 0.1);
 		vel_cov = vel_cov * vel_cov;	// std -> cov
 		// TF subsection
 		wo_nh.param("tf/send", tf_send, false);
-		wo_nh.param<std::string>("tf/frame_id", tf_frame_id, "odom");
-		wo_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, "base_link");
+		wo_nh.param<std::string>("tf/frame_id", tf_frame_id, uas_.get_odom_frame_id());
+		wo_nh.param<std::string>("tf/child_frame_id", tf_child_frame_id, uas_.get_base_link_frame_id());
 
 		// Read parameters for each wheel.
 		{


### PR DESCRIPTION
Similar to [another PR at branch-ros2](https://github.com/mavlink/mavros/pull/1909), this PR solves the problem of static transforms namespace conflicts in multi-vehicle systems by adding parameters. Also dealt with a similar issue with the `lookup_static_transform` function in the odometry plugin.

Users can modify the `frame_id` by adding the following parameter to the launch file :

```xml
<param name="base_link_frame_id" value="$(arg base_link_frame_id)" />
<param name="odom_frame_id" value="$(arg odom_frame_id)" />
<param name="map_frame_id" value="$(arg map_frame_id)" />
```

While changing the launch file also change the corresponding `frame_id` section in the `px4_config.yaml` file :

```yaml
# odom example
odometry:
  fcu:  # change frame_id to vehicle_0/...
    map_id_des: "vehicle_0/map"    # desired parent frame rotation of the FCU's odometry
    odom_child_id_des: "vehicle_0/base_link"    # desired child frame rotation of the FCU's odometry
    odom_parent_id_des: "vehicle_0/odom"
```
