### PR TITLE
Update build list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ CI Statuses
 
   - ROS2 Humble: [![Build Status](https://build.ros2.org/job/Hdev__mavros__ubuntu_jammy_amd64/badge/icon)](https://build.ros2.org/job/Hdev__mavros__ubuntu_jammy_amd64/)
   - ROS2 Iron: [![Build Status](https://build.ros2.org/job/Idev__mavros__ubuntu_jammy_amd64/badge/icon)](https://build.ros2.org/job/Idev__mavros__ubuntu_jammy_amd64/)
-  - ROS2 Rolling: [![Build Status](https://build.ros2.org/job/Rdev__mavros__ubuntu_jammy_amd64/badge/icon)](https://build.ros2.org/job/Rdev__mavros__ubuntu_jammy_amd64/)
+  - ROS2 Jazzy: [![Build Status](https://build.ros2.org/job/Jdev__mavros__ubuntu_jammy_amd64/badge/icon)](https://build.ros2.org/job/Jdev__mavros__ubuntu_noble_amd64/)
+  - ROS2 Rolling: [![Build Status](https://build.ros2.org/job/Rdev__mavros__ubuntu_jammy_amd64/badge/icon)](https://build.ros2.org/job/Rdev__mavros__ubuntu_noble_amd64/)
 
 
 [mrrm]: https://github.com/mavlink/mavros/blob/master/mavros/README.md


### PR DESCRIPTION
As promised, here is the updated README, which includes the build statuses for the latest Jazzy and Rolling releases. It doesn't appear as though the badges are available for these releases yet, but folks should still be able to determine that the binaries are available.

(marking these two issues as fixed - I can remove these if you'd prefer to manually close them)
- Fixes #1960
- Fixes #1958