### PR TITLE
Fix overflow in ros_time_from_ns()

### DIFF
--- a/mavros/src/lib/uas_timesync.cpp
+++ b/mavros/src/lib/uas_timesync.cpp
@@ -21,9 +21,7 @@ using namespace mavros::uas;    // NOLINT
 
 static inline rclcpp::Time ros_time_from_ns(const uint64_t stamp_ns)
 {
-  return rclcpp::Time(
-    stamp_ns / 1000000000UL,                            // t_sec
-    stamp_ns % 1000000000UL);                           // t_nsec
+  return rclcpp::Time(static_cast<int64_t>(stamp_ns));
 }
 
 rclcpp::Time UAS::synchronise_stamp(uint32_t time_boot_ms)

--- a/mavros/test/test_uas.cpp
+++ b/mavros/test/test_uas.cpp
@@ -252,6 +252,28 @@ TEST_F(TestUAS, add_plugin__route_message__filter)
   testing::Mock::VerifyAndClearExpectations(&(*plugin2));
 }
 
+TEST_F(TestUAS, synchronise_stamp_negative_offset)
+{
+  auto uas = create_node();
+
+  // Scenario: FCU was on boot time, so offset is approx current epoch (e.g. 1.7e9 seconds)
+  int64_t offset_ns = 1700000000LL * 1000000000LL;
+  uas->set_time_offset(static_cast<uint64_t>(offset_ns));
+
+  // FCU jumps to GPS time (also approx 1.7e9 seconds)
+  // Use uint64_t version of synchronise_stamp
+  uint64_t time_usec = 1700000000ULL * 1000000ULL;
+
+  // Total time = 3.4e9 seconds.
+  // This overflows int32_t (max 2.14e9), becoming negative.
+  // rclcpp::Time(int32_t, uint32_t) will see a negative second and throw.
+
+  // This should not throw (once fixed)
+  EXPECT_NO_THROW({
+    rclcpp::Time stamp = uas->synchronise_stamp(time_usec);
+  });
+}
+
 }  // namespace uas
 }  // namespace mavros
 

--- a/mavros/test/test_uas.cpp
+++ b/mavros/test/test_uas.cpp
@@ -269,9 +269,10 @@ TEST_F(TestUAS, synchronise_stamp_negative_offset)
   // rclcpp::Time(int32_t, uint32_t) will see a negative second and throw.
 
   // This should not throw (once fixed)
-  EXPECT_NO_THROW({
-    rclcpp::Time stamp = uas->synchronise_stamp(time_usec);
-  });
+  EXPECT_NO_THROW(
+      {
+        rclcpp::Time stamp = uas->synchronise_stamp(time_usec);
+      });
 }
 
 }  // namespace uas


### PR DESCRIPTION
## Summary
This pull request resolves an issue where MAVROS may throw a runtime exception when constructing `rclcpp::Time` under certain timing conditions. The problem occurs when the FCU transitions from boot-time timestamps to GPS epoch time, leading to extremely large timestamp values that overflow the `(sec, nsec)` constructor and appear negative.

```
terminate called after throwing an instance of 'std::runtime_error' what(): 
  cannot store a negative time point in rclcpp::Time Aborted (core dumped) 
  make: *** [Makefile:58: run] Error 134
```

## Root Cause
The previous implementation decomposed a nanosecond timestamp into `(sec, nsec)`:

```cpp
rclcpp::Time(stamp_ns / 1000000000UL, stamp_ns % 1000000000UL);
```

When combined timestamps exceeded the `int32_t` range for seconds, the constructor interpreted the result as negative, causing `rclcpp::Time` to throw an exception. This scenario commonly arises when:
- The FCU operates initially on monotonic boot-time.
- MAVROS applies a large offset to approximate epoch time.
- The FCU later switches to GPS time.

## Fix
The implementation now uses the `rclcpp::Time(int64_t nanoseconds)` constructor, which safely handles large 64-bit timestamps:

```cpp
return rclcpp::Time(static_cast<int64_t>(stamp_ns));
```

## Added Test
Added a test to `test_uas.cpp` which simulates:
- A large boot-time offset (~1.7e9 seconds).
- A subsequent shift to GPS time.
