### PR TITLE
(feat): Remap setpoint velocity cmd to separate floa32 topics

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -2,7 +2,7 @@
 	<!-- vim: set ft=xml noet : -->
 	<!-- example launch script for ArduPilot based FCU's -->
 
-	<arg name="fcu_url" default="/dev/ttyACM0:57600" />
+	<arg name="fcu_url" default="udp://0.0.0.0:14551@14555/?ids=255,240" />
 	<arg name="gcs_url" default="" />
 	<arg name="tgt_system" default="1" />
 	<arg name="tgt_component" default="1" />

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -73,7 +73,7 @@
 /**/local_position:
   ros__parameters:
     frame_id: "map"
-    tf.send: false
+    tf.send: true
     tf.frame_id: "map"
     tf.child_frame_id: "base_link"
     tf.send_fcu: false
@@ -93,7 +93,7 @@
 /**/setpoint_attitude:
   ros__parameters:
     reverse_thrust: false       # allow reversed thrust
-    use_quaternion: false       # enable PoseStamped topic subscriber
+    use_quaternion: true       # enable PoseStamped topic subscriber
     tf.listen: false            # enable tf listener (disable topic subscribers)
     tf.frame_id: "map"
     tf.child_frame_id: "target_attitude"
@@ -124,7 +124,7 @@
 # setpoint_velocity
 /**/setpoint_velocity:
   ros__parameters:
-    mav_frame: LOCAL_NED
+    mav_frame: BODY_NED   # But in actual, the control signal must be in FLU frame (ROS convention)
 
 # vfr_hud
 # None

--- a/mavros/launch/apm_config.yaml
+++ b/mavros/launch/apm_config.yaml
@@ -92,8 +92,8 @@
 # setpoint_attitude
 /**/setpoint_attitude:
   ros__parameters:
-    reverse_thrust: false       # allow reversed thrust
-    use_quaternion: true       # enable PoseStamped topic subscriber
+    reverse_thrust: true       # allow reversed thrust
+    use_quaternion: true       # keep this true because Ardupilot does not support body attitude rate for this message (https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html#set-attitude-target)
     tf.listen: false            # enable tf listener (disable topic subscribers)
     tf.frame_id: "map"
     tf.child_frame_id: "target_attitude"
@@ -124,7 +124,7 @@
 # setpoint_velocity
 /**/setpoint_velocity:
   ros__parameters:
-    mav_frame: BODY_NED   # But in actual, the control signal must be in FLU frame (ROS convention)
+    mav_frame: BODY_NED
 
 # vfr_hud
 # None

--- a/mavros/launch/apm_pluginlists.yaml
+++ b/mavros/launch/apm_pluginlists.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    system_id: 255
+
     plugin_denylist:
       # common
       - actuator_control
@@ -13,6 +15,13 @@
       - vibration
       - vision_speed_estimate
       - wheel_odometry
+      # - global_position
 
     # plugin_allowlist:
     #   - 'sys_*'
