### PR TITLE
Fix: yaml_cpp_vendor linking in mavros_extras

### DIFF
--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -186,10 +186,11 @@ public:
     // Delay parameter callback initialization because
     // add/del endpoints calls have to use shared_from_this(),
     // which cannot be used before we leave the constructor.
-    startup_delay_timer = this->create_wall_timer(10ms, [this]() {
-          this->startup_delay_timer->cancel();
-          this->param_init_once();
-    });
+    startup_delay_timer = this->create_wall_timer(
+      10ms, [this]() {
+        this->startup_delay_timer->cancel();
+        this->param_init_once();
+      });
   }
 
   void route_message(Endpoint::SharedPtr src, const mavlink_message_t * msg, const Framing framing);

--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -168,8 +168,9 @@ public:
   inline double geoid_to_ellipsoid_height(const T lla)
   {
     if (egm96_5) {
-      return egm96_5->ConvertHeight(lla->latitude, lla->longitude, 0.0,
-            GeographicLib::Geoid::GEOIDTOELLIPSOID);
+      return egm96_5->ConvertHeight(
+        lla->latitude, lla->longitude, 0.0,
+        GeographicLib::Geoid::GEOIDTOELLIPSOID);
     } else {
       return 0.0;
     }
@@ -189,8 +190,9 @@ public:
   inline double ellipsoid_to_geoid_height(const T lla)
   {
     if (egm96_5) {
-      return egm96_5->ConvertHeight(lla->latitude, lla->longitude, 0.0,
-            GeographicLib::Geoid::ELLIPSOIDTOGEOID);
+      return egm96_5->ConvertHeight(
+        lla->latitude, lla->longitude, 0.0,
+        GeographicLib::Geoid::ELLIPSOIDTOGEOID);
     } else {
       return 0.0;
     }

--- a/mavros/include/mavros/px4_custom_mode.hpp
+++ b/mavros/include/mavros/px4_custom_mode.hpp
@@ -100,7 +100,7 @@ union custom_mode {
   }
 
   constexpr custom_mode(uint8_t mm, uint8_t sm)
-  : mode{0, mm, sm}
+    : mode{0, mm, sm}
   {
   }
 };

--- a/mavros/src/lib/uas_tf.cpp
+++ b/mavros/src/lib/uas_tf.cpp
@@ -51,14 +51,17 @@ void UAS::publish_static_transform(
 void UAS::setup_static_tf()
 {
   std::vector<geometry_msgs::msg::TransformStamped> transform_vector;
-  add_static_transform(map_frame_id, map_frame_id + "_ned",
-            Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),
-            transform_vector);
-  add_static_transform(odom_frame_id, odom_frame_id + "_ned",
-            Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),
-            transform_vector);
-  add_static_transform(base_link_frame_id, base_link_frame_id + "_frd",
-            Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),
-            transform_vector);
+  add_static_transform(
+    map_frame_id, map_frame_id + "_ned",
+    Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),
+    transform_vector);
+  add_static_transform(
+    odom_frame_id, odom_frame_id + "_ned",
+    Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, M_PI_2)),
+    transform_vector);
+  add_static_transform(
+    base_link_frame_id, base_link_frame_id + "_frd",
+    Eigen::Affine3d(ftf::quaternion_from_rpy(M_PI, 0, 0)),
+    transform_vector);
   tf2_static_broadcaster.sendTransform(transform_vector);
 }

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -786,8 +786,9 @@ private:
       case enum_value(MAV_SEVERITY::ALERT):
       case enum_value(MAV_SEVERITY::CRITICAL):
       case enum_value(MAV_SEVERITY::ERROR):
-        RCLCPP_ERROR_STREAM(node->get_logger(),
-            "FCU: EVENT " << px4_id << " with args " << arg_str);
+        RCLCPP_ERROR_STREAM(
+          node->get_logger(),
+          "FCU: EVENT " << px4_id << " with args " << arg_str);
         break;
       case enum_value(MAV_SEVERITY::WARNING):
       case enum_value(MAV_SEVERITY::NOTICE):
@@ -797,8 +798,9 @@ private:
         RCLCPP_INFO_STREAM(node->get_logger(), "FCU: EVENT " << px4_id << " with args " << arg_str);
         break;
       case enum_value(MAV_SEVERITY::DEBUG):
-        RCLCPP_DEBUG_STREAM(node->get_logger(),
-            "FCU: EVENT " << px4_id << " with args " << arg_str);
+        RCLCPP_DEBUG_STREAM(
+          node->get_logger(),
+          "FCU: EVENT " << px4_id << " with args " << arg_str);
         break;
       // [[[end]]] (sum: g/XqtqiYn5)
       default:

