### PR TITLE
[Bugfix] bad_weak_ptr from Router when starting as composable node in kilted

### DIFF
--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -183,16 +183,7 @@ public:
     //
     // Repeat the pattern from mavros_uas of using a delay timer
     startup_delay_timer = this->create_wall_timer(
-      10ms, [this]() {
-        RCLCPP_WARN(get_logger(), "In timer callback");
-        startup_delay_timer->cancel();
-        set_parameters_handle_ptr =
-        this->add_on_set_parameters_callback(std::bind(&Router::on_set_parameters_cb, this, _1));
-
-        this->declare_parameter<StrV>("fcu_urls", StrV());
-        this->declare_parameter<StrV>("gcs_urls", StrV());
-        this->declare_parameter<StrV>("uas_urls", StrV());
-      });
+      10ms, std::bind(&Router::initialize_parameters, this));
   }
 
   void route_message(Endpoint::SharedPtr src, const mavlink_message_t * msg, const Framing framing);
@@ -229,6 +220,18 @@ private:
 
   void periodic_reconnect_endpoints();
   void periodic_clear_stale_remote_addrs();
+
+  void initialize_parameters()
+  {
+    RCLCPP_WARN(get_logger(), "In timer callback");
+    startup_delay_timer->cancel();
+    set_parameters_handle_ptr =
+      this->add_on_set_parameters_callback(std::bind(&Router::on_set_parameters_cb, this, _1));
+
+    this->declare_parameter<StrV>("fcu_urls", StrV());
+    this->declare_parameter<StrV>("gcs_urls", StrV());
+    this->declare_parameter<StrV>("uas_urls", StrV());
+  }
 
   rcl_interfaces::msg::SetParametersResult on_set_parameters_cb(
     const std::vector<rclcpp::Parameter> & parameters);

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -90,6 +90,7 @@ public:
   Router::SharedPtr create_node()
   {
     auto router = std::make_shared<Router>("test_mavros_router");
+    router->startup_delay_timer->cancel();
 
     auto make_and_add_mock_endpoint =
       [router](id_t id, const std::string & url, LT type,
@@ -116,6 +117,17 @@ public:
     make_and_add_mock_endpoint(1003, "/uas2", LT::uas, {0x0000, 0x0200, 0x02BF});
     make_and_add_mock_endpoint(1004, "mock://gcs1", LT::gcs, {0x0000, 0xFF00, 0xFFBE});
     make_and_add_mock_endpoint(1005, "mock://gcs2", LT::gcs, {0x0000, 0xFF00, 0xFFBD});
+
+    return router;
+  }
+
+  Router::SharedPtr create_node_no_endpoints()
+  {
+    auto router = std::make_shared<Router>("test_mavros_router");
+    router->startup_delay_timer->cancel();
+
+    // Call this manually
+    router->initialize_parameters();
 
     return router;
   }
@@ -184,7 +196,7 @@ public:
 
 TEST_F(TestRouter, set_parameter)
 {
-  auto router = std::make_shared<Router>("test_mavros_router");
+  auto router = this->create_node_no_endpoints();
 
   router->set_parameters(
     std::vector<rclcpp::Parameter>{
@@ -388,7 +400,7 @@ TEST_F(TestRouter, route_targeted_system_component)
 
 TEST_F(TestRouter, endpoint_recv_message)
 {
-  auto router = std::make_shared<Router>("test_mavros_router");
+  auto router = create_node_no_endpoints();
 
   router->set_parameters(
     std::vector<rclcpp::Parameter>{


### PR DESCRIPTION
Testing with current `ros2` head under Kilted.   Starting just Router as a composable node with (as an example):

```python
from launch import LaunchDescription
from launch_ros.actions import ComposableNodeContainer
from launch_ros.descriptions import ComposableNode

def generate_launch_description():

    """Generate launch description for MAVROS composable node."""
    container = ComposableNodeContainer(
        name="mavros_container",
        namespace="",
        package="rclcpp_components",
        executable="component_container_mt",
        composable_node_descriptions=[
            ComposableNode(
                package="mavros",
                plugin="mavros::router::Router",  # Or the specific MAVROS component you need
                name="mavros_router",
                parameters=[
                    {"fcu_urls": ["tcp://localhost:6777"]},
                    {"fcu_protocol": "v2.0"},
                    {"uas_urls": ["/uas1"]},
                    
                ],
                extra_arguments=[{"use_intra_process_comms": True}],
            )
        ],
        output="screen",
    )

    return LaunchDescription([container])
```

throws an exception:

```
[component_container_mt-1] [INFO] [1755795754.777550090] [mavros_router]: Requested to add endpoint: type: 0, url: tcp://192.168.2.2:6777
[component_container_mt-1] [ERROR] [1755795754.781504411] [mavros_container]: Component constructor threw an exception: bad_weak_ptr
[ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'mavros_router' of type 'mavros::router::Router' in container '/mavros_container': Component constructor threw an exception: bad_weak_ptr
```

This can be traced back to `Router::on_set_parameters_cb` being called before the constructor is finished, leading to a `shared_from_this` deep in setting up endpoints.

This pull request places the call to `add_on_set_parameters_callback` and parameter setup in a timed functional called 10ms after completion of the constructor, following the design pattern used in [mavros_uas.cpp](https://github.com/amarburg/mavros/blob/b0da849a06eb1a215b9205b92b8cf39c6d7cf88f/mavros/src/lib/mavros_uas.cpp#L88)

Tested under Kilted, I am able to load a router node and multuiple UAS nodes in a single component container.
