### PR TITLE
Fix: Race condition in param plugin causes "Promise already satisfied" crash

### DIFF
--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -406,6 +406,7 @@ public:
 
   Parameter param;
   std::atomic<size_t> retries_remaining;
+  std::atomic<bool> completed{false};
   std::promise<Result> promise;
 };
 
@@ -579,7 +580,10 @@ private:
         // check that ack required
         auto set_it = set_parameters.find(p.param_id);
         if (set_it != set_parameters.end()) {
-          set_it->second->promise.set_value({true, p});
+          // Guard against double-set if timeout already fired
+          if (!set_it->second->completed.exchange(true)) {
+            set_it->second->promise.set_value({true, p});
+          }
         }
 
         RCLCPP_WARN_STREAM_EXPRESSION(
@@ -842,7 +846,10 @@ private:
         RCLCPP_ERROR(
           lg, "PR: Param set for %s timed out.",
           it->second->param.param_id.c_str());
-        it->second->promise.set_value({false, it->second->param});
+        // Guard against double-set if param value arrives late
+        if (!it->second->completed.exchange(true)) {
+          it->second->promise.set_value({false, it->second->param});
+        }
       }
 
     } else {


### PR DESCRIPTION
## Problem

Race condition during parameter set operations using `/mavros/param/set` or `/mavros/param/set_parameters` can cause the MAVROS node to crash with:

```
terminate called after throwing an instance of 'std::future_error'
  what():  std::future_error: Promise already satisfied
```

This occurs when a MAVLink response arrives late to `handle_param_value()` after `timeout_cb()` for that particular param set operation has already set the promise to failure. Both code paths attempt to call `promise.set_value()`, but `std::promise` can only be satisfied once.

We hit this intermittently in PX4/APM SITL and on real hardware when uploading missions that require setting autopilot parameters immediately before mission upload. 

We attempted several workarounds on our application side (rate limiting, serializing param calls, adding delays) but could not consistently prevent the crash. Since the node crashing is a game-over scenario for a vehicle in flight, we opted to address the issue in MAVROS directly.

## Fix

Add an atomic completion flag to `ParamSetOpt` that guards all `promise.set_value()` call sites. Simply check if already completed and do not set the promise again if so.

An alternative approach would be to erase the offending `ParamSetOpt` from the operations map within `timeout_cb()` so that it's not found when checking for ACK requirement in `handle_param_value()`. `PARAM_TIMEOUT` could also be increased (and maybe should) but doing that alone still leaves open the potential race condition crash.

There is definitely potential for the param plugin logic to mislead the application side if the timeout resolves the service call with unsuccessful and it actually ends up succeeding. **But at least MAVROS won't crash.**

### Changes

**`src/plugins/param.cpp`**

1. Add `std::atomic<bool> completed{false}` to `ParamSetOpt` struct
2. Guard promise in `handle_param_value()`:
   ```cpp
   if (!set_it->second->completed.exchange(true)) {
     set_it->second->promise.set_value({true, p});
   }
   ```
3. Guard promise in `timeout_cb()`:
   ```cpp
   if (!it->second->completed.exchange(true)) {
     it->second->promise.set_value({false, it->second->param});
   }
   ```