--- a/mavros/test/test_frame_conversions.cpp
+++ b/mavros/test/test_frame_conversions.cpp
@@ -167,9 +167,9 @@ TEST(FRAME_TF, transform_frame__covariance3x3)
 
   // Rotation quaternion of PI around x axis
   const auto q = Eigen::Quaterniond(
-      Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitZ()) *
-                        Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) *
-                        Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX())
+    Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitZ()) *
+    Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) *
+    Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX())
   );
 
   /* Calculated as:
@@ -209,9 +209,9 @@ TEST(FRAME_TF, transform_frame__covariance6x6)
 
   // Rotation quaternion of PI around x axis
   const auto q = Eigen::Quaterniond(
-      Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitZ()) *
-                        Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) *
-                        Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX())
+    Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitZ()) *
+    Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) *
+    Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX())
   );
 
   /* Calculated as:

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -93,7 +93,7 @@ public:
 
     auto make_and_add_mock_endpoint =
       [router](id_t id, const std::string & url, LT type,
-      std::set<addr_t> remotes) {
+        std::set<addr_t> remotes) {
         auto ep = std::make_shared<MockEndpoint>();
 
         ep->parent = router;

--- a/mavros_extras/CMakeLists.txt
+++ b/mavros_extras/CMakeLists.txt
@@ -194,6 +194,8 @@ if(rclcpp_VERSION VERSION_GREATER_EQUAL 22.0.0)
   target_link_libraries(mavros_extras PUBLIC yaml-cpp::yaml-cpp)
 else()
   find_package(yaml_cpp_vendor REQUIRED)
+  target_link_libraries(mavros_extras_plugins PUBLIC yaml-cpp)
+  target_link_libraries(mavros_extras PUBLIC yaml-cpp)
 endif()
 
 install(TARGETS mavros_extras mavros_extras_plugins

--- a/mavros_extras/src/plugins/fake_gps.cpp
+++ b/mavros_extras/src/plugins/fake_gps.cpp
@@ -337,8 +337,9 @@ private:
       hil_gps.time_usec = get_time_usec(stamp);                 // [useconds]
       hil_gps.lat = geodetic.x() * 1e7;                         // [degrees * 1e7]
       hil_gps.lon = geodetic.y() * 1e7;                         // [degrees * 1e7]
-      hil_gps.alt = uas->data.egm96_5->ConvertHeight(geodetic.x(), geodetic.y(), geodetic.z(),
-            GeographicLib::Geoid::ELLIPSOIDTOGEOID) * 1e3;      // [meters * 1e3]
+      hil_gps.alt = uas->data.egm96_5->ConvertHeight(
+        geodetic.x(), geodetic.y(), geodetic.z(),
+        GeographicLib::Geoid::ELLIPSOIDTOGEOID) * 1e3;          // [meters * 1e3]
       hil_gps.vel = vel.block<2, 1>(0, 0).norm();               // [cm/s]
       hil_gps.vn = vel.x();                                     // [cm/s]
       hil_gps.ve = vel.y();                                     // [cm/s]
@@ -384,8 +385,9 @@ private:
       gps_input.vert_accuracy = vert_accuracy;          // [m] will either use the static parameter value, or the dynamic covariance from function mocap_pose_cov_cb() bellow  // NOLINT
       gps_input.lat = geodetic.x() * 1e7;               // [degrees * 1e7]
       gps_input.lon = geodetic.y() * 1e7;               // [degrees * 1e7]
-      gps_input.alt = uas->data.egm96_5->ConvertHeight(geodetic.x(), geodetic.y(), geodetic.z(),
-            GeographicLib::Geoid::ELLIPSOIDTOGEOID);        // [meters]
+      gps_input.alt = uas->data.egm96_5->ConvertHeight(
+        geodetic.x(), geodetic.y(), geodetic.z(),
+        GeographicLib::Geoid::ELLIPSOIDTOGEOID);            // [meters]
       gps_input.vn = vel.x();                               // [m/s]
       gps_input.ve = vel.y();                               // [m/s]
       gps_input.vd = vel.z();                               // [m/s]

--- a/mavros_extras/src/plugins/gimbal_control.cpp
+++ b/mavros_extras/src/plugins/gimbal_control.cpp
@@ -256,11 +256,13 @@ private:
     auto services_qos = rclcpp::ServicesQoS();
 #endif
 
-    cmd_cli = node->create_client<mavros_msgs::srv::CommandLong>("cmd/command", services_qos,
-          cb_group);
+    cmd_cli = node->create_client<mavros_msgs::srv::CommandLong>(
+      "cmd/command", services_qos,
+      cb_group);
     while (!cmd_cli->wait_for_service(std::chrono::seconds(5))) {
-      RCLCPP_ERROR(node->get_logger(),
-            "GimbalControl: mavros/cmd/command service not available after waiting");
+      RCLCPP_ERROR(
+        node->get_logger(),
+        "GimbalControl: mavros/cmd/command service not available after waiting");
       cmd_cli.reset();
       throw std::logic_error("client not connected");
     }

--- a/mavros_extras/src/plugins/landing_target.cpp
+++ b/mavros_extras/src/plugins/landing_target.cpp
@@ -466,11 +466,11 @@ private:
     bool position_valid = false;
 
     const auto data_frame = static_cast<MAV_FRAME>(req->frame);
-    switch(data_frame) {
+    switch (data_frame) {
       case MAV_FRAME::LOCAL_NED: {
           position = ftf::transform_frame_enu_ned(Eigen::Vector3d(tr.translation()));
           orientation = ftf::transform_orientation_enu_ned(
-          ftf::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation()))
+            ftf::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation()))
           );
           position_valid = true;
           break;
@@ -478,24 +478,24 @@ private:
       case MAV_FRAME::BODY_FRD: {
           position = ftf::transform_frame_baselink_aircraft(Eigen::Vector3d(tr.translation()));
           orientation = ftf::transform_orientation_baselink_aircraft(
-          Eigen::Quaterniond(tr.rotation()));
+            Eigen::Quaterniond(tr.rotation()));
           position_valid = true;
           break;
         }
       default: {
-        // Raise a warning if a non-zero frame value is provided
-        // XXX:  This is no ideal given that "0" is "MAV_FRAME::GLOBAL"
-        //      however this would be the "default value" for anyone
-        //      using this interface without setting frame correctly
-        //
-        //      The better option would be to expose "position_valid"
-        //      in mavros_msgs::msg::LandingTarget, but this will at
-        //      least allow people to use the angle interface without
-        //      getting a constant error stream.
-          if(data_frame != MAV_FRAME::GLOBAL) {
+          // Raise a warning if a non-zero frame value is provided
+          // XXX:  This is no ideal given that "0" is "MAV_FRAME::GLOBAL"
+          //      however this would be the "default value" for anyone
+          //      using this interface without setting frame correctly
+          //
+          //      The better option would be to expose "position_valid"
+          //      in mavros_msgs::msg::LandingTarget, but this will at
+          //      least allow people to use the angle interface without
+          //      getting a constant error stream.
+          if (data_frame != MAV_FRAME::GLOBAL) {
             RCLCPP_WARN_STREAM(
-            get_logger(),
-            "LT: Landing target frame '" << req->frame << "' is not supported"
+              get_logger(),
+              "LT: Landing target frame '" << req->frame << "' is not supported"
             );
           }
         }

--- a/mavros_extras/src/plugins/odom.cpp
+++ b/mavros_extras/src/plugins/odom.cpp
@@ -153,11 +153,11 @@ private:
     Eigen::Affine3d tf_child2child_des;
 
     lookup_static_transform(
-                fcu_map_id_des, fcu_map_id_des + "_ned",
-                tf_parent2parent_des);
+      fcu_map_id_des, fcu_map_id_des + "_ned",
+      tf_parent2parent_des);
     lookup_static_transform(
-                fcu_odom_child_id_des, fcu_odom_child_id_des + "_frd",
-                tf_child2child_des);
+      fcu_odom_child_id_des, fcu_odom_child_id_des + "_frd",
+      tf_child2child_des);
 
     //! Build 6x6 pose covariance matrix to be transformed and sent
     Matrix6d cov_pose = Matrix6d::Zero();

--- a/mavros_extras/src/plugins/onboard_computer_status.cpp
+++ b/mavros_extras/src/plugins/onboard_computer_status.cpp
@@ -99,8 +99,9 @@ private:
     std::copy(req->cpu_combined.cbegin(), req->cpu_combined.cend(), status.cpu_combined.begin());
     std::copy(req->gpu_cores.cbegin(), req->gpu_cores.cend(), status.gpu_cores.begin());
     std::copy(req->gpu_combined.cbegin(), req->gpu_combined.cend(), status.gpu_combined.begin());
-    std::copy(req->temperature_core.cbegin(), req->temperature_core.cend(),
-          status.temperature_core.begin());
+    std::copy(
+      req->temperature_core.cbegin(), req->temperature_core.cend(),
+      status.temperature_core.begin());
     std::copy(req->fan_speed.cbegin(), req->fan_speed.cend(), status.fan_speed.begin());
     std::copy(req->storage_type.cbegin(), req->storage_type.cend(), status.storage_type.begin());
     std::copy(req->storage_usage.cbegin(), req->storage_usage.cend(), status.storage_usage.begin());

--- a/mavros_extras/src/plugins/open_drone_id.cpp
+++ b/mavros_extras/src/plugins/open_drone_id.cpp
@@ -45,29 +45,29 @@ public:
   : Plugin(uas_, "open_drone_id")
   {
     basic_id_sub = node->create_subscription<mavros_msgs::msg::OpenDroneIDBasicID>(
-                        "~/basic_id", 1, std::bind(
-                        &OpenDroneIDPlugin::basic_id_cb, this,
-                        _1));
+      "~/basic_id", 1, std::bind(
+        &OpenDroneIDPlugin::basic_id_cb, this,
+        _1));
 
     operator_id_sub = node->create_subscription<mavros_msgs::msg::OpenDroneIDOperatorID>(
-                        "~/operator_id", 1, std::bind(
-                        &OpenDroneIDPlugin::operator_id_cb, this,
-                        _1));
+      "~/operator_id", 1, std::bind(
+        &OpenDroneIDPlugin::operator_id_cb, this,
+        _1));
 
     self_id_sub = node->create_subscription<mavros_msgs::msg::OpenDroneIDSelfID>(
-                        "~/self_id", 1, std::bind(
-                        &OpenDroneIDPlugin::self_id_cb, this,
-                        _1));
+      "~/self_id", 1, std::bind(
+        &OpenDroneIDPlugin::self_id_cb, this,
+        _1));
 
     system_sub = node->create_subscription<mavros_msgs::msg::OpenDroneIDSystem>(
-                        "~/system", 1, std::bind(
-                        &OpenDroneIDPlugin::system_cb, this,
-                        _1));
+      "~/system", 1, std::bind(
+        &OpenDroneIDPlugin::system_cb, this,
+        _1));
 
     system_update_sub = node->create_subscription<mavros_msgs::msg::OpenDroneIDSystemUpdate>(
-                        "~/system_update", 1, std::bind(
-                        &OpenDroneIDPlugin::system_update_cb, this,
-                        _1));
+      "~/system_update", 1, std::bind(
+        &OpenDroneIDPlugin::system_update_cb, this,
+        _1));
   }
 
   Subscriptions get_subscriptions()

--- a/mavros_extras/src/plugins/trajectory.cpp
+++ b/mavros_extras/src/plugins/trajectory.cpp
@@ -262,7 +262,7 @@ private:
 
       auto fill_point_rep_waypoints =
         [&](mavlink::common::msg::TRAJECTORY_REPRESENTATION_WAYPOINTS & t, const RosPoints & rp,
-        const size_t i) {
+          const size_t i) {
           const auto valid = req->point_valid[i];
 
           auto valid_so_far = trajectory.valid_points;
@@ -299,7 +299,7 @@ private:
       mavlink::common::msg::TRAJECTORY_REPRESENTATION_BEZIER trajectory {};
       auto fill_point_rep_bezier =
         [&](mavlink::common::msg::TRAJECTORY_REPRESENTATION_BEZIER & t, const RosPoints & rp,
-        const size_t i) {
+          const size_t i) {
           const auto valid = req->point_valid[i];
 
           auto valid_so_far = trajectory.valid_points;
@@ -382,7 +382,7 @@ private:
 
     auto fill_msg_point =
       [&](RosPoints & p, const mavlink::common::msg::TRAJECTORY_REPRESENTATION_WAYPOINTS & t,
-      const size_t i) {
+        const size_t i) {
         fill_msg_position(p.position, t, i);
         fill_msg_velocity(p.velocity, t, i);
         fill_msg_acceleration(p.acceleration_or_force, t, i);


### PR DESCRIPTION
## Summary
Fixes yaml_cpp_vendor linking issue in mavros_extras CMakeLists.txt

## Changes
- Updated CMake configuration in `mavros_extras/CMakeLists.txt` to properly handle
yaml_cpp_vendor target for older ROS2 versions
- Ensures compatibility across different ROS2 distributions

## Testing
- [✓] Built successfully with `colcon build`
- [✓] Code style checked with `ament_uncrustify --reformat`
- [✓] Tested on ROS2 Humble

## Related Issues
Fixes build/linking issues with yaml-cpp vendor package on pre-Jazzy ROS2 distributions

## Type of Change
- [✓] Bug fix (non-breaking change which fixes an issue)
- [✗] New feature
- [✗] Breaking change
- [✗] Documentation update