+    #   - 'rc_io'
+    #   - 'param'
+    #   - 'manual_control'
+    #   - 'setpoint_attitude'
+    #   - 'setpoint_position'
+    #   - 'setpoint_velocity'

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -133,6 +133,7 @@ add_library(mavros_extras_plugins SHARED
   src/plugins/vision_pose_estimate.cpp
   src/plugins/vision_speed_estimate.cpp
   src/plugins/wheel_odometry.cpp
+  src/plugins/remap_setpoint_velocity.cpp
   # [[[end]]] (checksum: 4564d922cfa3d36bf2089dade2323259)
 )
 ament_target_dependencies(mavros_extras_plugins

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library(mavros_extras_plugins SHARED
   src/plugins/play_tune.cpp
   src/plugins/px4flow.cpp
   src/plugins/rangefinder.cpp
+  src/plugins/rc_twist.cpp
   src/plugins/terrain.cpp
   src/plugins/trajectory.cpp
   src/plugins/tunnel.cpp

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(ament_cmake REQUIRED)
 
 # find mavros dependencies
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcpputils REQUIRED)
@@ -114,6 +115,7 @@ add_library(mavros_extras_plugins SHARED
   src/plugins/mag_calibration_status.cpp
   src/plugins/mocap_pose_estimate.cpp
   src/plugins/mount_control.cpp
+  src/plugins/move_to_pose_server.cpp
   src/plugins/obstacle_distance.cpp
   src/plugins/odom.cpp
   src/plugins/onboard_computer_status.cpp
@@ -146,6 +148,7 @@ ament_target_dependencies(mavros_extras_plugins
   nav_msgs
   trajectory_msgs
   rclcpp
+  rclcpp_action
   rclcpp_components
   rcpputils
   libmavconn
@@ -167,6 +170,7 @@ add_library(mavros_extras SHARED
 )
 ament_target_dependencies(mavros_extras
   rclcpp
+  rclcpp_action
   rclcpp_components
   std_msgs
   sensor_msgs

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -136,6 +136,12 @@ Sends motion capture data to FCU.</description>
 Publishes Mission commands to control the camera or antenna mount.
 @see command_cb()</description>
   </class>
+  <class name="move_to_pose_server" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::extra_plugins::MoveToPoseServerPlugin&gt;" base_class_type="mavros::plugin::PluginFactory">
+    <description>@brief Move To Pose Server plugin
+@plugin move_to_pose_server
+
+Handles the move to pose action server.</description>
+  </class>
   <class name="obstacle_distance" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::extra_plugins::ObstacleDistancePlugin&gt;" base_class_type="mavros::plugin::PluginFactory">
     <description>@brief Obstacle distance plugin
 @plugin obstacle_distance

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -140,6 +140,12 @@ Publishes Mission commands to control the camera or antenna mount.
     <description>@brief Move To Pose Server plugin
 @plugin move_to_pose_server
 
+Remaps individual velocity topics to mavros /setpoint_velocity/cmd_vel_unstamped topic.</description>
+  </class>
+  <class name="remap_setpoint_velocity" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::extra_plugins::RemapSetpointVelocityPlugin&gt;" base_class_type="mavros::plugin::PluginFactory">
+    <description>@brief Remap Setpoint Velocity Plugin
+@plugin remap_setpoint_velocity
+
 Handles the move to pose action server.</description>
   </class>
   <class name="obstacle_distance" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::extra_plugins::ObstacleDistancePlugin&gt;" base_class_type="mavros::plugin::PluginFactory">

--- a/mavros_extras/mavros_plugins.xml
+++ b/mavros_extras/mavros_plugins.xml
@@ -193,6 +193,12 @@ This plugin can publish data from PX4Flow camera to ROS</description>
 
 This plugin allows publishing rangefinder sensor data from Ardupilot FCU to ROS.</description>
   </class>
+  <class name="rc_twist" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::extra_plugins::RCTwistPlugin&gt;" base_class_type="mavros::plugin::PluginFactory">
+    <description>@brief RC Twist plugin.
+@plugin rc_twist
+
+This plugin allows publishing RC twist commands from ROS to Ardupilot FCU.</description>
+  </class>
   <class name="tdr_radio" type="mavros::plugin::PluginFactoryTemplate&lt;mavros::extra_plugins::TDRRadioPlugin&gt;" base_class_type="mavros::plugin::PluginFactory">
     <description>@brief 3DR Radio plugin.
 @plugin tdr_radio</description>

--- a/mavros_extras/package.xml
+++ b/mavros_extras/package.xml
@@ -45,6 +45,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
   <depend>rcpputils</depend>
   <depend>urdf</depend>

--- a/mavros_extras/src/plugins/move_to_pose_server.cpp
+++ b/mavros_extras/src/plugins/move_to_pose_server.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2014,2016,2021 Vladimir Ermakov.
+ *
+ * This file is part of the mavros package and subject to the license terms
+ * in the top-level LICENSE file of the mavros repository.
+ * https://github.com/mavlink/mavros/tree/master/LICENSE.md
+ */
+/**
+ * @brief SetpointPosition plugin
+ * @file setpoint_position.cpp
+ * @author Vladimir Ermakov <vooon341@gmail.com>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+
+#include <GeographicLib/Geocentric.hpp>
+#include <cmath>
+
+#include "tf2_eigen/tf2_eigen.hpp"
+#include "rcpputils/asserts.hpp"
+#include "mavros/mavros_uas.hpp"
+#include "mavros/plugin.hpp"
+#include "mavros/plugin_filter.hpp"
+#include "mavros/setpoint_mixin.hpp"
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "mavros_msgs/action/move_to_pose.hpp"
+
+
+namespace mavros
+{
+namespace extra_plugins
+{
+using namespace std::placeholders;      // NOLINT
+using mavlink::common::MAV_FRAME;
+using MoveToPose = mavros_msgs::action::MoveToPose;
+using GoalHandleMoveToPose = rclcpp_action::ServerGoalHandle<MoveToPose>;
+using PoseStamped = geometry_msgs::msg::PoseStamped;
+using mavlink::common::MAV_FRAME;
+
+/**
+ * @brief Setpoint position plugin
+ * @plugin setpoint_position
+ *
+ * Send setpoint positions to FCU controller.
+ */
+class MoveToPoseServerPlugin : public plugin::Plugin,
+  private plugin::SetPositionTargetLocalNEDMixin<MoveToPoseServerPlugin>
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+
+  explicit MoveToPoseServerPlugin(plugin::UASPtr uas_)
+  : Plugin(uas_, "move_to_pose_server")
+  {
+    enable_node_watch_parameters();
+
+    auto sensor_qos = rclcpp::SensorDataQoS();
+
+    local_sub = node->create_subscription<geometry_msgs::msg::PoseStamped>(
+      "local_position/pose", sensor_qos,
+      [this](const PoseStamped::SharedPtr msg) {
+        current_local_pose = *msg;
+      });
+
+    move_to_pose_action_server = rclcpp_action::create_server<MoveToPose>(
+      node, "~/set_pose",
+      [this](const rclcpp_action::GoalUUID & uuid [[maybe_unused]], std::shared_ptr<const MoveToPose::Goal> goal [[maybe_unused]]) {
+        RCLCPP_DEBUG(this->get_logger(), "Received MoveToPose goal request");
+        return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+      },
+      [this](const std::shared_ptr<GoalHandleMoveToPose> goal_handle [[maybe_unused]]) {
+        RCLCPP_DEBUG(this->get_logger(), "Received request to cancel MoveToPose goal");
+        return rclcpp_action::CancelResponse::ACCEPT;
+      },
+      [this](const std::shared_ptr<GoalHandleMoveToPose> goal_handle [[maybe_unused]]) {
+        std::thread([this, goal_handle]() {
+          execute(goal_handle);
+        }).detach();
+      }
+    );
+  }
+
+  Subscriptions get_subscriptions() override
+  {
+    return { /* Rx disabled */};
+  }
+
+private:
+  friend class plugin::SetPositionTargetLocalNEDMixin<MoveToPoseServerPlugin>;
+
+  rclcpp_action::Server<MoveToPose>::SharedPtr move_to_pose_action_server;
+  rclcpp::Subscription<PoseStamped>::SharedPtr local_sub;
+  PoseStamped current_local_pose;
+
+  /**
+   * @brief Send setpoint to FCU position controller.
+   *
+   * @warning Send only XYZ, Yaw. ENU frame.
+   */
+  void send_position_target(const Eigen::Affine3d & tr)
+  {
+    const uint16_t ignore_all_except_xyz_y = (1 << 11) | (7 << 6) | (7 << 3);
+    auto p = ftf::transform_frame_enu_ned(Eigen::Vector3d(tr.translation()));
+    auto q = ftf::transform_orientation_enu_ned(
+          ftf::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation())));
+
+    set_position_target_local_ned(
+      get_time_boot_ms(this->get_clock()->now()),
+      utils::enum_value(MAV_FRAME::LOCAL_NED),
+      ignore_all_except_xyz_y,
+      p,
+      Eigen::Vector3d::Zero(),
+      Eigen::Vector3d::Zero(),
+      ftf::quaternion_get_yaw(q), 0.0);
+  }
+
+  /* -*- main function for server -*- */
+
+  void execute(const std::shared_ptr<GoalHandleMoveToPose> goal_handle)
+  {
+    RCLCPP_INFO(this->get_logger(), "Executing MoveToPose goal");
+
+    // Get the goal and create feedback/result messages
+    const auto goal = goal_handle->get_goal();
+    auto feedback = std::make_shared<MoveToPose::Feedback>();
+    auto result = std::make_shared<MoveToPose::Result>();
+    
+    Eigen::Affine3d tr;
+    tf2::fromMsg(goal->target_pose.pose, tr);
+    
+    // Send the goal to AP
+    auto start_time = this->get_clock()->now();
+    send_position_target(tr);
+
+    // Main loop to check for abort, cancel or success
+    rclcpp::Rate loop_rate(10);
+    while (rclcpp::ok()) 
+    {
+      loop_rate.sleep();
+
+      // Check if there is a cancel request
+      if (goal_handle->is_canceling() || !goal_handle->is_active()) {
+        result->error_code = 2;
+        stop_at_current_pose();
+        goal_handle->canceled(result);
+        RCLCPP_DEBUG(this->get_logger(), "MoveToPose goal canceled");
+        return;
+      } 
+
+      // Check if timeout
+      auto elapsed = this->get_clock()->now() - start_time;
+      if (goal->timeout > 0.0 && elapsed.seconds() > goal->timeout) {
+        result->error_code = 1;
+        stop_at_current_pose();
+        goal_handle->abort(result);
+        RCLCPP_WARN(this->get_logger(), "MoveToPose goal aborted due to timeout");
+        return;
+      }
+
+      // Check if the goal is reached
+      double distance_remaining = (ftf::to_eigen(current_local_pose.pose.position) - Eigen::Vector3d(tr.translation())).norm();
+      
+      // Calculate heading difference
+      double target_yaw = ftf::quaternion_get_yaw(Eigen::Quaterniond(tr.rotation()));
+      double current_yaw = ftf::quaternion_get_yaw(ftf::to_eigen(current_local_pose.pose.orientation));
+      
+      // Normalize yaw difference to [-pi, pi]
+      double yaw_diff = target_yaw - current_yaw;
+      while (yaw_diff > M_PI) yaw_diff -= 2 * M_PI;
+      while (yaw_diff < -M_PI) yaw_diff += 2 * M_PI;
+      double heading_error = std::abs(yaw_diff);
+      
+      feedback->distance_remaining = distance_remaining;
+      feedback->current_pose = current_local_pose;
+
+      feedback->navigation_time = builtin_interfaces::msg::Duration();
+      feedback->navigation_time.sec = static_cast<int32_t>(elapsed.seconds());
+
+      goal_handle->publish_feedback(feedback);
+      RCLCPP_DEBUG(this->get_logger(), "Distance to goal: %.2f, Heading error: %.2f rad", distance_remaining, heading_error);
+
+      // Check if both position and heading are within tolerance
+      const double position_tolerance = 0.3;  // 0.3 meters
+      const double heading_tolerance = 0.1;   // 0.1 radians (~5.7 degrees)
+      
+      if (distance_remaining < position_tolerance && heading_error < heading_tolerance) {
+        result->error_code = 0;
+        goal_handle->succeed(result);
+        RCLCPP_INFO(this->get_logger(), "MoveToPose goal succeeded - position and heading reached");
+        return;
+      }
+
+    }
+  }
+
+  void stop_at_current_pose()
+  {
+    Eigen::Affine3d current_local_pose_eigen;
+    tf2::fromMsg(current_local_pose.pose, current_local_pose_eigen);
+    send_position_target(current_local_pose_eigen);
+
+    // Ignore position and accel vectors, yaw.
+    // uint16_t ignore_all_except_v_xyz_yr = (1 << 10) | (7 << 6) | (7 << 0);
+    // auto mav_frame = MAV_FRAME::BODY_NED;
+
+    // set_position_target_local_ned(
+    //   get_time_boot_ms(this->get_clock()->now()),
+    //   utils::enum_value(mav_frame),
+    //   ignore_all_except_v_xyz_yr,
+    //   Eigen::Vector3d::Zero(),
+    //   Eigen::Vector3d::Zero(),
+    //   Eigen::Vector3d::Zero(),
+    //   0.0, 0.0
+    // );
+  }
+};
+
+}       // namespace extra_plugins
+}       // namespace mavros
+
+#include <mavros/mavros_plugin_register_macro.hpp>  // NOLINT
+MAVROS_PLUGIN_REGISTER(mavros::extra_plugins::MoveToPoseServerPlugin)

