### PR TITLE
Refactor mavconn

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,97 @@
+---
+
+name: Coverage
+
+on:
+  push:
+    branches: [master, ros2]
+  pull_request:
+    branches: [master, ros2]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: "${{ matrix.component.name }} (ROS ${{ matrix.ros_distro }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: [kilted]
+        component:
+          # Add more entries here when enabling coverage for more modules.
+          # Example:
+          # - name: mavros
+          #   packages: mavros
+          #   source_filter: ".*/mavros/.*"
+          - name: libmavconn
+            packages: libmavconn
+            source_filter: ".*/libmavconn/.*"
+
+    env:
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+      COMPONENT_NAME: ${{ matrix.component.name }}
+      COMPONENT_PACKAGES: ${{ matrix.component.packages }}
+      COMPONENT_FILTER: ${{ matrix.component.source_filter }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTRO }}
+
+      - name: Install Coverage Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-gcovr
+
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          rosdep update
+          rosdep install --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} -y
+
+      - name: Build With Coverage
+        shell: bash
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          colcon build --packages-up-to ${COMPONENT_PACKAGES} --cmake-args \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS=--coverage \
+            -DCMAKE_CXX_FLAGS=--coverage
+
+      - name: Run Tests
+        shell: bash
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          source install/setup.bash
+          colcon test --packages-select ${COMPONENT_PACKAGES}
+          colcon test-result --verbose
+
+      - name: Generate Coverage Report
+        shell: bash
+        run: |
+          mkdir -p coverage/${COMPONENT_NAME}
+          gcovr \
+            --root "${GITHUB_WORKSPACE}" \
+            --filter "${COMPONENT_FILTER}" \
+            --xml-pretty \
+            --output "coverage/${COMPONENT_NAME}/coverage.xml" \
+            --html-details "coverage/${COMPONENT_NAME}/coverage.html" \
+            --exclude-unreachable-branches \
+            "${GITHUB_WORKSPACE}/build"
+
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.component.name }}-${{ matrix.ros_distro }}
+          path: coverage/${{ matrix.component.name }}
+          if-no-files-found: error

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Coverage Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-gcovr
+          sudo apt-get install -y gcovr
 
       - name: Install Dependencies
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,11 @@
 
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, ros2]
+  pull_request:
+    branches: [master, ros2]
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ core
 libmavconn/include/mavconn/mavlink_dialect.hpp
 libmavconn/src/mavlink_helpers.cpp
 tools/build/
+
+# in case you have run colcon here
+build/
+log/
+install/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Guidance for coding agents in this repository.
 
 ## Build And Test
 
+- Run build/test commands from workspace root (`/ws` in devcontainer), not from `/ws/src/mavros`.
 - Build (workspace root):
   - `colcon build --packages-up-to mavros mavros_extras mavros_msgs`
 - Local test runs are not required on every iteration, but are recommended for risky changes:
@@ -37,6 +38,7 @@ Guidance for coding agents in this repository.
 - Prefer devcontainer for reproducible local build/test when available.
 - Default config: `.devcontainer/devcontainer.json`
   - Scope-limited mount to `/ws/src/mavros` (only this repository).
+  - Run `colcon` from `/ws`.
 - Optional full-workspace config: `.devcontainer/whole-workspace/devcontainer.json`
   - Mounts `${localWorkspaceFolder}/../..` to `/ws`.
   - Requires repository path `<workspace>/src/mavros`.

--- a/libmavconn/README.md
+++ b/libmavconn/README.md
@@ -37,6 +37,35 @@ Same as for mavros:
   - compiler with C++14 support
 
 
+Shared io_service (optional)
+----------------------------
+
+By default each connection owns and runs its own `asio::io_service` thread.
+For multi-connection setups you can provide a shared `asio::io_service` and
+run it from your own thread pool.
+
+```cpp
+#include <asio.hpp>
+#include <mavconn/interface.hpp>
+
+asio::io_service shared_io;
+auto work = std::make_unique<asio::io_service::work>(shared_io);
+std::thread io_thread([&]() { shared_io.run(); });
+
+auto conn = mavconn::MAVConnInterface::open_url(
+  "udp://0.0.0.0:14555@127.0.0.1:14550",
+  1, mavconn::MAV_COMP_ID_UDP_BRIDGE,
+  [](const mavlink::mavlink_message_t *, mavconn::Framing) {},
+  {},
+  &shared_io);
+
+conn->close();
+work.reset();
+shared_io.stop();
+io_thread.join();
+```
+
+
 License
 -------
 

