### PR TITLE
Fix: Corrected compass calibration result report to match mavlink doc…

### DIFF
--- a/mavros_extras/src/plugins/mag_calibration_status.cpp
+++ b/mavros_extras/src/plugins/mag_calibration_status.cpp
@@ -106,7 +106,7 @@ private:
       auto mcr = mavros_msgs::msg::MagnetometerReporter();
       mcr.header.stamp = node->now();
       mcr.header.frame_id = std::to_string(mr.compass_id);
-      
+
       mcr.report = mr.cal_status;
       mcr.confidence = mr.orientation_confidence;
       mcr.compass_id = mr.compass_id;
@@ -127,9 +127,9 @@ private:
       mcr.old_orientation = mr.old_orientation;
       mcr.new_orientation = mr.new_orientation;
       mcr.scale_factor = mr.scale_factor;
-	
-	  mcr_pub->publish(mcr);
-	  calibration_show[mr.compass_id] = false;
+
+      mcr_pub->publish(mcr);
+      calibration_show[mr.compass_id] = false;
     }
   }
 };

--- a/mavros_extras/src/plugins/mag_calibration_status.cpp
+++ b/mavros_extras/src/plugins/mag_calibration_status.cpp
@@ -104,14 +104,32 @@ private:
     }
     if (calibration_show[mr.compass_id]) {
       auto mcr = mavros_msgs::msg::MagnetometerReporter();
-
       mcr.header.stamp = node->now();
       mcr.header.frame_id = std::to_string(mr.compass_id);
+      
       mcr.report = mr.cal_status;
       mcr.confidence = mr.orientation_confidence;
-
-      mcr_pub->publish(mcr);
-      calibration_show[mr.compass_id] = false;
+      mcr.compass_id = mr.compass_id;
+      mcr.cal_mask = mr.cal_mask;
+      mcr.cal_status = mr.cal_status;
+      mcr.autosaved = mr.autosaved;
+      mcr.fitness = mr.fitness;
+      mcr.ofs_x = mr.ofs_x;
+      mcr.ofs_y = mr.ofs_y;
+      mcr.ofs_z = mr.ofs_z;
+      mcr.diag_x = mr.diag_x;
+      mcr.diag_y = mr.diag_y;
+      mcr.diag_z = mr.diag_z;
+      mcr.offdiag_x = mr.offdiag_x;
+      mcr.offdiag_y = mr.offdiag_y;
+      mcr.offdiag_z = mr.offdiag_z;
+      mcr.orientation_confidence = mr.orientation_confidence;
+      mcr.old_orientation = mr.old_orientation;
+      mcr.new_orientation = mr.new_orientation;
+      mcr.scale_factor = mr.scale_factor;
+	
+	  mcr_pub->publish(mcr);
+	  calibration_show[mr.compass_id] = false;
     }
   }
 };

--- a/mavros_msgs/msg/MagnetometerReporter.msg
+++ b/mavros_msgs/msg/MagnetometerReporter.msg
@@ -2,3 +2,22 @@ std_msgs/Header header
 
 uint8 report
 float32 confidence
+uint8 compass_id
+uint8 cal_mask
+uint8 cal_status
+uint8 autosaved
+float32 fitness
+float32 ofs_x
+float32 ofs_y
+float32 ofs_z
+float32 diag_x
+float32 diag_y
+float32 diag_z
+float32 offdiag_x
+float32 offdiag_y
+float32 offdiag_z
+float32 orientation_confidence
+uint8 old_orientation
+uint8 new_orientation
+float32 scale_factor
+


### PR DESCRIPTION
## Summary

Improves parsing and publishing of **MAG_CAL_REPORT** (MAVLink message ID 192) in the `mag_calibration` plugin.  
This update aligns the `MagnetometerReporter.msg` structure with the official MAVLink documentation and ensures complete and accurate calibration report transmission via ROS 2 topic.

## Details

- Updated `MagnetometerReporter.msg` to include all fields defined in [MAG_CAL_REPORT](https://mavlink.io/en/messages/common.html#MAG_CAL_REPORT), such as:
  - `fitness` (calibration quality metric)
  - Offset: `ofs_x`, `ofs_y`, `ofs_z`
  - Diagonal: `diag_x`, `diag_y`, `diag_z`
  - Off-diagonal: `offdiag_x`, `offdiag_y`, `offdiag_z`
  - `orientation_confidence`, `old_orientation`, `new_orientation`
  - `scale_factor`, `report`, `autosaved`, `cal_mask`, etc.
- Modified `mag_calibration_status.cpp` to:
  - Assign each field correctly from incoming MAVLink MAG_CAL_REPORT message
  - Construct full `MagnetometerReporter` ROS 2 message with all available data
- This ensures the topic `/mavros/mag_calibration/report` contains accurate and complete information after compass calibration procedures.

## Testing

- ✅ Tested with ArduPilot SITL and real flight controller (Pixhawk) with ArduPilot firmware (Copter 4.4).
- ✅ Calibration command sent using `ros2 service call /mavros/cmd/command` with:
```bash
  ros2 service call /mavros/cmd/command mavros_msgs/srv/CommandLong "{
    command: 42424,
    confirmation: 1,
    param3: 1
  }"
```
✅ Observed output on ROS 2 topic:
 ```bash
ros2 topic echo /mavros/mag_calibration/report
```
📉 Before Fix (partial/incomplete output):
```yaml
header:
  stamp:
    sec: 1742818332
    nanosec: 990819562
  frame_id: '0'
report: 4
confidence: 1.1955742835998535
```
📈 After Fix (fully populated according to MAVLink spec)
```yaml
header:
  stamp:
    sec: 1745584691
    nanosec: 236922544
  frame_id: '0'
report: 4
confidence: 7.774540424346924
compass_id: 0
cal_mask: 1
cal_status: 4
autosaved: 1
fitness: 31.877994537353516
ofs_x: -43.93415451049805
ofs_y: -17.019399642944336
ofs_z: -22.630168914794922
diag_x: 1.0128146409988403
diag_y: 1.1006752252578735
diag_z: 0.9747106432914734
offdiag_x: 0.0010097220074385405
offdiag_y: -0.06996173411607742
offdiag_z: 0.056884389370679855
orientation_confidence: 7.774540424346924
old_orientation: 0
new_orientation: 0
scale_factor: 0.0
```
## Motivation 

Without this fix, the /mavros/mag_calibration/report topic published incomplete messages lacking critical calibration feedback fields like fitness, offsets, or orientation metrics.
This caused limited visibility for developers and GCS tools using MAVROS in ROS 2 setups. 

With this PR, the message now reflects the full MAVLink MAG_CAL_REPORT, improving integration and diagnostics. 