### PR TITLE
DDS equivalent of latched topic for gp_origin topic

### DIFF
--- a/mavros/src/plugins/global_position.cpp
+++ b/mavros/src/plugins/global_position.cpp
@@ -125,7 +125,7 @@ public:
 
     // global origin
     gp_global_origin_pub = node->create_publisher<geographic_msgs::msg::GeoPointStamped>(
-      "~/gp_origin", sensor_qos);
+      "~/gp_origin", rclcpp::QoS(1 /* depth */).reliable().transient_local());
     gp_set_global_origin_sub =
       node->create_subscription<geographic_msgs::msg::GeoPointStamped>(
       "~/set_gp_origin", sensor_qos,

--- a/mavros_extras/src/plugins/guided_target.cpp
+++ b/mavros_extras/src/plugins/guided_target.cpp
@@ -67,7 +67,7 @@ public:
 
     // Subscriber for global origin (aka map origin).
     gp_origin_sub = node->create_subscription<geographic_msgs::msg::GeoPointStamped>(
-      "global_position/gp_origin", rclcpp::SensorDataQoS(),
+      "global_position/gp_origin", rclcpp::QoS(1 /* depth */).reliable().transient_local(),
       std::bind(&GuidedTargetPlugin::gp_origin_cb, this, _1));
   }
 


### PR DESCRIPTION
Set a QoS profile equivalent to "latched" behavior of ROS1 in order to receive the `gp_origin` message for late joiners.