--- a/libmavconn/README.md
+++ b/libmavconn/README.md
@@ -34,7 +34,7 @@ Same as for mavros:
   - Linux host
   - Asio library ( https://think-async.com/Asio/ )
   - console-bridge library
-  - compiler with C++14 support
+  - compiler with C++20 support
 
 
 Shared io_service (optional)
@@ -50,7 +50,7 @@ run it from your own thread pool.
 
 asio::io_service shared_io;
 auto work = std::make_unique<asio::io_service::work>(shared_io);
-std::thread io_thread([&]() { shared_io.run(); });
+std::jthread io_thread([&]() { shared_io.run(); });
 
 auto conn = mavconn::MAVConnInterface::open_url(
   "udp://0.0.0.0:14555@127.0.0.1:14550",
@@ -62,7 +62,6 @@ auto conn = mavconn::MAVConnInterface::open_url(
 conn->close();
 work.reset();
 shared_io.stop();
-io_thread.join();
 ```
 
 

--- a/libmavconn/include/mavconn/interface.hpp
+++ b/libmavconn/include/mavconn/interface.hpp
@@ -218,11 +218,11 @@ public:
   //! Port closed notification callback
   ClosedCb port_closed_cb;
 
-  virtual mavlink::mavlink_status_t get_status();
-  virtual IOStat get_iostat();
-  virtual bool is_open() = 0;
+  [[nodiscard]] virtual mavlink::mavlink_status_t get_status();
+  [[nodiscard]] virtual IOStat get_iostat();
+  [[nodiscard]] virtual bool is_open() = 0;
 
-  inline uint8_t get_system_id()
+  [[nodiscard]] inline uint8_t get_system_id()
   {
     return sys_id;
   }
@@ -230,7 +230,7 @@ public:
   {
     sys_id = sysid;
   }
-  inline uint8_t get_component_id()
+  [[nodiscard]] inline uint8_t get_component_id()
   {
     return comp_id;
   }
@@ -243,7 +243,7 @@ public:
    * Set protocol used for encoding mavlink::Mavlink messages.
    */
   void set_protocol_version(Protocol pver);
-  Protocol get_protocol_version();
+  [[nodiscard]] Protocol get_protocol_version();
 
   /**
    * @brief Construct connection from URL

--- a/libmavconn/include/mavconn/interface.hpp
+++ b/libmavconn/include/mavconn/interface.hpp
@@ -262,7 +262,7 @@ public:
    * @return @a Ptr to constructed interface class,
    *         or throw @a DeviceError if error occurred.
    */
-  static Ptr open_url(
+  [[nodiscard]] static Ptr open_url(
     std::string url,
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     const ReceivedCb & cb_handle_message = ReceivedCb(),
@@ -273,13 +273,13 @@ public:
   /**
    * @brief version of open_url() which do not perform connect()
    */
-  static Ptr open_url_no_connect(
+  [[nodiscard]] static Ptr open_url_no_connect(
     std::string url,
     uint8_t system_id = 1,
     uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     asio::io_service * shared_io = nullptr);
 
-  static std::vector<std::string> get_known_dialects();
+  [[nodiscard]] static std::vector<std::string> get_known_dialects();
 
 protected:
   uint8_t sys_id;    //!< Connection System Id

--- a/libmavconn/include/mavconn/interface.hpp
+++ b/libmavconn/include/mavconn/interface.hpp
@@ -38,6 +38,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <asio.hpp>
 #include <mavconn/mavlink_dialect.hpp>
 
 namespace mavconn
@@ -266,7 +267,8 @@ public:
     std::string url,
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     const ReceivedCb & cb_handle_message = ReceivedCb(),
-    const ClosedCb & cb_handle_closed_port = ClosedCb()
+    const ClosedCb & cb_handle_closed_port = ClosedCb(),
+    asio::io_service * shared_io = nullptr
   );
 
   /**
@@ -275,7 +277,8 @@ public:
   static Ptr open_url_no_connect(
     std::string url,
     uint8_t system_id = 1,
-    uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE);
+    uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
+    asio::io_service * shared_io = nullptr);
 
   static std::vector<std::string> get_known_dialects();
 

--- a/libmavconn/include/mavconn/interface.hpp
+++ b/libmavconn/include/mavconn/interface.hpp
@@ -259,6 +259,8 @@ public:
    * @param[in] url           resource locator
    * @param[in] system_id     optional system id
    * @param[in] component_id  optional component id
+   * @param[in] shared_io     optional external io_service. If provided, caller owns
+   *                          its execution/threading lifecycle.
    * @return @a Ptr to constructed interface class,
    *         or throw @a DeviceError if error occurred.
    */
@@ -272,6 +274,9 @@ public:
 
   /**
    * @brief version of open_url() which do not perform connect()
+   *
+   * @param[in] shared_io optional external io_service. If provided, caller owns
+   *                      its execution/threading lifecycle.
    */
   [[nodiscard]] static Ptr open_url_no_connect(
     std::string url,

--- a/libmavconn/include/mavconn/interface.hpp
+++ b/libmavconn/include/mavconn/interface.hpp
@@ -44,7 +44,6 @@
 namespace mavconn
 {
 using steady_clock = std::chrono::steady_clock;
-using lock_guard = std::lock_guard<std::recursive_mutex>;
 
 //! Same as @p mavlink::common::MAV_COMPONENT::COMP_ID_UDP_BRIDGE
 static constexpr auto MAV_COMP_ID_UDP_BRIDGE = 240;
@@ -327,7 +326,7 @@ private:
   mavlink::mavlink_status_t m_mavlink_status;
 
   std::atomic<size_t> tx_total_bytes, rx_total_bytes;
-  std::recursive_mutex iostat_mutex;
+  std::mutex iostat_mutex;
   size_t last_tx_total_bytes, last_rx_total_bytes;
   std::chrono::time_point<steady_clock> last_iostat;
 

--- a/libmavconn/include/mavconn/io_context_runner.hpp
+++ b/libmavconn/include/mavconn/io_context_runner.hpp
@@ -35,17 +35,17 @@ public:
     is_running_(false)
   {}
 
-  asio::io_service & io()
+  [[nodiscard]] asio::io_service & io()
   {
     return io_;
   }
 
-  bool owns_thread() const
+  [[nodiscard]] bool owns_thread() const
   {
     return owns_thread_;
   }
 
-  bool is_running() const
+  [[nodiscard]] bool is_running() const
   {
     return is_running_.load();
   }

--- a/libmavconn/include/mavconn/io_context_runner.hpp
+++ b/libmavconn/include/mavconn/io_context_runner.hpp
@@ -81,9 +81,17 @@ public:
       return;
     }
 
-    if (std::this_thread::get_id() != io_thread_.get_id() && io_thread_.joinable()) {
-      io_thread_.join();
+    if (!io_thread_.joinable()) {
+      return;
     }
+
+    if (std::this_thread::get_id() == io_thread_.get_id()) {
+      // Cannot join from the same thread; detach so destructor can't terminate.
+      io_thread_.detach();
+      return;
+    }
+
+    io_thread_.join();
   }
 
   void reset_owned()

--- a/libmavconn/include/mavconn/io_context_runner.hpp
+++ b/libmavconn/include/mavconn/io_context_runner.hpp
@@ -1,0 +1,116 @@
+//
+// libmavconn
+// Copyright 2026 Vladimir Ermakov, contributors.
+//
+// This file is part of the mavros package and subject to the license terms
+// in the top-level LICENSE file of the mavros repository.
+// https://github.com/mavlink/mavros/tree/master/LICENSE.md
+//
+
+#pragma once
+#ifndef MAVCONN__IO_CONTEXT_RUNNER_HPP_
+#define MAVCONN__IO_CONTEXT_RUNNER_HPP_
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <utility>
+
+#include <asio.hpp>
+
+namespace mavconn
+{
+
+/**
+ * @brief Small utility to unify owned/shared io_service lifecycle handling.
+ */
+class IoContextRunner
+{
+public:
+  explicit IoContextRunner(asio::io_service * shared_io = nullptr)
+  : io_owner_(shared_io ? nullptr : std::make_shared<asio::io_service>()),
+    io_(shared_io ? *shared_io : *io_owner_),
+    io_work_(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_)),
+    owns_thread_(shared_io == nullptr),
+    is_running_(false)
+  {}
+
+  asio::io_service & io()
+  {
+    return io_;
+  }
+
+  bool owns_thread() const
+  {
+    return owns_thread_;
+  }
+
+  bool is_running() const
+  {
+    return is_running_.load();
+  }
+
+  template<typename Fn>
+  void start(Fn && fn)
+  {
+    if (!owns_thread_) {
+      return;
+    }
+
+    io_thread_ = std::thread(
+      [this, f = std::forward<Fn>(fn)]() mutable {
+        is_running_ = true;
+        f();
+        is_running_ = false;
+      });
+  }
+
+  void stop_owned()
+  {
+    if (!owns_thread_) {
+      return;
+    }
+
+    io_work_.reset();
+    io_.stop();
+  }
+
+  void join_owned()
+  {
+    if (!owns_thread_) {
+      return;
+    }
+
+    if (std::this_thread::get_id() != io_thread_.get_id() && io_thread_.joinable()) {
+      io_thread_.join();
+    }
+  }
+
+  void reset_owned()
+  {
+    if (!owns_thread_) {
+      return;
+    }
+
+    io_.reset();
+  }
+
+  void shutdown_owned()
+  {
+    stop_owned();
+    join_owned();
+    reset_owned();
+  }
+
+private:
+  std::shared_ptr<asio::io_service> io_owner_;
+  asio::io_service & io_;
+  std::unique_ptr<asio::io_service::work> io_work_;
+  bool owns_thread_;
+  std::atomic<bool> is_running_;
+  std::thread io_thread_;
+};
+
+}  // namespace mavconn
+
+#endif  // MAVCONN__IO_CONTEXT_RUNNER_HPP_

--- a/libmavconn/include/mavconn/io_context_runner.hpp
+++ b/libmavconn/include/mavconn/io_context_runner.hpp
@@ -57,7 +57,7 @@ public:
       return;
     }
 
-    io_thread_ = std::thread(
+    io_thread_ = std::jthread(
       [this, f = std::forward<Fn>(fn)]() mutable {
         is_running_ = true;
         f();
@@ -71,6 +71,7 @@ public:
       return;
     }
 
+    io_thread_.request_stop();
     io_work_.reset();
     io_.stop();
   }
@@ -116,7 +117,7 @@ private:
   std::unique_ptr<asio::io_service::work> io_work_;
   bool owns_thread_;
   std::atomic<bool> is_running_;
-  std::thread io_thread_;
+  std::jthread io_thread_;
 };
 
 }  // namespace mavconn

--- a/libmavconn/include/mavconn/serial.hpp
+++ b/libmavconn/include/mavconn/serial.hpp
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <string>
 
 #include <asio.hpp>
@@ -48,7 +49,8 @@ public:
    */
   MAVConnSerial(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
-    std::string device = DEFAULT_DEVICE, unsigned baudrate = DEFAULT_BAUDRATE, bool hwflow = false);
+    std::string device = DEFAULT_DEVICE, unsigned baudrate = DEFAULT_BAUDRATE,
+    bool hwflow = false, asio::io_service * shared_io = nullptr);
   virtual ~MAVConnSerial();
 
   void connect(
@@ -66,7 +68,9 @@ public:
   }
 
 private:
-  asio::io_service io_service;
+  std::shared_ptr<asio::io_service> io_context_owner;
+  asio::io_service & io_service;
+  bool own_io_thread;
   std::thread io_thread;
   asio::serial_port serial_dev;
 

--- a/libmavconn/include/mavconn/serial.hpp
+++ b/libmavconn/include/mavconn/serial.hpp
@@ -77,7 +77,7 @@ private:
   std::atomic<bool> tx_in_progress;
   std::deque<MsgBuffer> tx_q;
   std::array<uint8_t, MsgBuffer::MAX_SIZE> rx_buf;
-  std::recursive_mutex mutex;
+  std::mutex mutex;
 
   void do_read();
   void do_write(bool check_tx_state);

--- a/libmavconn/include/mavconn/serial.hpp
+++ b/libmavconn/include/mavconn/serial.hpp
@@ -63,7 +63,7 @@ public:
   void send_message(const mavlink::Message & message, const uint8_t source_compid) override;
   void send_bytes(const uint8_t * bytes, size_t length) override;
 
-  inline bool is_open() override
+  [[nodiscard]] inline bool is_open() override
   {
     return serial_dev.is_open();
   }

--- a/libmavconn/include/mavconn/serial.hpp
+++ b/libmavconn/include/mavconn/serial.hpp
@@ -26,6 +26,7 @@
 
 #include <asio.hpp>
 #include <mavconn/interface.hpp>
+#include <mavconn/io_context_runner.hpp>
 #include <mavconn/msgbuffer.hpp>
 
 namespace mavconn
@@ -68,10 +69,8 @@ public:
   }
 
 private:
-  std::shared_ptr<asio::io_service> io_context_owner;
+  IoContextRunner io_runner;
   asio::io_service & io_service;
-  bool own_io_thread;
-  std::thread io_thread;
   asio::serial_port serial_dev;
 
   std::atomic<bool> tx_in_progress;

--- a/libmavconn/include/mavconn/serial.hpp
+++ b/libmavconn/include/mavconn/serial.hpp
@@ -47,6 +47,8 @@ public:
    *
    * @param[in] device    TTY device path
    * @param[in] baudrate  serial baudrate
+   * @param[in] shared_io optional external io_service. If provided, caller owns
+   *                      its execution/threading lifecycle.
    */
   MAVConnSerial(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -96,7 +96,7 @@ private:
   std::atomic<bool> tx_in_progress;
   std::deque<MsgBuffer> tx_q;
   std::array<uint8_t, MsgBuffer::MAX_SIZE> rx_buf;
-  std::recursive_mutex mutex;
+  std::mutex mutex;
 
   /**
    * This special function called by TCP server when connection accepted.
@@ -163,7 +163,7 @@ private:
   std::atomic<bool> is_destroying;
 
   std::list<std::shared_ptr<MAVConnTCPClient>> client_list;
-  std::recursive_mutex mutex;
+  std::mutex mutex;
 
   void do_accept();
 

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -28,6 +28,7 @@
 
 #include <asio.hpp>
 #include <mavconn/interface.hpp>
+#include <mavconn/io_context_runner.hpp>
 #include <mavconn/msgbuffer.hpp>
 
 namespace mavconn
@@ -81,12 +82,8 @@ public:
 
 private:
   friend class MAVConnTCPServer;
-  std::shared_ptr<asio::io_service> io_context_owner;
+  IoContextRunner io_runner;
   asio::io_service & io_service;
-  std::unique_ptr<asio::io_service::work> io_work;
-  bool own_io_thread;
-  std::thread io_thread;
-  std::atomic<bool> is_running;  //!< io_thread running
 
   asio::ip::tcp::socket socket;
   asio::ip::tcp::endpoint server_ep;
@@ -151,11 +148,8 @@ public:
   }
 
 private:
-  std::shared_ptr<asio::io_service> io_context_owner;
+  IoContextRunner io_runner;
   asio::io_service & io_service;
-  std::unique_ptr<asio::io_service::work> io_work;
-  bool own_io_thread;
-  std::thread io_thread;
 
   asio::ip::tcp::acceptor acceptor;
   asio::ip::tcp::endpoint bind_ep;

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -53,7 +53,8 @@ public:
   MAVConnTCPClient(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     std::string server_host = DEFAULT_SERVER_HOST,
-    uint16_t server_port = DEFAULT_SERVER_PORT);
+    uint16_t server_port = DEFAULT_SERVER_PORT,
+    asio::io_service * shared_io = nullptr);
 
   /**
    * Special client variation for use in MAVConnTCPServer
@@ -80,8 +81,10 @@ public:
 
 private:
   friend class MAVConnTCPServer;
-  asio::io_service io_service;
+  std::shared_ptr<asio::io_service> io_context_owner;
+  asio::io_service & io_service;
   std::unique_ptr<asio::io_service::work> io_work;
+  bool own_io_thread;
   std::thread io_thread;
   std::atomic<bool> is_running;  //!< io_thread running
 
@@ -127,7 +130,8 @@ public:
    */
   MAVConnTCPServer(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
-    std::string bind_host = DEFAULT_BIND_HOST, uint16_t bind_port = DEFAULT_BIND_PORT);
+    std::string bind_host = DEFAULT_BIND_HOST, uint16_t bind_port = DEFAULT_BIND_PORT,
+    asio::io_service * shared_io = nullptr);
   virtual ~MAVConnTCPServer();
 
   void connect(
@@ -147,8 +151,10 @@ public:
   }
 
 private:
-  asio::io_service io_service;
+  std::shared_ptr<asio::io_service> io_context_owner;
+  asio::io_service & io_service;
   std::unique_ptr<asio::io_service::work> io_work;
+  bool own_io_thread;
   std::thread io_thread;
 
   asio::ip::tcp::acceptor acceptor;

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -50,6 +50,8 @@ public:
    * Create generic TCP client (connect to the server)
    * @param[id] server_addr    remote host
    * @param[id] server_port    remote port
+   * @param[id] shared_io      optional external io_service. If provided, caller owns
+   *                           its execution/threading lifecycle.
    */
   MAVConnTCPClient(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
@@ -124,6 +126,8 @@ public:
   /**
    * @param[id] server_addr    bind host
    * @param[id] server_port    bind port
+   * @param[id] shared_io      optional external io_service. If provided, caller owns
+   *                           its execution/threading lifecycle.
    */
   MAVConnTCPServer(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -75,7 +75,7 @@ public:
   void send_message(const mavlink::Message & message, const uint8_t source_compid) override;
   void send_bytes(const uint8_t * bytes, size_t length) override;
 
-  inline bool is_open() override
+  [[nodiscard]] inline bool is_open() override
   {
     return socket.is_open();
   }
@@ -142,7 +142,7 @@ public:
 
   mavlink::mavlink_status_t get_status() override;
   IOStat get_iostat() override;
-  inline bool is_open() override
+  [[nodiscard]] inline bool is_open() override
   {
     return acceptor.is_open();
   }

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -54,6 +54,8 @@ public:
    * @param[id] bind_port    bind port
    * @param[id] remote_host  remote host (optional)
    * @param[id] remote_port  remote port (optional)
+   * @param[id] shared_io    optional external io_service. If provided, caller owns
+   *                         its execution/threading lifecycle.
    */
   MAVConnUDP(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -26,6 +26,7 @@
 
 #include <asio.hpp>
 #include <mavconn/interface.hpp>
+#include <mavconn/io_context_runner.hpp>
 #include <mavconn/msgbuffer.hpp>
 
 namespace mavconn
@@ -80,12 +81,8 @@ public:
   std::string get_remote_endpoint() const;
 
 private:
-  std::shared_ptr<asio::io_service> io_context_owner;
+  IoContextRunner io_runner;
   asio::io_service & io_service;
-  std::unique_ptr<asio::io_service::work> io_work;
-  bool own_io_thread;
-  std::thread io_thread;
-  std::atomic<bool> is_running;  //!< io_thread running
   bool permanent_broadcast;
 
   std::atomic<bool> remote_exists;

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -58,7 +58,8 @@ public:
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     std::string bind_host = DEFAULT_BIND_HOST, uint16_t bind_port = DEFAULT_BIND_PORT,
     std::string remote_host = DEFAULT_REMOTE_HOST,
-    uint16_t remote_port = DEFAULT_REMOTE_PORT);
+    uint16_t remote_port = DEFAULT_REMOTE_PORT,
+    asio::io_service * shared_io = nullptr);
 
   virtual ~MAVConnUDP();
 
@@ -79,8 +80,10 @@ public:
   std::string get_remote_endpoint() const;
 
 private:
-  asio::io_service io_service;
+  std::shared_ptr<asio::io_service> io_context_owner;
+  asio::io_service & io_service;
   std::unique_ptr<asio::io_service::work> io_work;
+  bool own_io_thread;
   std::thread io_thread;
   std::atomic<bool> is_running;  //!< io_thread running
   bool permanent_broadcast;

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -78,7 +78,7 @@ public:
     return socket.is_open();
   }
 
-  std::string get_remote_endpoint() const;
+  [[nodiscard]] std::string get_remote_endpoint() const;
 
 private:
   IoContextRunner io_runner;

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -73,7 +73,7 @@ public:
   void send_message(const mavlink::Message & message, const uint8_t source_compid) override;
   void send_bytes(const uint8_t * bytes, size_t length) override;
 
-  inline bool is_open() override
+  [[nodiscard]] inline bool is_open() override
   {
     return socket.is_open();
   }

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -98,7 +98,7 @@ private:
   std::atomic<bool> tx_in_progress;
   std::deque<MsgBuffer> tx_q;
   std::array<uint8_t, MsgBuffer::MAX_SIZE> rx_buf;
-  std::recursive_mutex mutex;
+  std::mutex mutex;
 
   void do_recvfrom();
   void do_sendto(bool check_tx_state);

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -80,10 +80,14 @@ MAVConnInterface::IOStat MAVConnInterface::get_iostat()
   auto dt = now - last_iostat;
   last_iostat = now;
 
-  float dt_s = std::chrono::duration_cast<std::chrono::seconds>(dt).count();
-
-  stat.tx_speed = d_tx / dt_s;
-  stat.rx_speed = d_rx / dt_s;
+  const float dt_s = std::chrono::duration<float>(dt).count();
+  if (dt_s > 0.0f) [[likely]] {
+    stat.tx_speed = d_tx / dt_s;
+    stat.rx_speed = d_rx / dt_s;
+  } else {
+    stat.tx_speed = 0.0f;
+    stat.rx_speed = 0.0f;
+  }
 
   return stat;
 }

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -280,7 +280,7 @@ static void url_parse_query(const std::string & query, uint8_t & sysid, uint8_t 
 
 static MAVConnInterface::Ptr url_parse_serial(
   const std::string & path, const std::string & query,
-  uint8_t system_id, uint8_t component_id, bool hwflow)
+  uint8_t system_id, uint8_t component_id, bool hwflow, asio::io_service * shared_io)
 {
   std::string file_path;
   int baudrate;
@@ -293,12 +293,13 @@ static MAVConnInterface::Ptr url_parse_serial(
 
   return std::make_shared<MAVConnSerial>(
     system_id, component_id,
-    file_path, baudrate, hwflow);
+    file_path, baudrate, hwflow, shared_io);
 }
 
 static MAVConnInterface::Ptr url_parse_udp(
   const std::string & hosts, const std::string & query,
-  uint8_t system_id, uint8_t component_id, bool is_udpb, bool permanent_broadcast)
+  uint8_t system_id, uint8_t component_id, bool is_udpb, bool permanent_broadcast,
+  asio::io_service * shared_io)
 {
   std::string bind_pair, remote_pair;
   std::string bind_host, remote_host;
@@ -329,12 +330,12 @@ static MAVConnInterface::Ptr url_parse_udp(
   return std::make_shared<MAVConnUDP>(
     system_id, component_id,
     bind_host, bind_port,
-    remote_host, remote_port);
+    remote_host, remote_port, shared_io);
 }
 
 static MAVConnInterface::Ptr url_parse_tcp_client(
   const std::string & host, const std::string & query,
-  uint8_t system_id, uint8_t component_id)
+  uint8_t system_id, uint8_t component_id, asio::io_service * shared_io)
 {
   std::string server_host;
   int server_port;
@@ -345,12 +346,12 @@ static MAVConnInterface::Ptr url_parse_tcp_client(
 
   return std::make_shared<MAVConnTCPClient>(
     system_id, component_id,
-    server_host, server_port);
+    server_host, server_port, shared_io);
 }
 
 static MAVConnInterface::Ptr url_parse_tcp_server(
   const std::string & host, const std::string & query,
-  uint8_t system_id, uint8_t component_id)
+  uint8_t system_id, uint8_t component_id, asio::io_service * shared_io)
 {
   std::string bind_host;
   int bind_port;
@@ -361,13 +362,14 @@ static MAVConnInterface::Ptr url_parse_tcp_server(
 
   return std::make_shared<MAVConnTCPServer>(
     system_id, component_id,
-    bind_host, bind_port);
+    bind_host, bind_port, shared_io);
 }
 
 MAVConnInterface::Ptr MAVConnInterface::open_url_no_connect(
   std::string url,
   uint8_t system_id,
-  uint8_t component_id)
+  uint8_t component_id,
+  asio::io_service * shared_io)
 {
   /* Based on code found here:
    * http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
@@ -385,7 +387,7 @@ MAVConnInterface::Ptr MAVConnInterface::open_url_no_connect(
   if (proto_it == url.end()) {
     // looks like file path
     CONSOLE_BRIDGE_logDebug(PFX "URL: %s: looks like file path", url.c_str());
-    return url_parse_serial(url, "", system_id, component_id, false);
+    return url_parse_serial(url, "", system_id, component_id, false, shared_io);
   }
 
   // copy protocol
@@ -419,19 +421,19 @@ MAVConnInterface::Ptr MAVConnInterface::open_url_no_connect(
   MAVConnInterface::Ptr interface_ptr;
 
   if (proto == "udp") {
-    interface_ptr = url_parse_udp(host, query, system_id, component_id, false, false);
+    interface_ptr = url_parse_udp(host, query, system_id, component_id, false, false, shared_io);
   } else if (proto == "udp-b") {
-    interface_ptr = url_parse_udp(host, query, system_id, component_id, true, false);
+    interface_ptr = url_parse_udp(host, query, system_id, component_id, true, false, shared_io);
   } else if (proto == "udp-pb") {
-    interface_ptr = url_parse_udp(host, query, system_id, component_id, true, true);
+    interface_ptr = url_parse_udp(host, query, system_id, component_id, true, true, shared_io);
   } else if (proto == "tcp") {
-    interface_ptr = url_parse_tcp_client(host, query, system_id, component_id);
+    interface_ptr = url_parse_tcp_client(host, query, system_id, component_id, shared_io);
   } else if (proto == "tcp-l") {
-    interface_ptr = url_parse_tcp_server(host, query, system_id, component_id);
+    interface_ptr = url_parse_tcp_server(host, query, system_id, component_id, shared_io);
   } else if (proto == "serial") {
-    interface_ptr = url_parse_serial(path, query, system_id, component_id, false);
+    interface_ptr = url_parse_serial(path, query, system_id, component_id, false, shared_io);
   } else if (proto == "serial-hwfc") {
-    interface_ptr = url_parse_serial(path, query, system_id, component_id, true);
+    interface_ptr = url_parse_serial(path, query, system_id, component_id, true, shared_io);
   } else {
     throw DeviceError("url", "Unknown URL type");
   }
@@ -444,9 +446,10 @@ MAVConnInterface::Ptr MAVConnInterface::open_url(
   uint8_t system_id,
   uint8_t component_id,
   const ReceivedCb & cb_handle_message,
-  const ClosedCb & cb_handle_closed_port)
+  const ClosedCb & cb_handle_closed_port,
+  asio::io_service * shared_io)
 {
-  auto interface_ptr = open_url_no_connect(url, system_id, component_id);
+  auto interface_ptr = open_url_no_connect(url, system_id, component_id, shared_io);
   if (interface_ptr) {
     if (!cb_handle_message) {
       CONSOLE_BRIDGE_logWarn(

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -65,7 +65,7 @@ mavlink_status_t MAVConnInterface::get_status()
 
 MAVConnInterface::IOStat MAVConnInterface::get_iostat()
 {
-  std::lock_guard<std::recursive_mutex> lock(iostat_mutex);
+  std::lock_guard<std::mutex> lock(iostat_mutex);
   IOStat stat;
 
   stat.tx_total_bytes = tx_total_bytes;

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -81,7 +81,7 @@ MAVConnInterface::IOStat MAVConnInterface::get_iostat()
   last_iostat = now;
 
   const float dt_s = std::chrono::duration<float>(dt).count();
-  if (dt_s > 0.0f) [[likely]] {
+  if (dt_s > 0.0f) [[likely]] {  // NOLINT(readability/braces)
     stat.tx_speed = d_tx / dt_s;
     stat.rx_speed = d_rx / dt_s;
   } else {

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <cassert>
+#include <limits>
 #include <memory>
 #include <set>
 #include <string>
@@ -215,6 +216,23 @@ static void url_parse_host(
   std::string & host_out, int & port_out,
   const std::string & def_host, const int def_port)
 {
+  auto parse_int_in_range = [](const std::string & value, int min, int max, const char * field) {
+      size_t pos = 0;
+      int parsed = 0;
+      const std::string err = std::string("invalid ") + field + " value: '" + value + "'";
+      try {
+        parsed = std::stoi(value, &pos);
+      } catch (const std::exception &) {
+        throw DeviceError("url", err.c_str());
+      }
+
+      if (pos != value.size() || parsed < min || parsed > max) {
+        throw DeviceError("url", err.c_str());
+      }
+
+      return parsed;
+    };
+
   std::string port;
 
   auto sep_it = std::find(host.begin(), host.end(), ':');
@@ -239,7 +257,7 @@ static void url_parse_host(
   }
 
   port.assign(sep_it + 1, host.end());
-  port_out = std::stoi(port);
+  port_out = parse_int_in_range(port, 1, std::numeric_limits<uint16_t>::max(), "port");
 }
 
 /**
@@ -247,6 +265,23 @@ static void url_parse_host(
  */
 static void url_parse_query(const std::string & query, uint8_t & sysid, uint8_t & compid)
 {
+  auto parse_uint8_value = [](const std::string & value, const char * field) {
+      size_t pos = 0;
+      int parsed = 0;
+      const std::string err = std::string("invalid ") + field + " value: '" + value + "'";
+      try {
+        parsed = std::stoi(value, &pos);
+      } catch (const std::exception &) {
+        throw DeviceError("url", err.c_str());
+      }
+
+      if (pos != value.size() || parsed < 0 || parsed > std::numeric_limits<uint8_t>::max()) {
+        throw DeviceError("url", err.c_str());
+      }
+
+      return static_cast<uint8_t>(parsed);
+    };
+
   const std::string ids_end("ids=");
   std::string sys, comp;
 
@@ -272,8 +307,8 @@ static void url_parse_query(const std::string & query, uint8_t & sysid, uint8_t 
   sys.assign(ids_it, comma_it);
   comp.assign(comma_it + 1, query.end());
 
-  sysid = std::stoi(sys);
-  compid = std::stoi(comp);
+  sysid = parse_uint8_value(sys, "system id");
+  compid = parse_uint8_value(comp, "component id");
 
   CONSOLE_BRIDGE_logDebug(PFX "URL: found system/component id = [%u, %u]", sysid, compid);
 }

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -269,22 +269,29 @@ void MAVConnSerial::do_write(bool check_tx_state)
       }
 
       sthis->iostat_tx_add(bytes_transferred);
-      lock_guard lock(sthis->mutex);
+      bool continue_send = false;
+      {
+        lock_guard lock(sthis->mutex);
 
-      if (sthis->tx_q.empty()) {
-        sthis->tx_in_progress = false;
-        return;
+        if (sthis->tx_q.empty()) {
+          sthis->tx_in_progress = false;
+          return;
+        }
+
+        buf_ref.pos += bytes_transferred;
+        if (buf_ref.nbytes() == 0) {
+          sthis->tx_q.pop_front();
+        }
+
+        if (!sthis->tx_q.empty()) {
+          continue_send = true;
+        } else {
+          sthis->tx_in_progress = false;
+        }
       }
 
-      buf_ref.pos += bytes_transferred;
-      if (buf_ref.nbytes() == 0) {
-        sthis->tx_q.pop_front();
-      }
-
-      if (!sthis->tx_q.empty()) {
-        sthis->do_write(false);
-      } else {
-        sthis->tx_in_progress = false;
+      if (continue_send) {
+        sthis->io_service.post(std::bind(&MAVConnSerial::do_write, sthis, false));
       }
     });
 }

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -41,7 +41,7 @@ MAVConnSerial::MAVConnSerial(
   uint8_t system_id, uint8_t component_id,
   std::string device, unsigned baudrate, bool hwflow, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
   io_service(shared_io ? *shared_io : *io_context_owner),
   own_io_thread(shared_io == nullptr),
   serial_dev(io_service),

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -41,9 +41,8 @@ MAVConnSerial::MAVConnSerial(
   uint8_t system_id, uint8_t component_id,
   std::string device, unsigned baudrate, bool hwflow, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
-  io_service(shared_io ? *shared_io : *io_context_owner),
-  own_io_thread(shared_io == nullptr),
+  io_runner(shared_io),
+  io_service(io_runner.io()),
   serial_dev(io_service),
   tx_in_progress(false),
   tx_q{},
@@ -127,9 +126,9 @@ void MAVConnSerial::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnSerial::do_read, this));
 
-  if (own_io_thread) {
+  if (io_runner.owns_thread()) {
     // run io_service for async io
-    io_thread = std::thread(
+    io_runner.start(
       [this]() {
         utils::set_this_thread_name("mserial%zu", conn_id);
         io_service.run();
@@ -148,14 +147,8 @@ void MAVConnSerial::close()
   serial_dev.cancel();
   serial_dev.close();
 
-  if (own_io_thread) {
-    io_service.stop();
-
-    if (std::this_thread::get_id() != io_thread.get_id() && io_thread.joinable()) {
-      io_thread.join();
-    }
-
-    io_service.reset();
+  if (io_runner.owns_thread()) {
+    io_runner.shutdown_owned();
   }
 
   if (port_closed_cb) {

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -39,9 +39,11 @@ using std::error_code;
 
 MAVConnSerial::MAVConnSerial(
   uint8_t system_id, uint8_t component_id,
-  std::string device, unsigned baudrate, bool hwflow)
+  std::string device, unsigned baudrate, bool hwflow, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_service(),
+  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_service(shared_io ? *shared_io : *io_context_owner),
+  own_io_thread(shared_io == nullptr),
   serial_dev(io_service),
   tx_in_progress(false),
   tx_q{},
@@ -125,12 +127,14 @@ void MAVConnSerial::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnSerial::do_read, this));
 
-  // run io_service for async io
-  io_thread = std::thread(
-    [this]() {
-      utils::set_this_thread_name("mserial%zu", conn_id);
-      io_service.run();
-    });
+  if (own_io_thread) {
+    // run io_service for async io
+    io_thread = std::thread(
+      [this]() {
+        utils::set_this_thread_name("mserial%zu", conn_id);
+        io_service.run();
+      });
+  }
 }
 
 
@@ -144,13 +148,15 @@ void MAVConnSerial::close()
   serial_dev.cancel();
   serial_dev.close();
 
-  io_service.stop();
+  if (own_io_thread) {
+    io_service.stop();
 
-  if (io_thread.joinable()) {
-    io_thread.join();
+    if (std::this_thread::get_id() != io_thread.get_id() && io_thread.joinable()) {
+      io_thread.join();
+    }
+
+    io_service.reset();
   }
-
-  io_service.reset();
 
   if (port_closed_cb) {
     port_closed_cb();

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -140,7 +140,7 @@ void MAVConnSerial::connect(
 
 void MAVConnSerial::close()
 {
-  lock_guard lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (!is_open()) {
     return;
   }
@@ -171,7 +171,7 @@ void MAVConnSerial::send_bytes(const uint8_t * bytes, size_t length)
   }
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnSerial::send_bytes: TX queue overflow");
@@ -194,7 +194,7 @@ void MAVConnSerial::send_message(const mavlink_message_t * message)
   log_send(PFX, message);
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnSerial::send_message: TX queue overflow");
@@ -215,7 +215,7 @@ void MAVConnSerial::send_message(const mavlink::Message & message, const uint8_t
   log_send_obj(PFX, message);
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnSerial::send_message: TX queue overflow");
@@ -249,7 +249,7 @@ void MAVConnSerial::do_write(bool check_tx_state)
     return;
   }
 
-  lock_guard lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (tx_q.empty()) {
     return;
   }
@@ -271,7 +271,7 @@ void MAVConnSerial::do_write(bool check_tx_state)
       sthis->iostat_tx_add(bytes_transferred);
       bool continue_send = false;
       {
-        lock_guard lock(sthis->mutex);
+        std::lock_guard<std::mutex> lock(sthis->mutex);
 
         if (sthis->tx_q.empty()) {
           sthis->tx_in_progress = false;

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -124,7 +124,7 @@ void MAVConnSerial::connect(
   port_closed_cb = cb_handle_closed_port;
 
   // give some work to io_service before start
-  io_service.post(std::bind(&MAVConnSerial::do_read, this));
+  io_service.post([this]() {this->do_read();});
 
   if (io_runner.owns_thread()) {
     // run io_service for async io
@@ -172,7 +172,8 @@ void MAVConnSerial::send_bytes(const uint8_t * bytes, size_t length)
 
     tx_q.emplace_back(bytes, length);
   }
-  io_service.post(std::bind(&MAVConnSerial::do_write, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  io_service.post([sthis]() {sthis->do_write(true);});
 }
 
 void MAVConnSerial::send_message(const mavlink_message_t * message)
@@ -195,7 +196,8 @@ void MAVConnSerial::send_message(const mavlink_message_t * message)
 
     tx_q.emplace_back(message);
   }
-  io_service.post(std::bind(&MAVConnSerial::do_write, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  io_service.post([sthis]() {sthis->do_write(true);});
 }
 
 void MAVConnSerial::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -216,7 +218,8 @@ void MAVConnSerial::send_message(const mavlink::Message & message, const uint8_t
 
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
-  io_service.post(std::bind(&MAVConnSerial::do_write, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  io_service.post([sthis]() {sthis->do_write(true);});
 }
 
 void MAVConnSerial::do_read(void)
@@ -284,7 +287,7 @@ void MAVConnSerial::do_write(bool check_tx_state)
       }
 
       if (continue_send) {
-        sthis->io_service.post(std::bind(&MAVConnSerial::do_write, sthis, false));
+        sthis->io_service.post([sthis]() {sthis->do_write(false);});
       }
     });
 }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -544,19 +544,20 @@ void MAVConnTCPServer::do_accept()
         return;
       }
 
+      std::weak_ptr<MAVConnTCPClient> weak_client{acceptor_client};
       {
         lock_guard lock(sthis->mutex);
 
-        std::weak_ptr<MAVConnTCPClient> weak_client{acceptor_client};
         acceptor_client->message_received_cb = sthis->message_received_cb;
         acceptor_client->port_closed_cb = [weak_client, sthis]() {
-          sthis->client_closed(weak_client);
-        };
-        acceptor_client->client_connected(sthis->conn_id);
+            sthis->client_closed(weak_client);
+          };
 
         sthis->client_list.push_back(acceptor_client);
-        sthis->do_accept();
       }
+
+      acceptor_client->client_connected(sthis->conn_id);
+      sthis->do_accept();
     });
 }
 

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -196,7 +196,7 @@ void MAVConnTCPClient::stop()
 void MAVConnTCPClient::close()
 {
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     if (!is_open()) {
       return;
     }
@@ -228,7 +228,7 @@ void MAVConnTCPClient::send_bytes(const uint8_t * bytes, size_t length)
   }
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnTCPClient::send_bytes: TX queue overflow");
@@ -251,7 +251,7 @@ void MAVConnTCPClient::send_message(const mavlink_message_t * message)
   log_send(PFX, message);
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnTCPClient::send_message: TX queue overflow");
@@ -272,7 +272,7 @@ void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint
   log_send_obj(PFX, message);
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnTCPClient::send_message: TX queue overflow");
@@ -309,7 +309,7 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
     return;
   }
 
-  lock_guard lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (tx_q.empty()) {
     return;
   }
@@ -331,7 +331,7 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
       sthis->iostat_tx_add(bytes_transferred);
       bool continue_send = false;
       {
-        lock_guard lock(sthis->mutex);
+        std::lock_guard<std::mutex> lock(sthis->mutex);
 
         if (sthis->tx_q.empty()) {
           sthis->tx_in_progress = false;
@@ -415,7 +415,7 @@ void MAVConnTCPServer::close()
 {
   std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     if (!is_open()) {
       return;
     }
@@ -454,7 +454,7 @@ mavlink_status_t MAVConnTCPServer::get_status()
   std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     clients.assign(client_list.begin(), client_list.end());
   }
   for (auto & instp : clients) {
@@ -483,7 +483,7 @@ MAVConnInterface::IOStat MAVConnTCPServer::get_iostat()
   std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     clients.assign(client_list.begin(), client_list.end());
   }
   for (auto & instp : clients) {
@@ -508,7 +508,7 @@ void MAVConnTCPServer::send_bytes(const uint8_t * bytes, size_t length)
 {
   std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     clients.assign(client_list.begin(), client_list.end());
   }
   for (auto & instp : clients) {
@@ -520,7 +520,7 @@ void MAVConnTCPServer::send_message(const mavlink_message_t * message)
 {
   std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     clients.assign(client_list.begin(), client_list.end());
   }
   for (auto & instp : clients) {
@@ -532,7 +532,7 @@ void MAVConnTCPServer::send_message(const mavlink::Message & message, const uint
 {
   std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     clients.assign(client_list.begin(), client_list.end());
   }
   for (auto & instp : clients) {
@@ -559,7 +559,7 @@ void MAVConnTCPServer::do_accept()
 
       std::weak_ptr<MAVConnTCPClient> weak_client{acceptor_client};
       {
-        lock_guard lock(sthis->mutex);
+        std::lock_guard<std::mutex> lock(sthis->mutex);
 
         acceptor_client->message_received_cb = sthis->message_received_cb;
         acceptor_client->port_closed_cb = [weak_client, sthis]() {
@@ -582,7 +582,7 @@ void MAVConnTCPServer::client_closed(std::weak_ptr<MAVConnTCPClient> weak_instp)
       conn_id, instp.get(), to_string_ss(instp->server_ep).c_str());
 
     {
-      lock_guard lock(mutex);
+      std::lock_guard<std::mutex> lock(mutex);
       client_list.remove(instp);
     }
   }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -86,11 +86,8 @@ MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
   std::string server_host, uint16_t server_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
-  io_service(shared_io ? *shared_io : *io_context_owner),
-  io_work(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_service)),
-  own_io_thread(shared_io == nullptr),
-  is_running(false),
+  io_runner(shared_io),
+  io_service(io_runner.io()),
   socket(io_service),
   is_destroying(false),
   tx_in_progress(false),
@@ -115,11 +112,8 @@ MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
   asio::io_service & server_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(),
-  io_service(server_io),
-  io_work(nullptr),
-  own_io_thread(false),
-  is_running(false),
+  io_runner(&server_io),
+  io_service(io_runner.io()),
   socket(io_service),
   is_destroying(false),
   tx_in_progress(false),
@@ -146,7 +140,7 @@ MAVConnTCPClient::~MAVConnTCPClient()
 
   // If the client is already disconnected on error (By the io_service thread)
   // and io_service running
-  if (own_io_thread && is_running) {
+  if (io_runner.owns_thread() && io_runner.is_running()) {
     stop();
   }
 }
@@ -161,36 +155,27 @@ void MAVConnTCPClient::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnTCPClient::do_recv, this));
 
-  if (own_io_thread) {
+  if (io_runner.owns_thread()) {
     // run io_service for async io
-    io_thread = std::thread(
+    io_runner.start(
       [this]() {
-        is_running = true;
         utils::set_this_thread_name("mtcp%zu", conn_id);
         try {
           io_service.run();
         } catch (std::exception & ex) {
           CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
         }
-        is_running = false;
       });
   }
 }
 
 void MAVConnTCPClient::stop()
 {
-  if (!own_io_thread) {
+  if (!io_runner.owns_thread()) {
     return;
   }
 
-  io_work.reset();
-  io_service.stop();
-
-  if (io_thread.joinable()) {
-    io_thread.join();
-  }
-
-  io_service.reset();
+  io_runner.shutdown_owned();
 }
 
 void MAVConnTCPClient::close()
@@ -210,8 +195,8 @@ void MAVConnTCPClient::close()
     socket.close();
   }
 
-  // Stop io_service if the thread is not the io_thread (else exception "resource deadlock avoided")
-  if (own_io_thread && std::this_thread::get_id() != io_thread.get_id()) {
+  // For owned contexts this is safe from callbacks: shutdown avoids self-join.
+  if (io_runner.owns_thread()) {
     stop();
   }
 
@@ -362,10 +347,8 @@ MAVConnTCPServer::MAVConnTCPServer(
   uint8_t system_id, uint8_t component_id,
   std::string server_host, uint16_t server_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
-  io_service(shared_io ? *shared_io : *io_context_owner),
-  io_work(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_service)),
-  own_io_thread(shared_io == nullptr),
+  io_runner(shared_io),
+  io_service(io_runner.io()),
   acceptor(io_service),
   is_destroying(false)
 {
@@ -401,9 +384,9 @@ void MAVConnTCPServer::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnTCPServer::do_accept, this));
 
-  if (own_io_thread) {
+  if (io_runner.owns_thread()) {
     // run io_service for async io
-    io_thread = std::thread(
+    io_runner.start(
       [this]() {
         utils::set_this_thread_name("mtcps%zu", conn_id);
         io_service.run();
@@ -434,13 +417,8 @@ void MAVConnTCPServer::close()
     instp->close();
   }
 
-  if (own_io_thread) {
-    io_work.reset();
-    io_service.stop();
-
-    if (std::this_thread::get_id() != io_thread.get_id() && io_thread.joinable()) {
-      io_thread.join();
-    }
+  if (io_runner.owns_thread()) {
+    io_runner.shutdown_owned();
   }
 
   if (port_closed_cb) {

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -130,7 +130,8 @@ void MAVConnTCPClient::client_connected(size_t server_channel)
     server_channel, conn_id, to_string_ss(server_ep).c_str());
 
   // start recv
-  GET_IO_SERVICE(socket).post(std::bind(&MAVConnTCPClient::do_recv, shared_from_this()));
+  auto sthis = shared_from_this();
+  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_recv();});
 }
 
 MAVConnTCPClient::~MAVConnTCPClient()
@@ -153,7 +154,7 @@ void MAVConnTCPClient::connect(
   port_closed_cb = cb_handle_closed_port;
 
   // give some work to io_service before start
-  io_service.post(std::bind(&MAVConnTCPClient::do_recv, this));
+  io_service.post([this]() {this->do_recv();});
 
   if (io_runner.owns_thread()) {
     // run io_service for async io
@@ -221,7 +222,8 @@ void MAVConnTCPClient::send_bytes(const uint8_t * bytes, size_t length)
 
     tx_q.emplace_back(bytes, length);
   }
-  GET_IO_SERVICE(socket).post(std::bind(&MAVConnTCPClient::do_send, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink_message_t * message)
@@ -244,7 +246,8 @@ void MAVConnTCPClient::send_message(const mavlink_message_t * message)
 
     tx_q.emplace_back(message);
   }
-  GET_IO_SERVICE(socket).post(std::bind(&MAVConnTCPClient::do_send, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -265,7 +268,8 @@ void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint
 
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
-  GET_IO_SERVICE(socket).post(std::bind(&MAVConnTCPClient::do_send, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::do_recv()
@@ -336,7 +340,7 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
       }
 
       if (continue_send) {
-        GET_IO_SERVICE(sthis->socket).post(std::bind(&MAVConnTCPClient::do_send, sthis, false));
+        GET_IO_SERVICE(sthis->socket).post([sthis]() {sthis->do_send(false);});
       }
     });
 }
@@ -382,7 +386,7 @@ void MAVConnTCPServer::connect(
   port_closed_cb = cb_handle_closed_port;
 
   // give some work to io_service before start
-  io_service.post(std::bind(&MAVConnTCPServer::do_accept, this));
+  io_service.post([this]() {this->do_accept();});
 
   if (io_runner.owns_thread()) {
     // run io_service for async io

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -85,9 +85,9 @@ MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
   std::string server_host, uint16_t server_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
   io_service(shared_io ? *shared_io : *io_context_owner),
-  io_work(shared_io ? nullptr : std::make_unique<io_service::work>(io_service)),
+  io_work(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_service)),
   own_io_thread(shared_io == nullptr),
   is_running(false),
   socket(io_service),
@@ -354,9 +354,9 @@ MAVConnTCPServer::MAVConnTCPServer(
   uint8_t system_id, uint8_t component_id,
   std::string server_host, uint16_t server_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
   io_service(shared_io ? *shared_io : *io_context_owner),
-  io_work(shared_io ? nullptr : std::make_unique<io_service::work>(io_service)),
+  io_work(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_service)),
   own_io_thread(shared_io == nullptr),
   acceptor(io_service),
   is_destroying(false)

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -413,12 +413,15 @@ void MAVConnTCPServer::connect(
 
 void MAVConnTCPServer::close()
 {
+  std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
   {
     lock_guard lock(mutex);
     if (!is_open()) {
       return;
     }
     is_destroying = true;
+    clients.assign(client_list.begin(), client_list.end());
+    client_list.clear();
   }
 
   CONSOLE_BRIDGE_logInform(
@@ -427,6 +430,9 @@ void MAVConnTCPServer::close()
     conn_id);
 
   acceptor.close();
+  for (auto & instp : clients) {
+    instp->close();
+  }
 
   if (own_io_thread) {
     io_work.reset();

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -25,13 +25,6 @@
 #include "mavconn/tcp.hpp"
 #include "mavconn/thread_utils.hpp"
 
-// Ensure the correct io_service() is called based on asio version
-#if ASIO_VERSION >= 101400
-#define GET_IO_SERVICE(s) ((asio::io_context &)(s).get_executor().context())
-#else
-#define GET_IO_SERVICE(s) ((s).get_io_service())
-#endif
-
 namespace mavconn
 {
 
@@ -45,6 +38,15 @@ using utils::to_string_ss;
 
 #define PFX "mavconn: tcp"
 #define PFXd PFX "%zu: "
+
+static asio::io_service & get_socket_io_service(tcp::socket & sock)
+{
+#if ASIO_VERSION >= 101400
+  return static_cast<asio::io_context &>(sock.get_executor().context());
+#else
+  return sock.get_io_service();
+#endif
+}
 
 static bool resolve_address_tcp(
   io_service & io, size_t chan, std::string host, uint16_t port,
@@ -131,7 +133,7 @@ void MAVConnTCPClient::client_connected(size_t server_channel)
 
   // start recv
   auto sthis = shared_from_this();
-  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_recv();});
+  get_socket_io_service(socket).post([sthis]() {sthis->do_recv();});
 }
 
 MAVConnTCPClient::~MAVConnTCPClient()
@@ -223,7 +225,7 @@ void MAVConnTCPClient::send_bytes(const uint8_t * bytes, size_t length)
     tx_q.emplace_back(bytes, length);
   }
   auto sthis = shared_from_this();
-  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_send(true);});
+  get_socket_io_service(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink_message_t * message)
@@ -247,7 +249,7 @@ void MAVConnTCPClient::send_message(const mavlink_message_t * message)
     tx_q.emplace_back(message);
   }
   auto sthis = shared_from_this();
-  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_send(true);});
+  get_socket_io_service(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -269,7 +271,7 @@ void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
   auto sthis = shared_from_this();
-  GET_IO_SERVICE(socket).post([sthis]() {sthis->do_send(true);});
+  get_socket_io_service(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::do_recv()
@@ -340,7 +342,7 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
       }
 
       if (continue_send) {
-        GET_IO_SERVICE(sthis->socket).post([sthis]() {sthis->do_send(false);});
+        get_socket_io_service(sthis->socket).post([sthis]() {sthis->do_send(false);});
       }
     });
 }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "mavconn/console_bridge_compat.hpp"
 #include "mavconn/tcp.hpp"
@@ -405,9 +406,12 @@ void MAVConnTCPServer::connect(
 
 void MAVConnTCPServer::close()
 {
-  lock_guard lock(mutex);
-  if (!is_open()) {
-    return;
+  {
+    lock_guard lock(mutex);
+    if (!is_open()) {
+      return;
+    }
+    is_destroying = true;
   }
 
   CONSOLE_BRIDGE_logInform(
@@ -415,14 +419,15 @@ void MAVConnTCPServer::close()
     "All connections will be closed.",
     conn_id);
 
+  acceptor.close();
+
   if (own_io_thread) {
     io_work.reset();
     io_service.stop();
-  }
-  acceptor.close();
 
-  if (own_io_thread && io_thread.joinable()) {
-    io_thread.join();
+    if (std::this_thread::get_id() != io_thread.get_id() && io_thread.joinable()) {
+      io_thread.join();
+    }
   }
 
   if (port_closed_cb) {
@@ -433,9 +438,13 @@ void MAVConnTCPServer::close()
 mavlink_status_t MAVConnTCPServer::get_status()
 {
   mavlink_status_t status {};
+  std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
 
-  lock_guard lock(mutex);
-  for (auto & instp : client_list) {
+  {
+    lock_guard lock(mutex);
+    clients.assign(client_list.begin(), client_list.end());
+  }
+  for (auto & instp : clients) {
     auto inst_status = instp->get_status();
 
     // [[[cog:
@@ -458,9 +467,13 @@ mavlink_status_t MAVConnTCPServer::get_status()
 MAVConnInterface::IOStat MAVConnTCPServer::get_iostat()
 {
   MAVConnInterface::IOStat iostat {};
+  std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
 
-  lock_guard lock(mutex);
-  for (auto & instp : client_list) {
+  {
+    lock_guard lock(mutex);
+    clients.assign(client_list.begin(), client_list.end());
+  }
+  for (auto & instp : clients) {
     auto inst_iostat = instp->get_iostat();
 
     // [[[cog:
@@ -480,24 +493,36 @@ MAVConnInterface::IOStat MAVConnTCPServer::get_iostat()
 
 void MAVConnTCPServer::send_bytes(const uint8_t * bytes, size_t length)
 {
-  lock_guard lock(mutex);
-  for (auto & instp : client_list) {
+  std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
+  {
+    lock_guard lock(mutex);
+    clients.assign(client_list.begin(), client_list.end());
+  }
+  for (auto & instp : clients) {
     instp->send_bytes(bytes, length);
   }
 }
 
 void MAVConnTCPServer::send_message(const mavlink_message_t * message)
 {
-  lock_guard lock(mutex);
-  for (auto & instp : client_list) {
+  std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
+  {
+    lock_guard lock(mutex);
+    clients.assign(client_list.begin(), client_list.end());
+  }
+  for (auto & instp : clients) {
     instp->send_message(message);
   }
 }
 
 void MAVConnTCPServer::send_message(const mavlink::Message & message, const uint8_t source_compid)
 {
-  lock_guard lock(mutex);
-  for (auto & instp : client_list) {
+  std::vector<std::shared_ptr<MAVConnTCPClient>> clients;
+  {
+    lock_guard lock(mutex);
+    clients.assign(client_list.begin(), client_list.end());
+  }
+  for (auto & instp : clients) {
     instp->send_message(message, source_compid);
   }
 }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -329,22 +329,29 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
       }
 
       sthis->iostat_tx_add(bytes_transferred);
-      lock_guard lock(sthis->mutex);
+      bool continue_send = false;
+      {
+        lock_guard lock(sthis->mutex);
 
-      if (sthis->tx_q.empty()) {
-        sthis->tx_in_progress = false;
-        return;
+        if (sthis->tx_q.empty()) {
+          sthis->tx_in_progress = false;
+          return;
+        }
+
+        buf_ref.pos += bytes_transferred;
+        if (buf_ref.nbytes() == 0) {
+          sthis->tx_q.pop_front();
+        }
+
+        if (!sthis->tx_q.empty()) {
+          continue_send = true;
+        } else {
+          sthis->tx_in_progress = false;
+        }
       }
 
-      buf_ref.pos += bytes_transferred;
-      if (buf_ref.nbytes() == 0) {
-        sthis->tx_q.pop_front();
-      }
-
-      if (!sthis->tx_q.empty()) {
-        sthis->do_send(false);
-      } else {
-        sthis->tx_in_progress = false;
+      if (continue_send) {
+        GET_IO_SERVICE(sthis->socket).post(std::bind(&MAVConnTCPClient::do_send, sthis, false));
       }
     });
 }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -83,10 +83,12 @@ static bool resolve_address_tcp(
 
 MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
-  std::string server_host, uint16_t server_port)
+  std::string server_host, uint16_t server_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_service(),
-  io_work(new io_service::work(io_service)),
+  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_service(shared_io ? *shared_io : *io_context_owner),
+  io_work(shared_io ? nullptr : std::make_unique<io_service::work>(io_service)),
+  own_io_thread(shared_io == nullptr),
   is_running(false),
   socket(io_service),
   is_destroying(false),
@@ -112,8 +114,12 @@ MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
   asio::io_service & server_io)
 : MAVConnInterface(system_id, component_id),
+  io_context_owner(),
+  io_service(server_io),
+  io_work(nullptr),
+  own_io_thread(false),
   is_running(false),
-  socket(server_io),
+  socket(io_service),
   is_destroying(false),
   tx_in_progress(false),
   tx_q{},
@@ -139,7 +145,7 @@ MAVConnTCPClient::~MAVConnTCPClient()
 
   // If the client is already disconnected on error (By the io_service thread)
   // and io_service running
-  if (is_running) {
+  if (own_io_thread && is_running) {
     stop();
   }
 }
@@ -154,22 +160,28 @@ void MAVConnTCPClient::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnTCPClient::do_recv, this));
 
-  // run io_service for async io
-  io_thread = std::thread(
-    [this]() {
-      is_running = true;
-      utils::set_this_thread_name("mtcp%zu", conn_id);
-      try {
-        io_service.run();
-      } catch (std::exception & ex) {
-        CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
-      }
-      is_running = false;
-    });
+  if (own_io_thread) {
+    // run io_service for async io
+    io_thread = std::thread(
+      [this]() {
+        is_running = true;
+        utils::set_this_thread_name("mtcp%zu", conn_id);
+        try {
+          io_service.run();
+        } catch (std::exception & ex) {
+          CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
+        }
+        is_running = false;
+      });
+  }
 }
 
 void MAVConnTCPClient::stop()
 {
+  if (!own_io_thread) {
+    return;
+  }
+
   io_work.reset();
   io_service.stop();
 
@@ -198,7 +210,7 @@ void MAVConnTCPClient::close()
   }
 
   // Stop io_service if the thread is not the io_thread (else exception "resource deadlock avoided")
-  if (std::this_thread::get_id() != io_thread.get_id()) {
+  if (own_io_thread && std::this_thread::get_id() != io_thread.get_id()) {
     stop();
   }
 
@@ -340,9 +352,12 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
 
 MAVConnTCPServer::MAVConnTCPServer(
   uint8_t system_id, uint8_t component_id,
-  std::string server_host, uint16_t server_port)
+  std::string server_host, uint16_t server_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_service(),
+  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_service(shared_io ? *shared_io : *io_context_owner),
+  io_work(shared_io ? nullptr : std::make_unique<io_service::work>(io_service)),
+  own_io_thread(shared_io == nullptr),
   acceptor(io_service),
   is_destroying(false)
 {
@@ -378,12 +393,14 @@ void MAVConnTCPServer::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnTCPServer::do_accept, this));
 
-  // run io_service for async io
-  io_thread = std::thread(
-    [this]() {
-      utils::set_this_thread_name("mtcps%zu", conn_id);
-      io_service.run();
-    });
+  if (own_io_thread) {
+    // run io_service for async io
+    io_thread = std::thread(
+      [this]() {
+        utils::set_this_thread_name("mtcps%zu", conn_id);
+        io_service.run();
+      });
+  }
 }
 
 void MAVConnTCPServer::close()
@@ -398,10 +415,13 @@ void MAVConnTCPServer::close()
     "All connections will be closed.",
     conn_id);
 
-  io_service.stop();
+  if (own_io_thread) {
+    io_work.reset();
+    io_service.stop();
+  }
   acceptor.close();
 
-  if (io_thread.joinable()) {
+  if (own_io_thread && io_thread.joinable()) {
     io_thread.join();
   }
 

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -146,7 +146,7 @@ void MAVConnUDP::connect(
   port_closed_cb = cb_handle_closed_port;
 
   // give some work to io_service before start
-  io_service.post(std::bind(&MAVConnUDP::do_recvfrom, this));
+  io_service.post([this]() {this->do_recvfrom();});
 
   if (io_runner.owns_thread()) {
     // run io_service for async io
@@ -214,7 +214,8 @@ void MAVConnUDP::send_bytes(const uint8_t * bytes, size_t length)
 
     tx_q.emplace_back(bytes, length);
   }
-  io_service.post(std::bind(&MAVConnUDP::do_sendto, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  io_service.post([sthis]() {sthis->do_sendto(true);});
 }
 
 void MAVConnUDP::send_message(const mavlink_message_t * message)
@@ -242,7 +243,8 @@ void MAVConnUDP::send_message(const mavlink_message_t * message)
 
     tx_q.emplace_back(message);
   }
-  io_service.post(std::bind(&MAVConnUDP::do_sendto, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  io_service.post([sthis]() {sthis->do_sendto(true);});
 }
 
 void MAVConnUDP::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -268,7 +270,8 @@ void MAVConnUDP::send_message(const mavlink::Message & message, const uint8_t so
 
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
-  io_service.post(std::bind(&MAVConnUDP::do_sendto, shared_from_this(), true));
+  auto sthis = shared_from_this();
+  io_service.post([sthis]() {sthis->do_sendto(true);});
 }
 
 void MAVConnUDP::do_recvfrom()
@@ -351,7 +354,7 @@ void MAVConnUDP::do_sendto(bool check_tx_state)
       }
 
       if (continue_send) {
-        sthis->io_service.post(std::bind(&MAVConnUDP::do_sendto, sthis, false));
+        sthis->io_service.post([sthis]() {sthis->do_sendto(false);});
       }
     });
 }

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -186,7 +186,7 @@ void MAVConnUDP::stop()
 void MAVConnUDP::close()
 {
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     if (!is_open()) {
       return;
     }
@@ -218,7 +218,7 @@ void MAVConnUDP::send_bytes(const uint8_t * bytes, size_t length)
   }
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnUDP::send_bytes: TX queue overflow");
@@ -246,7 +246,7 @@ void MAVConnUDP::send_message(const mavlink_message_t * message)
   log_send(PFX, message);
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnUDP::send_message: TX queue overflow");
@@ -272,7 +272,7 @@ void MAVConnUDP::send_message(const mavlink::Message & message, const uint8_t so
   log_send_obj(PFX, message);
 
   {
-    lock_guard lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
 
     if (tx_q.size() >= MAX_TXQ_SIZE) {
       throw std::length_error("MAVConnUDP::send_message: TX queue overflow");
@@ -315,7 +315,7 @@ void MAVConnUDP::do_sendto(bool check_tx_state)
     return;
   }
 
-  lock_guard lock(mutex);
+  std::lock_guard<std::mutex> lock(mutex);
   if (tx_q.empty()) {
     return;
   }
@@ -343,7 +343,7 @@ void MAVConnUDP::do_sendto(bool check_tx_state)
       sthis->iostat_tx_add(bytes_transferred);
       bool continue_send = false;
       {
-        lock_guard lock(sthis->mutex);
+        std::lock_guard<std::mutex> lock(sthis->mutex);
 
         if (sthis->tx_q.empty()) {
           sthis->tx_in_progress = false;

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -75,9 +75,9 @@ MAVConnUDP::MAVConnUDP(
   std::string bind_host, uint16_t bind_port,
   std::string remote_host, uint16_t remote_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
   io_service(shared_io ? *shared_io : *io_context_owner),
-  io_work(shared_io ? nullptr : std::make_unique<io_service::work>(io_service)),
+  io_work(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_service)),
   own_io_thread(shared_io == nullptr),
   is_running(false),
   permanent_broadcast(false),

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -75,11 +75,8 @@ MAVConnUDP::MAVConnUDP(
   std::string bind_host, uint16_t bind_port,
   std::string remote_host, uint16_t remote_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_context_owner(shared_io ? nullptr : std::make_shared<asio::io_service>()),
-  io_service(shared_io ? *shared_io : *io_context_owner),
-  io_work(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_service)),
-  own_io_thread(shared_io == nullptr),
-  is_running(false),
+  io_runner(shared_io),
+  io_service(io_runner.io()),
   permanent_broadcast(false),
   remote_exists(false),
   socket(io_service),
@@ -136,7 +133,7 @@ MAVConnUDP::~MAVConnUDP()
   close();
 
   // If the socket already closed and the io_service running
-  if (own_io_thread && is_running) {
+  if (io_runner.owns_thread() && io_runner.is_running()) {
     stop();
   }
 }
@@ -151,36 +148,27 @@ void MAVConnUDP::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnUDP::do_recvfrom, this));
 
-  if (own_io_thread) {
+  if (io_runner.owns_thread()) {
     // run io_service for async io
-    io_thread = std::thread(
+    io_runner.start(
       [this]() {
-        is_running = true;
         utils::set_this_thread_name("mudp%zu", conn_id);
         try {
           io_service.run();
         } catch (std::exception & ex) {
           CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
         }
-        is_running = false;
       });
   }
 }
 
 void MAVConnUDP::stop()
 {
-  if (!own_io_thread) {
+  if (!io_runner.owns_thread()) {
     return;
   }
 
-  io_work.reset();
-  io_service.stop();
-
-  if (io_thread.joinable()) {
-    io_thread.join();
-  }
-
-  io_service.reset();
+  io_runner.shutdown_owned();
 }
 
 void MAVConnUDP::close()
@@ -195,8 +183,8 @@ void MAVConnUDP::close()
     socket.close();
   }
 
-  // Stop io_service if the thread is not the io_thread (else exception "resource deadlock avoided")
-  if (own_io_thread && std::this_thread::get_id() != io_thread.get_id()) {
+  // For owned contexts this is safe from callbacks: shutdown avoids self-join.
+  if (io_runner.owns_thread()) {
     stop();
   }
 

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -341,22 +341,29 @@ void MAVConnUDP::do_sendto(bool check_tx_state)
       }
 
       sthis->iostat_tx_add(bytes_transferred);
-      lock_guard lock(sthis->mutex);
+      bool continue_send = false;
+      {
+        lock_guard lock(sthis->mutex);
 
-      if (sthis->tx_q.empty()) {
-        sthis->tx_in_progress = false;
-        return;
+        if (sthis->tx_q.empty()) {
+          sthis->tx_in_progress = false;
+          return;
+        }
+
+        buf_ref.pos += bytes_transferred;
+        if (buf_ref.nbytes() == 0) {
+          sthis->tx_q.pop_front();
+        }
+
+        if (!sthis->tx_q.empty()) {
+          continue_send = true;
+        } else {
+          sthis->tx_in_progress = false;
+        }
       }
 
-      buf_ref.pos += bytes_transferred;
-      if (buf_ref.nbytes() == 0) {
-        sthis->tx_q.pop_front();
-      }
-
-      if (!sthis->tx_q.empty()) {
-        sthis->do_sendto(false);
-      } else {
-        sthis->tx_in_progress = false;
+      if (continue_send) {
+        sthis->io_service.post(std::bind(&MAVConnUDP::do_sendto, sthis, false));
       }
     });
 }

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -73,10 +73,12 @@ static bool resolve_address_udp(
 MAVConnUDP::MAVConnUDP(
   uint8_t system_id, uint8_t component_id,
   std::string bind_host, uint16_t bind_port,
-  std::string remote_host, uint16_t remote_port)
+  std::string remote_host, uint16_t remote_port, asio::io_service * shared_io)
 : MAVConnInterface(system_id, component_id),
-  io_service(),
-  io_work(new io_service::work(io_service)),
+  io_context_owner(shared_io ? nullptr : std::make_shared<io_service>()),
+  io_service(shared_io ? *shared_io : *io_context_owner),
+  io_work(shared_io ? nullptr : std::make_unique<io_service::work>(io_service)),
+  own_io_thread(shared_io == nullptr),
   is_running(false),
   permanent_broadcast(false),
   remote_exists(false),
@@ -134,7 +136,7 @@ MAVConnUDP::~MAVConnUDP()
   close();
 
   // If the socket already closed and the io_service running
-  if (is_running) {
+  if (own_io_thread && is_running) {
     stop();
   }
 }
@@ -149,22 +151,28 @@ void MAVConnUDP::connect(
   // give some work to io_service before start
   io_service.post(std::bind(&MAVConnUDP::do_recvfrom, this));
 
-  // run io_service for async io
-  io_thread = std::thread(
-    [this]() {
-      is_running = true;
-      utils::set_this_thread_name("mudp%zu", conn_id);
-      try {
-        io_service.run();
-      } catch (std::exception & ex) {
-        CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
-      }
-      is_running = false;
-    });
+  if (own_io_thread) {
+    // run io_service for async io
+    io_thread = std::thread(
+      [this]() {
+        is_running = true;
+        utils::set_this_thread_name("mudp%zu", conn_id);
+        try {
+          io_service.run();
+        } catch (std::exception & ex) {
+          CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
+        }
+        is_running = false;
+      });
+  }
 }
 
 void MAVConnUDP::stop()
 {
+  if (!own_io_thread) {
+    return;
+  }
+
   io_work.reset();
   io_service.stop();
 
@@ -188,7 +196,7 @@ void MAVConnUDP::close()
   }
 
   // Stop io_service if the thread is not the io_thread (else exception "resource deadlock avoided")
-  if (std::this_thread::get_id() != io_thread.get_id()) {
+  if (own_io_thread && std::this_thread::get_id() != io_thread.get_id()) {
     stop();
   }
 

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -25,6 +25,7 @@
 #include <condition_variable>
 #include <limits>
 #include <memory>
+#include <thread>
 
 #include "mavconn/interface.hpp"
 #include "mavconn/serial.hpp"
@@ -167,6 +168,60 @@ TEST_F(UDP, send_message)
   send_heartbeat(client.get());
   EXPECT_EQ(wait_one(), true);
   EXPECT_EQ(message_id, msgid);
+}
+
+TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
+{
+  asio::io_service shared_io;
+  auto io_work = std::make_unique<asio::io_service::work>(shared_io);
+  std::thread io_thread([&shared_io]() {shared_io.run();});
+
+  std::mutex mutex;
+  std::condition_variable cond;
+  bool got_echo = false;
+  bool posted_done = false;
+
+  auto echo = std::make_shared<MAVConnUDP>(
+    42, 200, "0.0.0.0", 45022, "", MAVConnUDP::DEFAULT_REMOTE_PORT, &shared_io);
+  echo->connect(
+    [&](const mavlink_message_t * msg, const Framing framing [[maybe_unused]]) {
+      echo->send_message(msg);
+    });
+
+  auto client = std::make_shared<MAVConnUDP>(
+    44, 200, "0.0.0.0", 45023, "localhost", 45022, &shared_io);
+  client->connect(
+    [&](const mavlink_message_t * message [[maybe_unused]],
+      const Framing framing [[maybe_unused]])
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      got_echo = true;
+      cond.notify_all();
+    });
+
+  send_heartbeat(client.get());
+  send_heartbeat(client.get());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    EXPECT_EQ(cond.wait_for(lock, std::chrono::seconds(2), [&]() {return got_echo;}), true);
+  }
+
+  echo->close();
+
+  shared_io.post([&]() {
+    std::lock_guard<std::mutex> lock(mutex);
+    posted_done = true;
+    cond.notify_all();
+  });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    EXPECT_EQ(cond.wait_for(lock, std::chrono::seconds(2), [&]() {return posted_done;}), true);
+  }
+
+  client->close();
+  io_work.reset();
+  shared_io.stop();
+  io_thread.join();
 }
 
 class TCP : public UDP

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -224,6 +224,50 @@ TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
   io_thread.join();
 }
 
+TEST(IO_THREAD, udp_close_from_callback_does_not_deadlock)
+{
+  std::mutex mutex;
+  std::condition_variable cond;
+  bool callback_finished = false;
+  bool closed_callback_called = false;
+
+  auto echo = std::make_shared<MAVConnUDP>(42, 200, "0.0.0.0", 45032);
+  echo->connect(
+    [&](const mavlink_message_t * msg, const Framing framing [[maybe_unused]]) {
+      echo->send_message(msg);
+    });
+
+  auto client = std::make_shared<MAVConnUDP>(
+    44, 200, "0.0.0.0", 45033, "localhost", 45032);
+  client->connect(
+    [&](const mavlink_message_t * message [[maybe_unused]],
+      const Framing framing [[maybe_unused]])
+    {
+      client->close();
+      std::lock_guard<std::mutex> lock(mutex);
+      callback_finished = true;
+      cond.notify_all();
+    },
+    [&]() {
+      std::lock_guard<std::mutex> lock(mutex);
+      closed_callback_called = true;
+      cond.notify_all();
+    });
+
+  send_heartbeat(client.get());
+  send_heartbeat(client.get());
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    EXPECT_EQ(
+      cond.wait_for(lock, std::chrono::seconds(2), [&]() {return callback_finished;}), true);
+    EXPECT_EQ(
+      cond.wait_for(lock, std::chrono::seconds(2), [&]() {return closed_callback_called;}), true);
+  }
+
+  echo->close();
+}
+
 class TCP : public UDP
 {
 };

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -84,7 +84,10 @@ public:
     const uint8_t source_compid [[maybe_unused]]) override
   {}
 
-  void send_bytes(const uint8_t * bytes [[maybe_unused]], size_t length [[maybe_unused]]) override {}
+  void send_bytes(
+    const uint8_t * bytes [[maybe_unused]],
+    size_t length [[maybe_unused]]) override
+  {}
 
   bool is_open() override
   {

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -159,14 +159,14 @@ TEST_F(UDP, send_message)
   // create client
   client = std::make_shared<MAVConnUDP>(44, 200, "0.0.0.0", 45003, "localhost", 45002);
   client->connect(
-    std::bind(
-      &UDP::recv_message, this, std::placeholders::_1,
-      std::placeholders::_2));
+    [this](const mavlink_message_t * msg, const Framing framing) {
+      this->recv_message(msg, framing);
+    });
 
   // wait echo
   send_heartbeat(client.get());
   send_heartbeat(client.get());
-  EXPECT_EQ(wait_one(), true);
+  EXPECT_TRUE(wait_one());
   EXPECT_EQ(message_id, msgid);
 }
 
@@ -174,7 +174,7 @@ TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
 {
   asio::io_service shared_io;
   auto io_work = std::make_unique<asio::io_service::work>(shared_io);
-  std::thread io_thread([&shared_io]() {shared_io.run();});
+  std::jthread io_thread([&shared_io]() {shared_io.run();});
 
   std::mutex mutex;
   std::condition_variable cond;
@@ -203,7 +203,7 @@ TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
   send_heartbeat(client.get());
   {
     std::unique_lock<std::mutex> lock(mutex);
-    EXPECT_EQ(cond.wait_for(lock, std::chrono::seconds(2), [&]() {return got_echo;}), true);
+    EXPECT_TRUE(cond.wait_for(lock, std::chrono::seconds(2), [&]() {return got_echo;}));
   }
 
   echo->close();
@@ -215,13 +215,12 @@ TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
   });
   {
     std::unique_lock<std::mutex> lock(mutex);
-    EXPECT_EQ(cond.wait_for(lock, std::chrono::seconds(2), [&]() {return posted_done;}), true);
+    EXPECT_TRUE(cond.wait_for(lock, std::chrono::seconds(2), [&]() {return posted_done;}));
   }
 
   client->close();
   io_work.reset();
   shared_io.stop();
-  io_thread.join();
 }
 
 TEST(IO_THREAD, udp_close_from_callback_does_not_deadlock)
@@ -309,14 +308,14 @@ TEST_F(TCP, send_message)
   // create client
   client = std::make_shared<MAVConnTCPClient>(44, 200, "localhost", 57602);
   client->connect(
-    std::bind(
-      &TCP::recv_message, this, std::placeholders::_1,
-      std::placeholders::_2));
+    [this](const mavlink_message_t * msg, const Framing framing) {
+      this->recv_message(msg, framing);
+    });
 
   // wait echo
   send_heartbeat(client.get());
   send_heartbeat(client.get());
-  EXPECT_EQ(wait_one(), true);
+  EXPECT_TRUE(wait_one());
   EXPECT_EQ(message_id, msgid);
 }
 

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <limits>
 #include <memory>
@@ -61,6 +62,47 @@ static void send_heartbeat(MAVConnInterface * ip)
   hb.system_status = static_cast<int>(MAV_STATE::ACTIVE);
 
   ip->send_message(hb);
+}
+
+class DummyConn : public MAVConnInterface
+{
+public:
+  using MAVConnInterface::iostat_rx_add;
+  using MAVConnInterface::iostat_tx_add;
+
+  void connect(
+    const ReceivedCb & cb_handle_message [[maybe_unused]],
+    const ClosedCb & cb_handle_closed_port [[maybe_unused]] = ClosedCb()) override
+  {}
+
+  void close() override {}
+
+  void send_message(const mavlink_message_t * message [[maybe_unused]]) override {}
+
+  void send_message(
+    const mavlink::Message & message [[maybe_unused]],
+    const uint8_t source_compid [[maybe_unused]]) override
+  {}
+
+  void send_bytes(const uint8_t * bytes [[maybe_unused]], size_t length [[maybe_unused]]) override {}
+
+  bool is_open() override
+  {
+    return true;
+  }
+};
+
+TEST(IOSTAT, finite_speed_for_subsecond_polling)
+{
+  DummyConn conn;
+  conn.iostat_tx_add(64);
+  conn.iostat_rx_add(128);
+
+  const auto stat = conn.get_iostat();
+  EXPECT_EQ(stat.tx_total_bytes, 64U);
+  EXPECT_EQ(stat.rx_total_bytes, 128U);
+  EXPECT_TRUE(std::isfinite(stat.tx_speed));
+  EXPECT_TRUE(std::isfinite(stat.rx_speed));
 }
 
 class UDP : public ::testing::Test

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -414,6 +414,42 @@ TEST(URL, open_url_udp)
     udp = MAVConnInterface::open_url("udp://localhost:45008");
   },
     DeviceError);
+
+  EXPECT_THROW(
+  {
+    udp = MAVConnInterface::open_url("udp://localhost:0@localhost:14550");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    udp = MAVConnInterface::open_url("udp://localhost:65536@localhost:14550");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    udp = MAVConnInterface::open_url("udp://localhost:14550x@localhost:14550");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    udp = MAVConnInterface::open_url("udp://localhost:14550@localhost:14550/?ids=300,1");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    udp = MAVConnInterface::open_url("udp://localhost:14550@localhost:14550/?ids=-1,1");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    udp = MAVConnInterface::open_url("udp://localhost:14550@localhost:14550/?ids=a,1");
+  },
+    DeviceError);
 }
 
 TEST(URL, open_url_tcp)
@@ -436,6 +472,18 @@ TEST(URL, open_url_tcp)
     tcp_client_p = dynamic_cast<MAVConnTCPClient *>(tcp_client.get());
     EXPECT_NE(tcp_client_p, nullptr);
   });
+
+  EXPECT_THROW(
+  {
+    tcp_client = MAVConnInterface::open_url("tcp://localhost:0");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    tcp_client = MAVConnInterface::open_url("tcp://localhost:abc");
+  },
+    DeviceError);
 }
 
 int main(int argc, char ** argv)

--- a/tools/plugin_doc_gen.py
+++ b/tools/plugin_doc_gen.py
@@ -380,12 +380,15 @@ def render_plugin_markdown_with_template(
         raise RuntimeError(
             "Jinja2 is required for templated markdown output. Install dependencies with `uv sync`."
         )
+    # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+    # This renderer is used only for offline docs generation, not for request/response HTML.
     env = Environment(loader=FileSystemLoader(str(template_path.parent)), autoescape=False)
     template = env.get_template(template_path.name)
     try:
         shown_path = plugin.path.relative_to(repo_root).as_posix()
     except ValueError:
         shown_path = plugin.path.as_posix()
+    # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
     body = template.render(plugin=plugin, shown_path=shown_path)
     return body.rstrip() + "\n"
 


### PR DESCRIPTION
# Summary

This PR modernizes and hardens libmavconn threading/lifecycle behavior, improves URL parsing validation, and adds initial CI coverage reporting.

# What Changed

- Refactored transport IO lifecycle with shared/owned io_service support and a common runner.
- Fixed close-path/thread lifecycle edge cases (including callback-thread shutdown).
- Reduced lock scope and removed recursive mutex usage in transport paths.
- Modernized code to C++20 style in touched areas (std::jthread, lambdas, [[nodiscard]] where appropriate).
- Hardened URL parsing with strict numeric/range validation for ports and ids.
- Expanded tests for:
  - shared-io threading behavior,
  - callback-close safety,
  - invalid URL parse cases.
- Added coverage.yml workflow with an extensible component matrix (enabled for libmavconn first).