### PR TITLE
Resolve build error when linking yaml-cpp

### DIFF
--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -131,7 +131,6 @@ add_library(mavros_extras_plugins SHARED
   src/plugins/wheel_odometry.cpp
   # [[[end]]] (checksum: 1f8cd51fa90b89b27ee35d276b5f8c83)
 )
-target_link_libraries(mavros_extras_plugins yaml-cpp::yaml-cpp)
 ament_target_dependencies(mavros_extras_plugins
   angles
   geometry_msgs
@@ -164,7 +163,6 @@ add_library(mavros_extras SHARED
   src/lib/servo_state_publisher.cpp
   # [[[end]]] (checksum: a3ce43c71c567f697861bcbcd0f25aa3)
 )
-target_link_libraries(mavros_extras yaml-cpp::yaml-cpp)
 ament_target_dependencies(mavros_extras
   rclcpp
   rclcpp_components

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -32,7 +32,6 @@ find_package(libmavconn REQUIRED)
 
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
-# find_package(yaml_cpp REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
 ## Find GeographicLib
@@ -175,6 +174,13 @@ ament_target_dependencies(mavros_extras
   urdf
 )
 rclcpp_components_register_node(mavros_extras PLUGIN "mavros::extras::ServoStatePublisher" EXECUTABLE servo_state_publisher)
+
+# yaml-cpp is required for Jazzy and newer
+if (rclcpp_VERSION VERSION_GREATER_EQUAL 22.0.0)
+  find_package(yaml-cpp REQUIRED)
+  target_link_libraries(mavros_extras_plugins yaml-cpp::yaml-cpp)
+  target_link_libraries(mavros_extras yaml-cpp::yaml-cpp)
+endif()
 
 install(TARGETS mavros_extras mavros_extras_plugins
   EXPORT export_${PROJECT_NAME}


### PR DESCRIPTION
This PR addresses the pre-Jazzy build error introduced in #1988, where `yaml-cpp` cannot be found. I've done some testing to verify that things build and run as expected using ROS 2 Humble, Iron, Jazzy, and Rolling.

- Fixes #1989