### PR TITLE
Fix:: Reduce CPU usage by enabling intra-process communication and b…

### DIFF
--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -469,8 +469,7 @@ std::pair<bool, std::string> ROSEndpoint::open()
   }
 
   try {
-    auto qos = QoS(
-      1000).best_effort().durability_volatile();
+    auto qos = rclcpp::SensorDataQoS();
     this->source =
       nh->create_publisher<mavros_msgs::msg::Mavlink>(
       utils::format(

--- a/mavros/src/lib/mavros_uas.cpp
+++ b/mavros/src/lib/mavros_uas.cpp
@@ -346,8 +346,7 @@ rcl_interfaces::msg::SetParametersResult UAS::on_set_parameters_cb(
 
 void UAS::connect_to_router()
 {
-  auto qos = rclcpp::QoS(
-    1000).best_effort().durability_volatile();
+  auto qos = rclcpp::SensorDataQoS();
 
   this->sink =
     this->create_publisher<mavros_msgs::msg::Mavlink>(

--- a/mavros/src/lib/uas_executor.cpp
+++ b/mavros/src/lib/uas_executor.cpp
@@ -29,7 +29,7 @@ UASExecutor::UASExecutor(const rclcpp::ExecutorOptions & options)
 size_t UASExecutor::select_number_of_threads()
 {
   // return std::max<size_t>(16, std::min<size_t>(std::thread::hardware_concurrency(), 4));
-  return std::clamp<size_t>(std::thread::hardware_concurrency(), 4, 16);
+  return std::clamp<size_t>(std::thread::hardware_concurrency(), 2, 8);
 }
 
 void UASExecutor::set_ids(uint8_t sysid, uint8_t compid)

--- a/mavros/src/mavros_node.cpp
+++ b/mavros/src/mavros_node.cpp
@@ -29,7 +29,7 @@ int main(int argc, char * argv[])
   rclcpp::executors::MultiThreadedExecutor exec(rclcpp::ExecutorOptions(), 2);
 
   rclcpp::NodeOptions options;
-  // options.use_intra_process_comms(true);
+  options.use_intra_process_comms(true);
 
   std::string fcu_url, gcs_url, uas_url;
   std::string base_link_frame_id, odom_frame_id, map_frame_id;


### PR DESCRIPTION
Reduced CPU usage by enabling intra-process communication and by switching to sensor Qos.

Without intra-process comms, messages traverse the RMW and DDS layers even when publisher and subscriber are in the same process. Also there is a chance of aggressive default QoS on internal bus.

1. uncomment this -> options.use_intra_process_comms(true);
2. Use SensorDataQoS instead of Default Qos.
3. I have also reduced the number of threads, but 'std::thread::hardware_concurrency()' can be configurable by using an env or something.