--- a/mavros_extras/src/plugins/rc_twist.cpp
+++ b/mavros_extras/src/plugins/rc_twist.cpp
@@ -1,0 +1,117 @@
+/**
+ * @brief RC Twsit plugin
+ * @file rc_twist.cpp
+ * @author Tien Luc Vu <luc001@e.ntu.edu.sg>
+ *
+ * @addtogroup plugin
+ * @{
+ */
+
+#include <vector>
+#include <cstdint>
+
+#include "rcpputils/asserts.hpp"
+#include "mavros/mavros_uas.hpp"
+#include "mavros/plugin.hpp"
+#include "mavros/plugin_filter.hpp"
+
+#include "mavros_msgs/msg/rc_in.hpp"
+#include "mavros_msgs/msg/rc_out.hpp"
+#include "mavros_msgs/msg/override_rc_in.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+namespace mavros
+{
+namespace extra_plugins
+{
+using namespace std::placeholders;      // NOLINT
+
+/**
+ * @brief RC Twist plugin
+ * @plugin rc_twist
+ */
+class RCTwistPlugin : public plugin::Plugin
+{
+public:
+  explicit RCTwistPlugin(plugin::UASPtr uas_)
+  : Plugin(uas_, "rc_twist")
+  {
+    twist_sub = node->create_subscription<geometry_msgs::msg::Twist>(
+      "~/send", 10, std::bind(
+        &RCTwistPlugin::twist_cb, this,
+        _1));
+
+    enable_connection_cb();
+  }
+
+  Subscriptions get_subscriptions() override
+  {
+    return {};
+  }
+
+private:
+  using lock_guard = std::lock_guard<std::mutex>;
+  std::mutex mutex;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub;
+
+  void connection_cb([[maybe_unused]] bool connected) override
+  {
+    lock_guard lock(mutex);
+  }
+
+  /* -*- callbacks -*- */
+
+  void twist_cb(const geometry_msgs::msg::Twist::SharedPtr req)
+  {
+    if (!uas->is_ardupilotmega() && !uas->is_px4()) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(),
+        *get_clock(), 30000, "RC override not supported by this FCU!");
+    }
+
+    mavlink::common::msg::RC_CHANNELS_OVERRIDE ovr = {};
+    uas->msg_set_target(ovr);
+
+    // [[[cog:
+    // for i in range(7, 19):
+    //     cog.outl(f"ovr.chan{i}_raw = UINT16_MAX;")
+    // ]]]
+
+    ovr.chan1_raw = convert_normalized_to_pwm(req->angular.y);  // Pitch
+    ovr.chan2_raw = convert_normalized_to_pwm(req->angular.x);  // Roll
+    ovr.chan3_raw = convert_normalized_to_pwm(req->linear.z);  // Throttle
+    ovr.chan4_raw = convert_normalized_to_pwm(req->angular.z);  // Yaw
+    ovr.chan5_raw = convert_normalized_to_pwm(req->linear.x);  // Forward
+    ovr.chan6_raw = convert_normalized_to_pwm(req->linear.y);  // Lateral
+    ovr.chan7_raw = UINT16_MAX;
+    ovr.chan8_raw = UINT16_MAX;
+    ovr.chan9_raw = UINT16_MAX;
+    ovr.chan10_raw = UINT16_MAX;
+    ovr.chan11_raw = UINT16_MAX;
+    ovr.chan12_raw = UINT16_MAX;
+    ovr.chan13_raw = UINT16_MAX;
+    ovr.chan14_raw = UINT16_MAX;
+    ovr.chan15_raw = UINT16_MAX;
+    ovr.chan16_raw = UINT16_MAX;
+    ovr.chan17_raw = UINT16_MAX;
+    ovr.chan18_raw = UINT16_MAX;
+    // [[[end]]] (checksum: f878252945b6d1ca47c416b4f3aec145)
+
+    uas->send_message(ovr);
+  }
+
+  uint16_t convert_normalized_to_pwm(double normalized)
+  {
+    normalized = std::max(-1.0, std::min(1.0, normalized));
+    if (abs(normalized) < 0.01) {
+      return UINT16_MAX;
+    }
+    return static_cast<uint16_t>(normalized * 400 + 1500);
+  }
+};
+
+}       // namespace std_plugins
+}       // namespace mavros
+
+#include <mavros/mavros_plugin_register_macro.hpp>  // NOLINT
+MAVROS_PLUGIN_REGISTER(mavros::extra_plugins::RCTwistPlugin)

