### PR TITLE
fix depcrecation errors

### DIFF
--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -161,7 +161,7 @@ public:
   inline double geoid_to_ellipsoid_height(const T lla)
   {
     if (egm96_5) {
-      return GeographicLib::Geoid::GEOIDTOELLIPSOID * (*egm96_5)(lla->latitude, lla->longitude);
+      return int(GeographicLib::Geoid::GEOIDTOELLIPSOID) * (*egm96_5)(lla->latitude, lla->longitude);
     } else {
       return 0.0;
     }
@@ -181,7 +181,7 @@ public:
   inline double ellipsoid_to_geoid_height(const T lla)
   {
     if (egm96_5) {
-      return GeographicLib::Geoid::ELLIPSOIDTOGEOID * (*egm96_5)(lla->latitude, lla->longitude);
+      return int(GeographicLib::Geoid::ELLIPSOIDTOGEOID) * (*egm96_5)(lla->latitude, lla->longitude);
     } else {
       return 0.0;
     }

--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -161,7 +161,7 @@ public:
   inline double geoid_to_ellipsoid_height(const T lla)
   {
     if (egm96_5) {
-      return int(GeographicLib::Geoid::GEOIDTOELLIPSOID) * (*egm96_5)(lla->latitude, lla->longitude);
+      return egm96_5->ConvertHeight(lla->latitude, lla->longitude, 0.0, GeographicLib::Geoid::GEOIDTOELLIPSOID);
     } else {
       return 0.0;
     }
@@ -181,7 +181,7 @@ public:
   inline double ellipsoid_to_geoid_height(const T lla)
   {
     if (egm96_5) {
-      return int(GeographicLib::Geoid::ELLIPSOIDTOGEOID) * (*egm96_5)(lla->latitude, lla->longitude);
+      return egm96_5->ConvertHeight(lla->latitude, lla->longitude, 0.0, GeographicLib::Geoid::ELLIPSOIDTOGEOID);
     } else {
       return 0.0;
     }

--- a/mavros/setup.cfg
+++ b/mavros/setup.cfg
@@ -3,7 +3,7 @@ name = 'mavros'
 description = 'Helper scripts and module for MAVROS'
 license = 'Triple licensed under GPLv3, LGPLv3 and BSD'
 author = 'Vladimir Ermakov'
-author-email = 'vooon341@gmail.com'
+author_email = 'vooon341@gmail.com'
 maintainer = 'Vladimir Ermakov'
 maintainer_email = 'vooon341@gmail.com'
 keywords = 'ROS'
@@ -21,10 +21,10 @@ console_scripts =
     mav=mavros.cmd:cli
 
 [develop]
-script-dir=$base/lib/mavros
+script_dir=$base/lib/mavros
 
 [install]
-install-scripts=$base/lib/mavros
+install_scripts=$base/lib/mavros
 
 [yapf]
 blank_line_before_nested_class_or_def = True


### PR DESCRIPTION
Building mavros (ubuntu 22.04 ros2 humble) fails due to deprecation warnings treated as errors.