### PR TITLE
Fix incorrect macro usage

### DIFF
--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -69,7 +69,7 @@ class Router;
 class Endpoint : public std::enable_shared_from_this<Endpoint>
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(Endpoint)
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(Endpoint)
 
   enum class Type
   {

--- a/mavros/include/mavros/plugin.hpp
+++ b/mavros/include/mavros/plugin.hpp
@@ -65,7 +65,7 @@ private:
   explicit Plugin(const Plugin &) = delete;
 
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(Plugin)
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(Plugin)
 
   //! generic message handler callback
   using HandlerCb = mavconn::MAVConnInterface::ReceivedCb;


### PR DESCRIPTION
RCLCPP_SMART_PTR_DEFINITIONS eventually is expanding to:

\#define __RCLCPP_MAKE_UNIQUE_DEFINITION(...) \
  template<typename ... Args> \
  static std::unique_ptr<__VA_ARGS__> \
  make_unique(Args && ... args) \
  { \
    return std::unique_ptr<__VA_ARGS__>(new __VA_ARGS__(std::forward<Args>(args) ...)); \
  }

which is incorrect for abstract classes like Endpoint or Plugin

RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE is used instead excluding make_unique functionality

This allows to use clang compiler to build mavros