--- a/mavros_extras/src/plugins/remap_setpoint_velocity.cpp
+++ b/mavros_extras/src/plugins/remap_setpoint_velocity.cpp
@@ -1,0 +1,208 @@
+#include "tf2_eigen/tf2_eigen.hpp"
+#include "rcpputils/asserts.hpp"
+#include "mavros/mavros_uas.hpp"
+#include "mavros/plugin.hpp"
+#include "mavros/plugin_filter.hpp"
+#include "mavros/setpoint_mixin.hpp"
+
+#include "std_msgs/msg/float32.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+#include <thread>
+#include <atomic>
+#include <mutex>
+
+namespace mavros
+{
+namespace std_plugins
+{
+using namespace std::placeholders;
+using mavlink::common::MAV_FRAME;
+
+/**
+ * @brief Custom Setpoint velocity plugin
+ * @plugin custom_setpoint_velocity
+ *
+ * Send setpoint velocities to FCU controller via individual Float32 topics.
+ */
+class CustomSetpointVelocityPlugin : public plugin::Plugin,
+  private plugin::SetPositionTargetLocalNEDMixin<CustomSetpointVelocityPlugin>
+{
+public:
+  explicit CustomSetpointVelocityPlugin(plugin::UASPtr uas_)
+  : Plugin(uas_, "custom_setpoint_velocity"),
+    cur_vel_x(0.0f),
+    cur_vel_y(0.0f), 
+    cur_vel_z(0.0f),
+    cur_vel_r(0.0f),
+    run_publisher_(true),
+    active_(false)
+  {
+    enable_node_watch_parameters();
+
+    auto sensor_qos = rclcpp::SensorDataQoS();
+
+    twist_pub_ = node->create_publisher<geometry_msgs::msg::Twist>(
+      "/mavros/setpoint_velocity/cmd_vel_unstamped", 10);
+      
+    vel_x_sub_ = node->create_subscription<std_msgs::msg::Float32>(
+      "~/vel_x", sensor_qos, 
+      std::bind(&CustomSetpointVelocityPlugin::setpoint_vel_x_cb, this, _1));
+
+    vel_y_sub_ = node->create_subscription<std_msgs::msg::Float32>(
+      "~/vel_y", sensor_qos,
+      std::bind(&CustomSetpointVelocityPlugin::setpoint_vel_y_cb, this, _1));
+
+    vel_z_sub_ = node->create_subscription<std_msgs::msg::Float32>(
+      "~/vel_z", sensor_qos,
+      std::bind(&CustomSetpointVelocityPlugin::setpoint_vel_z_cb, this, _1));
+
+    vel_r_sub_ = node->create_subscription<std_msgs::msg::Float32>(
+      "~/vel_r", sensor_qos,
+      std::bind(&CustomSetpointVelocityPlugin::setpoint_vel_r_cb, this, _1));
+
+    // Timer
+    timeout_timer_ = node->create_wall_timer(
+      std::chrono::milliseconds(100),
+      [this]() { check_timeout(); });
+    last_msg_time_ = node->now();
+
+    // Start publisher thread
+    publisher_thread_ = std::thread(&CustomSetpointVelocityPlugin::publish_loop, this);
+  }
+
+  ~CustomSetpointVelocityPlugin()
+  {
+    run_publisher_.store(false);
+    if (publisher_thread_.joinable()) {
+      publisher_thread_.join();
+    }
+  }
+
+  Subscriptions get_subscriptions() override
+  {
+    return { /* Rx disabled */};
+  }
+
+private:
+  friend class plugin::SetPositionTargetLocalNEDMixin<CustomSetpointVelocityPlugin>;
+
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_pub_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr vel_x_sub_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr vel_y_sub_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr vel_z_sub_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr vel_r_sub_;
+  
+  std::atomic<float> cur_vel_x;
+  std::atomic<float> cur_vel_y;
+  std::atomic<float> cur_vel_z;
+  std::atomic<float> cur_vel_r;
+
+  std::thread publisher_thread_;
+  std::atomic<bool> run_publisher_;
+  std::atomic<bool> active_;
+  
+  // Timeout management (protected by mutex for thread safety)
+  std::mutex time_mutex_;
+  rclcpp::Time last_msg_time_;
+  rclcpp::TimerBase::SharedPtr timeout_timer_;
+
+  void publish_loop()
+  {
+    rclcpp::Rate rate(50); // 50 Hz publishing rate
+    
+    while (rclcpp::ok() && run_publisher_.load(std::memory_order_acquire))
+    {
+      if (active_.load(std::memory_order_acquire)) {
+        send_setpoint_velocity();
+      }
+      rate.sleep();
+    }
+  }
+
+  /**
+   * @brief Send combined velocity setpoint to MAVROS
+   * 
+   * @warning Send only VX VY VZ and RZ
+   */
+  void send_setpoint_velocity()
+  {
+    geometry_msgs::msg::Twist twist;
+
+    // Read current velocities atomically
+    twist.linear.x = cur_vel_x.load(std::memory_order_acquire);
+    twist.linear.y = cur_vel_y.load(std::memory_order_acquire);
+    twist.linear.z = cur_vel_z.load(std::memory_order_acquire);
+    twist.angular.z = cur_vel_r.load(std::memory_order_acquire);
+
+    twist_pub_->publish(twist);
+  }
+
+  void check_timeout()
+  {
+    if (!active_.load(std::memory_order_acquire))
+      return;
+
+    rclcpp::Time current_time;
+    {
+      std::lock_guard<std::mutex> lock(time_mutex_);
+      current_time = last_msg_time_;
+    }
+
+    // Check if more than 1 second since last message
+    if ((node->now() - current_time).seconds() > 1.0) {
+      RCLCPP_WARN(get_logger(), "Velocity setpoint timeout - stopping");
+      
+      // Zero all velocities
+      cur_vel_x.store(0.0f, std::memory_order_release);
+      cur_vel_y.store(0.0f, std::memory_order_release);
+      cur_vel_z.store(0.0f, std::memory_order_release);
+      cur_vel_r.store(0.0f, std::memory_order_release);
+      send_setpoint_velocity();
+
+      // Deactivate publishing
+      active_.store(false, std::memory_order_release);
+    }
+  }
+
+  void update_timestamp_and_activate()
+  {
+    {
+      std::lock_guard<std::mutex> lock(time_mutex_);
+      last_msg_time_ = node->now();
+    }
+    active_.store(true, std::memory_order_release);
+  }
+
+  /* -*- callbacks -*- */
+  void setpoint_vel_x_cb(const std_msgs::msg::Float32::SharedPtr vel_x)
+  {
+    cur_vel_x.store(vel_x->data, std::memory_order_release);
+    update_timestamp_and_activate();
+  }
+
+  void setpoint_vel_y_cb(const std_msgs::msg::Float32::SharedPtr vel_y)
+  {
+    cur_vel_y.store(vel_y->data, std::memory_order_release);
+    update_timestamp_and_activate();
+  }
+
+  void setpoint_vel_z_cb(const std_msgs::msg::Float32::SharedPtr vel_z)
+  {
+    cur_vel_z.store(vel_z->data, std::memory_order_release);
+    update_timestamp_and_activate();
+  }
+
+  void setpoint_vel_r_cb(const std_msgs::msg::Float32::SharedPtr vel_r)
+  {
+    cur_vel_r.store(vel_r->data, std::memory_order_release);
+    update_timestamp_and_activate();
+  }
+};
+
+} // namespace std_plugins
+} // namespace mavros
+
+#include <mavros/mavros_plugin_register_macro.hpp>
+MAVROS_PLUGIN_REGISTER(mavros::std_plugins::CustomSetpointVelocityPlugin)

