### PR TITLE
Add missing std_srvs dependency

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   std_msgs
+  std_srvs
   tf
   tf2_eigen
   urdf

--- a/mavros_extras/package.xml
+++ b/mavros_extras/package.xml
@@ -26,6 +26,7 @@
   <depend>mavros_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>visualization_msgs</depend>
   <depend>urdf</depend>
   <depend>tf</depend>


### PR DESCRIPTION
Solves std_srvs/Trigger.h not found when compiling log_transfer.cpp.