### PR TITLE
Fix 3x3 covariance matrix rotation/transformation

### DIFF
--- a/mavros/src/lib/ftf_frame_conversions.cpp
+++ b/mavros/src/lib/ftf_frame_conversions.cpp
@@ -132,7 +132,7 @@ Covariance3d transform_static_frame(const Covariance3d & cov, const StaticTF tra
 
     case StaticTF::AIRCRAFT_TO_BASELINK:
     case StaticTF::BASELINK_TO_AIRCRAFT:
-      cov_out = cov_in * AIRCRAFT_BASELINK_Q;
+      cov_out = AIRCRAFT_BASELINK_Q * cov_in * AIRCRAFT_BASELINK_Q.conjugate();
       return cov_out_;
 
     default:
@@ -279,7 +279,7 @@ Covariance3d transform_frame(const Covariance3d & cov, const Eigen::Quaterniond 
   EigenMapConstCovariance3d cov_in(cov.data());
   EigenMapCovariance3d cov_out(cov_out_.data());
 
-  cov_out = cov_in * q;
+  cov_out = q * cov_in * q.conjugate();
   return cov_out_;
 }
 


### PR DESCRIPTION
The template specializations of `transform_static_frame()` and `transform_frame()` for the type `Covariance3d` improperly rotate the covariance matrix.

# Implementation details

**Old (broken) implementation**

The old implementation is wrong and returns an ill-conditioned covariance matrix, breaking symmetry and positive-semi-definitiveness.

Taking for example the following covariance matrix `P`  and quaternion `q`:
```
    | 0.1 0.2 0.3 |
P = | 0.2 0.4 0.5 |
    | 0.3 0.5 0.6 |

q = 1i + 0j + 0k + 0  # 180deg around X
```
The old implementation would return the matrix `P'`:
```
                        | 0.1 -0.2 -0.3 |
P' = P * q = P * R(q) = | 0.2 -0.4 -0.5 |
                        | 0.3 -0.5 -0.6 |
```
which is clearly invalid (asymmetric and negative).

**New (proper) implementation**

The new implementation correctly rotates the 3x3 covariance matrix by left- and right-multiplying by the rotation quaternion (as done for the 6x6 and 9x9 cases):
```
                                                 |  0.1 -0.2 -0.3 |
P' = q * P * q.conjugate() = R(q) * P * R(q).T = | -0.2  0.4  0.5 |
                                                 | -0.3  0.5  0.6 |
```
which is a valid covariance matrix.

# Useful resources

GodBolt example: [link](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxCCSZqQADqgKhE4MHt6%2BekkpjgJBIeEsUTFxtpj2eQxCBEzEBBk%2BflzllWk1dQQFYZHRsfEKtfWNWS2Dnd1FJf0AlLaoXsTI7BzmAMzByN5YANQma27YeMCMAPQAIoxK%2B9gmGgCC65vbmHsHToPEmKw3d49mGwYWy8u32bmQLCYBAQvwefwAbqg8OgdgliMECAB9NDwzHBfgQNAMQY7I4nPwgACyUPRqgAGuhzAA2HY40isgQk5AIOoAKh2zDYMz2AHYrA8dpKdoN0CAUAsCG83GC9mYzABaTVa7U63V6rXmMxKlUyuWuWh/KVW40HAWsV5glWGkCGm1uaUEWUgc1ujnw32m70MdAWiXWyWO22Bn2R92BiKoTxiBI8vZh8Ox1VmG47IQATxYbAI6OQICzvsJqH9%2B3ONb9ADpi4YFDlMBAZsLM9Hg6H7uGIwcnWqc8pkql4a98ExgAIxGXXZnK/D61OZ8xaO36yxgh5MFQqO23rc1ucdhp6xpO4Oo56zT3Lf3Y4b9S/X9qF9e47egyH9uLHiKtZwg8GI7JCwQQKBdTAMg7Lcny/LQfCnZin8D6SkSJJkowcoAGqYA4JBrCixAJHmbyniYYqUpiygAJLsueGiMReVG1ms/5WkwXhEDsACOFGkscOEgAAil4ULRAwaToBA6H9pK2EUvcRj0Pcqh4AosmkXm9YAF7tuySl4QRRDEMRcpyNJBAAFrtsKvJoRoACcdyuS5xkgCpwBqRpWkQDp9Z5oZQnkiZhHmV6VmEAAmvZOyOcB7nJZ53m%2BZp2lkfWqghZ5%2BERRZIDRQQdL2fJMx/vJpynDsyjooIOzEKgtRVPxEkEFJaTyYGaA8b6hp8S6aoBt%2BMafvxI1eualXpmmfZSp51LFngqjEbVM3zZKyi%2Bme9YtLt8S7Ws7LyeG56Hee0i7QArKQp3Wuex03SxTIbVVNV1aBUT8F8jXNVCaQKPJaIYtiVZ4gwBLKCdarKIaFUcU5m07NVOwAEr/R1fp1HghjLGBNIrXNXE8agtWYk1WIREwKJ1tt/J8X%2BKM1QAKggmk7MW3wEAotU7EwvNMH9LVpATy2qDs6o5mgLCtrz0KvJTAOcvJ3G8coFPNZiM4YIJAn8vT/H1kS2heMAkntkzqNsxzSsdfLCCvNtkLi0jVog4IYO4viqAQBrlOYtT6Aw2Y/ta0H8Mbe79VYjiENQ5rWI68HWZh0niaMmqCOcVK8lfAQiwMGeb2AX8HBzLQnDXbwfjcLwqCcMqljWNKCxLA6AI8KQBCaOXcwANaxGs9ZrNdGjXVwaxMpIGgigAHBoc9z/onCSDXvekA3HC8AoIDMT3HBaHMcCwEgMsJHQ0TkJQ5%2BXzEwBSPENC0B1xC7xAEQbxEwR1HmnBd9/ZgxA8wAHkIjaFMhvGWbBBAgIYLQP%2Bh9eBYAiGbNwYhaC7zrqQLAkJVIrC7vgL4Dg8ATiwVoUgmBVAER4isChGIKj/14LQPAERiC/w8FgDey0WBMNIBOYgCYlCXDwT5YIoAkFzCoAYYAChcJ4EwAAdxAQkHC2D%2BCCBEGIdgUgZCCEUCodQSDSC6BaAYIwKBrDWH0Kw3esBBTsEwMJBg/C%2BgcDWDPPum8EhVCwfXAR6IsB2MMnYUyaQXDBhGM0ShwZJi9BiC0HIqQBBROyGOKocTih9DGBUMJAgOjDE8E0PQoSSH5KGF0YIPQskJNsBU1JYwKmZOmFwOYCg27LAkBXKu69jFbx2KoOeTJ1TTx2DBZAOwpD1iNBAXAhASCqjWK03gB8j4DxAGqeszk56SBnh4tYGgZ4z2utISuHA16kFrhQreO897d17sfGAiAQAKgSDxa%2BlZZZ31CPaTgdQWDwjnuqIWWxDDAEmZIC8F5eCYHwGZZEegNHCFEOIXRSKDFqA3qY0gij2EJCYd0jg1dLkby3iAnibzFSoCoAMoZIzJBjOQBMqZMyPBfPoMQRZyz7mSPWWsYeTImRjznmYZyZgl5cDHkyFe5zenXM4Lc/eDzCVmDlfXBVPK1muLfuEyQQA%3D%3D%3D)

Covariance matrix rotation derivation: https://robotics.stackexchange.com/questions/2556/how-to-rotate-covariance

_Edit: Updated GodBolt link to use un-shortened version for posterity_