--- a/mavros_msgs/CMakeLists.txt
+++ b/mavros_msgs/CMakeLists.txt
@@ -166,9 +166,14 @@ set(srv_files
   # [[[end]]] (checksum: cd7701b28a3176d96ef65cb1f2157917)
 )
 
+set(action_files
+  action/MoveToPose.action  
+)
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
+  ${action_files}
   DEPENDENCIES
   builtin_interfaces
   rcl_interfaces

--- a/mavros_msgs/action/MoveToPose.action
+++ b/mavros_msgs/action/MoveToPose.action
@@ -1,9 +1,17 @@
 # goal
 
+# if parent and child frame are provided, target_pose will be ignored
+string parent_frame
+string target_frame
+
 geometry_msgs/PoseStamped target_pose
 
 # set timeout to negative value for infinite duration
-uint16 timeout
+float32 timeout
+
+float32 position_tolerance
+float32 heading_tolerance
+float32 min_success_duration
 
 ---
 # result

--- a/mavros_msgs/action/MoveToPose.action
+++ b/mavros_msgs/action/MoveToPose.action
@@ -1,0 +1,20 @@
+# goal
+
+geometry_msgs/PoseStamped target_pose
+
+# set timeout to negative value for infinite duration
+uint16 timeout
+
+---
+# result
+
+uint8 SUCCESS = 0
+uint8 TIMEOUT = 1
+uint8 CANCELLED = 2
+uint8 error_code
+
+---
+# feedback
+geometry_msgs/PoseStamped current_pose
+builtin_interfaces/Duration navigation_time
+float32 distance_remaining

--- a/mavros_msgs/action/MoveToPose.action
+++ b/mavros_msgs/action/MoveToPose.action
@@ -19,6 +19,7 @@ float32 min_success_duration
 uint8 SUCCESS = 0
 uint8 TIMEOUT = 1
 uint8 CANCELLED = 2
+uint8 WRONG_MODE = 3
 uint8 error_code
 
 ---

--- a/mavros_msgs/package.xml
+++ b/mavros_msgs/package.xml
@@ -29,6 +29,7 @@
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>action_msgs</depend>
   <!-- <depend>std_msgs</depend> -->
   <!-- XXX needed for users of mavlink_convert.h
   <build_export_depend>libmavconn</build_export_depend>


### PR DESCRIPTION
In order to control vehicle with BT Node `publish float`, we need to remap the original mavros topic `/mavros/setpoint_velocity/cmd_vel_unstamped` to 4 separate `float32` topic:
* `/mavros/remap_setpoint_velocity/vel_r`
* `/mavros/remap_setpoint_velocity/vel_x`
* `/mavros/remap_setpoint_velocity/vel_y`
* `/mavros/remap_setpoint_velocity/vel_z `

Logic:
* The node will read velocity command from each of above topics, saving in a buffer and send this buffer to mavros topic at 40hz.
* For each axis, if there is no msg received in 1s, it will set the value of that axis to 0.