### PR TITLE
Refactor router

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,14 +25,12 @@ jobs:
       matrix:
         ros_distro: [kilted]
         component:
-          # Add more entries here when enabling coverage for more modules.
-          # Example:
-          # - name: mavros
-          #   packages: mavros
-          #   source_filter: ".*/mavros/.*"
           - name: libmavconn
             packages: libmavconn
             source_filter: ".*/libmavconn/.*"
+          - name: mavros
+            packages: mavros
+            source_filter: ".*/mavros/.*"
 
     env:
       ROS_DISTRO: ${{ matrix.ros_distro }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,10 @@ jobs:
       COMPONENT_NAME: ${{ matrix.component.name }}
       COMPONENT_PACKAGES: ${{ matrix.component.packages }}
       COMPONENT_FILTER: ${{ matrix.component.source_filter }}
+      # Enable the libmavconn e2e test dep (python3-pymavlink-pip) and allow
+      # rosdep to pip-install it on PEP 668 distros (jazzy+)
+      TEST_ENABLE_E2E: "1"
+      PIP_BREAK_SYSTEM_PACKAGES: "1"
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,10 @@ jobs:
           # - {ROS_DISTRO: iron, ROS_REPO: main}
           - {ROS_DISTRO: jazzy, ROS_REPO: main}
           - {ROS_DISTRO: kilted, ROS_REPO: main}
-          - {ROS_DISTRO: lyrical, ROS_REPO: main}
+          # lyrical has no released ros-lyrical-mavlink apt package yet, so
+          # build mavlink from source via dependencies.rosinstall (upstream ws).
+          # (rolling and lyrical mavlink releases are published together; same code.)
+          - {ROS_DISTRO: lyrical, ROS_REPO: main, UPSTREAM_WORKSPACE: dependencies.rosinstall}
           - {ROS_DISTRO: rolling, ROS_REPO: testing}
     env:
       CCACHE_DIR: /github/home/.ccache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
     env:
       CCACHE_DIR: /github/home/.ccache
       AFTER_INSTALL_TARGET_DEPENDENCIES: ./mavros/scripts/install_geographiclib_datasets.sh
+      # Enable the libmavconn e2e test dep (python3-pymavlink-pip) and allow
+      # rosdep to pip-install it on PEP 668 distros (jazzy+)
+      TEST_ENABLE_E2E: "1"
+      PIP_BREAK_SYSTEM_PACKAGES: "1"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,63 @@ Guidance for coding agents in this repository.
   - Mounts `${localWorkspaceFolder}/../..` to `/ws`.
   - Requires repository path `<workspace>/src/mavros`.
 
+## Local Container (Podman)
+
+As an alternative to the devcontainer, use a plain ROS container with full-workspace mount.
+
+### Setup
+
+Container creation (one-time):
+
+    podman run -it --name ros2-<distro> \
+      -v <workspace>:/ws \
+      -v $HOME/.gitconfig:/root/.gitconfig \
+      -v $HOME/.ssh:/root/.ssh \
+      -v $HOME/.gnupg:/root/.gnupg \
+      -v $HOME/.config:/root/.config \
+      -p 14540:14540/udp -p 14545:14545/udp -p 5761:5761 \
+      ros:<distro>
+
+Restart after host reboot:
+
+    podman start ros2-<distro>
+
+First-run dependencies (inside container):
+
+    apt-get update && rosdep update && rosdep install -y -i --from-paths /ws/src
+    ./src/mavros/mavros/scripts/install_geographiclib_datasets.sh
+
+Remove system mavlink if building from source (avoids duplicate-package error):
+
+    apt-get remove -y ros-<distro>-mavlink
+
+### Build and Test
+
+Run commands on the host via `podman exec <name> bash -lc '...'`.
+Prepend `source /opt/ros/<distro>/setup.bash` before every command.
+
+Build:
+
+    podman exec ros2-<distro> bash -lc 'source /opt/ros/<distro>/setup.bash && colcon build'
+
+If extra source packages cause duplicate-package errors, scope discovery:
+
+    colcon build --base-paths /ws/src/mavros --packages-up-to mavros
+
+Test (after source of install; `install/setup.bash` includes the system setup):
+
+    podman exec ros2-<distro> bash -lc '\
+      source /ws/install/setup.bash \
+      && cd /ws/build/mavros && ctest --output-on-failure'
+
+`ctest` from the build directory is preferred over `colcon test` — it avoids workspace-scanning issues.
+
+To reformat with uncrustify:
+
+    podman exec ros2-<distro> bash -lc '\
+      source /opt/ros/<distro>/setup.bash \
+      && ament_uncrustify --reformat /ws/src/mavros/mavros'
+
 ## Style And Compatibility
 
 - C++ style is enforced by `ament_uncrustify` (latest/current supported ROS 2 baseline).

--- a/docs/mavlink-e2e-tests-plan.md
+++ b/docs/mavlink-e2e-tests-plan.md
@@ -1,0 +1,138 @@
+# MAVLink byte-stream e2e tests (pymavlink-referenced)
+
+**Status:** Tier 1 = **implemented** (libmavconn TX/RX + signing e2e, all green in container).
+Tier 2 = postponed, scope confirmed.
+
+**Goal:** Verify libmavconn serializes/deserializes MAVLink byte streams correctly, using
+pymavlink as the reference implementation. Later, verify the MAVLink router end-to-end in
+all modes.
+
+**Design constraints (from maintainer):**
+
+- `test_depend` on a pip package (`python3-pymavlink-pip`) is acceptable.
+- Minimize owned surface area: no shared Python framework, no CI/pip automation, tests must
+  skip cleanly when pymavlink is absent so there is nothing to babysit.
+- Deterministic, low-flake tests preferred.
+
+**Environment:** Container `ros2-lyrical` (podman), workspace at `/ws`, repo mounted at
+`/ws/src/mavros`. pymavlink installed via `pip install --break-system-packages pymavlink`
+(one-time, manual — not automated anywhere).
+
+---
+
+## Tier 1 — libmavconn byte-stream e2e (IMPLEMENT NOW)
+
+### Files
+
+1. **`libmavconn/test/e2e/mavconn_e2e_shim.cpp`** (new; built only under `BUILD_TESTING`)
+   - Thin C-ABI wrapper over `MAVConnUDP` for `ctypes`. Glue only, no abstractions.
+   - API:
+     - `mavconn_udp_create(sysid, compid, bind_port, remote_host, remote_port) -> void*`
+       (receive callback pushes decoded `(msgid, sysid, compid, seq, len, framing, payload[])`
+       to a thread-safe queue)
+     - `mavconn_poll_rx(handle, out*, timeout_ms) -> int`
+     - `mavconn_send_heartbeat(handle, ...) -> int`
+       (serialize `common::msg::HEARTBEAT`, `send_message()`)
+     - `mavconn_send_raw_bytes(handle, bytes, len) -> int` (`send_bytes()`)
+     - `mavconn_setup_signing(handle, key[32], sign_outgoing, link_id, init_ts)`
+     - `mavconn_destroy(handle)`
+
+2. **`libmavconn/test/e2e/test_libmavconn_e2e.py`** (new, pytest)
+   - Loads shim via `ctypes` (path from `MAVCONN_E2E_SHIM` env var set by CMake).
+   - pymavlink packing/parsing inlined directly — no shared helper module.
+   - Every test guarded by `pytest.importorskip("pymavlink")` → skips in CI/buildfarm
+     without pip (verified: whole module skips when pymavlink is absent).
+   - Tests (all passing in `ros2-lyrical`):
+     - `test_tx_heartbeat_matches_pymavlink` — libmavconn HEARTBEAT byte-for-byte equal to
+       pymavlink reference frame.
+     - `test_rx_heartbeat_from_pymavlink` — pymavlink HEARTBEAT → libmavconn decodes
+       msgid/ids/seq/payload exactly.
+     - `test_rx_sys_status_from_pymavlink` — extension-field message payload round-trips.
+     - `test_tx_signed_heartbeat_verified_by_pymavlink` — signed TX verified by pymavlink
+       (SIGNED incompat flag set, `badsig_count == 0`).
+     - `test_rx_signed_heartbeat_from_pymavlink` — signed RX accepted with `Framing::ok`.
+     - `test_rx_bad_signature_rejected` — wrong key → `Framing::bad_signature`.
+
+   **Gotcha captured:** pymavlink message constructors take fields in *declaration* order,
+   not wire order — always construct reference frames with keyword args (a positional
+   mix-up here initially produced a false wire mismatch).
+
+3. **`libmavconn/CMakeLists.txt`** (edit)
+   - In `if(BUILD_TESTING)`: `find_package(ament_cmake_pytest REQUIRED)`; build shim as
+     `SHARED` lib linked to `mavconn`; `ament_add_pytest_test(libmavconn_pymavlink_e2e …)`
+     passing shim path via `ENV MAVCONN_E2E_SHIM` and shim dir via
+     `APPEND_ENV LD_LIBRARY_PATH`. Also points flake8 at the new `setup.cfg`.
+
+4. **`libmavconn/package.xml`** (edit)
+   - Add `<test_depend>ament_cmake_pytest</test_depend>` and
+     `<test_depend>python3-pymavlink-pip</test_depend>`.
+
+5. **`libmavconn/setup.cfg`** (new)
+   - flake8 config mirroring `mavros/setup.cfg` (double quotes allowed, google import
+     order), so the new Python test matches the project's actual style. libmavconn had no
+     flake8 config before, so it previously used ament's stricter default.
+
+### Build / run (container)
+
+    podman exec ros2-lyrical bash -lc 'source /opt/ros/lyrical/setup.bash && \
+      colcon build --base-paths /ws/src/mavros --packages-select libmavconn'
+    podman exec ros2-lyrical bash -lc 'source /ws/install/setup.bash && \
+      cd /ws/build/libmavconn && ctest --output-on-failure -R pymavlink'
+
+**Est. tokens:** ~70–120k (deterministic, in-process, no ROS runtime → low flake).
+
+---
+
+## Tier 2 — router wire e2e (POSTPONED, scope confirmed)
+
+**Confirmed requirement:** router must be verified functioning correctly in **all modes**
+(FCU↔GCS, FCU↔UAS, GCS↔UAS routing; broadcast + targeted). Postponed until after Tier 1
+lands.
+
+**Endpoint mapping (verified from code):**
+
+- `fcu_urls` / `gcs_urls` → `MAVConnEndpoint` (real UDP/TCP wire links).
+- `uas_urls` → `ROSEndpoint` (ROS topics `<url>/mavlink_source` FCU→UAS,
+  `<url>/mavlink_sink` UAS→FCU; QoS best_effort + volatile).
+
+**Planned topology:** pymavlink peer (FCU over UDP) → `MAVConnEndpoint` → Router →
+`ROSEndpoint` ↔ test's rclpy node on `/uas1/mavlink_{source,sink}`. Optionally add a
+`gcs_urls` UDP link for wire→wire broadcast coverage.
+
+**Test cases (all asserted against pymavlink reference):**
+
+- FCU→UAS (wire→ROS topic): pymavlink packs HEARTBEAT + targeted msg into FCU link; rclpy
+  asserts `mavros_msgs::msg::Mavlink` fields (msgid/sysid/compid/payload64/len/framing_status)
+  match.
+- UAS→FCU (ROS topic→wire): rclpy publishes `Mavlink` (from pymavlink-packed msg) to sink;
+  pymavlink peer asserts emitted wire bytes parse and match (msgid, payload, ids, CRC).
+- Targeted routing: `target_system`/`target_component` reaches only matching endpoint.
+- All-modes matrix: verify each FCU/GCS/UAS pairing per routing rules in
+  `Router::route_message`.
+- Signing through router: **blocked** — `MAVConnEndpoint::open()` has
+  `// TODO(vooon): message signing?` and does not wire signing. Deferred until router
+  signing is implemented.
+
+**Files (planned):**
+
+- `mavros/test/router_e2e/test_router_wire_e2e.py` (rclpy + pymavlink; `importorskip`
+  guard; inline pymavlink helpers, no shared module).
+- `mavros/CMakeLists.txt` — `ament_add_pytest_test(mavros_router_wire_e2e …)`.
+- `mavros/package.xml` — `<test_depend>python3-pymavlink-pip</test_depend>`.
+
+**Risk note:** Tier 2 introduces rclpy + DDS + running component + timing → highest
+flake/maintenance potential. Time-box when implemented; if router launch/timing flakes in
+the container, cut scope rather than nurse it. Existing `test_router.cpp` already
+unit-tests the routing table with mocks — Tier 2 targets the **wire path +
+`mavros_msgs::mavlink::convert` round-trip**, which is the real gap.
+
+**Est. tokens:** ~70–130k (2–4 debug iterations likely).
+
+---
+
+## Model / execution notes
+
+- Implementation: mid-tier agentic coding model is sufficient; escalate only router-launch
+  debugging to a flagship if it drags >2 iterations.
+- Recommendation (cost control): land Tier 1 as its own PR; Tier 2 as a follow-up PR
+  rebased on it.

--- a/libmavconn/CMakeLists.txt
+++ b/libmavconn/CMakeLists.txt
@@ -92,7 +92,11 @@ install(DIRECTORY cmake
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+
+  # NOTE(vooon): i prefer black style, which uses double quotes
+  set(ament_cmake_flake8_CONFIG_FILE "./setup.cfg")
 
   # NOTE(vooon): Does not support our custom triple-license, tiered to make it to work.
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_copyright)
@@ -108,6 +112,22 @@ if(BUILD_TESTING)
   target_link_libraries(test_mavconn
     mavconn
     console_bridge::console_bridge
+  )
+
+  # pymavlink-referenced byte-stream e2e test.
+  # Small ctypes shim over MAVConnUDP; the pytest skips cleanly when pymavlink
+  # (a pip package) is not installed, so CI/buildfarm stays green.
+  add_library(mavconn_e2e_shim SHARED test/e2e/mavconn_e2e_shim.cpp)
+  target_link_libraries(mavconn_e2e_shim
+    mavconn
+    console_bridge::console_bridge
+  )
+
+  ament_add_pytest_test(libmavconn_pymavlink_e2e test/e2e
+    ENV
+      MAVCONN_E2E_SHIM=$<TARGET_FILE:mavconn_e2e_shim>
+    APPEND_ENV
+      LD_LIBRARY_PATH=$<TARGET_FILE_DIR:mavconn_e2e_shim>
   )
 
 endif()

--- a/libmavconn/package.xml
+++ b/libmavconn/package.xml
@@ -34,7 +34,12 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>python3-pymavlink-pip</test_depend>
+  <!-- pymavlink is pip-only and only wanted where the e2e test should actually
+       run (CI). Gate it on TEST_ENABLE_E2E=1 so regular source-based installs
+       do not pull a global pip package. On PEP 668 distros rosdep also needs
+       PIP_BREAK_SYSTEM_PACKAGES=1 (both set in CI). Where pymavlink is absent,
+       the e2e test self-skips via pytest.importorskip. -->
+  <test_depend condition="$TEST_ENABLE_E2E == 1">python3-pymavlink-pip</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/libmavconn/package.xml
+++ b/libmavconn/package.xml
@@ -31,8 +31,10 @@
   <build_depend>python3-empy</build_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-pymavlink-pip</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/libmavconn/setup.cfg
+++ b/libmavconn/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+# NOTE: same relaxed style as mavros/setup.cfg (ament_flake8.ini from Jazzy,
+# extended with A005,Q000,I100,I101 so double quotes are allowed).
+extend-ignore = A005,B902,C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202,Q000,I100,I101
+import-order-style = google
+max-line-length = 99
+show-source = true
+statistics = true

--- a/libmavconn/test/e2e/mavconn_e2e_shim.cpp
+++ b/libmavconn/test/e2e/mavconn_e2e_shim.cpp
@@ -1,0 +1,199 @@
+//
+// libmavconn
+// Copyright 2026, mavros contributors. Licensed as the rest of the package.
+//
+// This file is part of the mavros package and subject to the license terms
+// in the top-level LICENSE file of the mavros repository.
+// https://github.com/mavlink/mavros/tree/master/LICENSE.md
+//
+
+/**
+ * @brief Minimal C-ABI shim over MAVConnUDP for ctypes-based e2e tests.
+ *
+ * Test-only glue (built under BUILD_TESTING). Not installed, not a library.
+ * It exposes just enough to drive a UDP link and capture decoded messages so
+ * a Python (pytest + pymavlink) test can compare byte streams against the
+ * reference implementation.
+ */
+
+#include <array>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "mavconn/udp.hpp"
+
+namespace mavlink
+{
+namespace common
+{
+using namespace mavlink::minimal;  // NOLINT
+namespace msg
+{
+using namespace mavlink::minimal::msg;  // NOLINT
+}
+}  // namespace common
+}  // namespace mavlink
+
+namespace
+{
+
+using mavlink_message_t = mavlink::mavlink_message_t;
+
+// Mirror of the C struct handed to Python. Fixed-size, POD, ctypes-friendly.
+struct RxMsg
+{
+  uint32_t msgid;
+  uint8_t sysid;
+  uint8_t compid;
+  uint8_t seq;
+  uint8_t len;
+  uint8_t framing;      // mavconn::Framing value
+  uint8_t payload[255];
+};
+
+struct Shim
+{
+  explicit Shim(std::shared_ptr<mavconn::MAVConnUDP> c)
+  : conn(std::move(c))
+  {}
+
+  std::shared_ptr<mavconn::MAVConnUDP> conn;
+  std::mutex mutex;
+  std::condition_variable cond;
+  std::deque<RxMsg> rx_queue;
+};
+
+inline Shim * as_shim(void * handle)
+{
+  return static_cast<Shim *>(handle);
+}
+
+}  // namespace
+
+extern "C"
+{
+void * mavconn_udp_create(
+  uint8_t sysid, uint8_t compid,
+  uint16_t bind_port, const char * remote_host, uint16_t remote_port)
+{
+  auto conn = std::make_shared<mavconn::MAVConnUDP>(
+    sysid, compid,
+    "0.0.0.0", bind_port,
+    std::string(remote_host ? remote_host : ""), remote_port);
+
+  auto shim = std::make_unique<Shim>(conn);
+  Shim * shim_ptr = shim.get();
+
+  conn->connect(
+    [shim_ptr](const mavlink_message_t * msg, const mavconn::Framing framing) {
+      RxMsg out = {};
+      out.msgid = msg->msgid;
+      out.sysid = msg->sysid;
+      out.compid = msg->compid;
+      out.seq = msg->seq;
+      out.len = msg->len;
+      out.framing = static_cast<uint8_t>(framing);
+      const auto copy_len = std::min<size_t>(msg->len, sizeof(out.payload));
+      std::memcpy(out.payload, _MAV_PAYLOAD(msg), copy_len);
+
+      std::lock_guard<std::mutex> lock(shim_ptr->mutex);
+      shim_ptr->rx_queue.push_back(out);
+      shim_ptr->cond.notify_all();
+    });
+
+  return shim.release();
+}
+
+int mavconn_poll_rx(void * handle, RxMsg * out, int timeout_ms)
+{
+  auto * shim = as_shim(handle);
+  if (!shim || !out) {
+    return -1;
+  }
+
+  std::unique_lock<std::mutex> lock(shim->mutex);
+  const bool got = shim->cond.wait_for(
+    lock, std::chrono::milliseconds(timeout_ms),
+    [&]() {return !shim->rx_queue.empty();});
+  if (!got) {
+    return 0;      // timeout
+  }
+
+  *out = shim->rx_queue.front();
+  shim->rx_queue.pop_front();
+  return 1;
+}
+
+int mavconn_send_heartbeat(
+  void * handle,
+  uint8_t type, uint8_t autopilot, uint8_t base_mode,
+  uint32_t custom_mode, uint8_t system_status)
+{
+  auto * shim = as_shim(handle);
+  if (!shim) {
+    return -1;
+  }
+
+  mavlink::common::msg::HEARTBEAT hb = {};
+  hb.type = type;
+  hb.autopilot = autopilot;
+  hb.base_mode = base_mode;
+  hb.custom_mode = custom_mode;
+  hb.system_status = system_status;
+  hb.mavlink_version = 3;  // matches pymavlink default
+
+  try {
+    // base-class convenience overload uses the object's own compid
+    static_cast<mavconn::MAVConnInterface &>(*shim->conn).send_message(hb);
+  } catch (const std::length_error &) {
+    return -2;
+  }
+  return 0;
+}
+
+int mavconn_send_raw_bytes(void * handle, const uint8_t * bytes, uint32_t length)
+{
+  auto * shim = as_shim(handle);
+  if (!shim || !bytes) {
+    return -1;
+  }
+
+  try {
+    shim->conn->send_bytes(bytes, length);
+  } catch (const std::length_error &) {
+    return -2;
+  }
+  return 0;
+}
+
+int mavconn_setup_signing(
+  void * handle,
+  const uint8_t * secret_key,   // 32 bytes
+  uint8_t sign_outgoing, uint8_t link_id, uint64_t initial_timestamp)
+{
+  auto * shim = as_shim(handle);
+  if (!shim || !secret_key) {
+    return -1;
+  }
+
+  std::array<uint8_t, 32> key = {};
+  std::memcpy(key.data(), secret_key, key.size());
+  shim->conn->setup_signing(key, sign_outgoing != 0, link_id, initial_timestamp);
+  return 0;
+}
+
+void mavconn_destroy(void * handle)
+{
+  auto * shim = as_shim(handle);
+  if (!shim) {
+    return;
+  }
+  shim->conn->close();
+  delete shim;
+}
+}  // extern "C"

--- a/libmavconn/test/e2e/test_libmavconn_e2e.py
+++ b/libmavconn/test/e2e/test_libmavconn_e2e.py
@@ -18,6 +18,7 @@ without pip stays green.
 """
 
 import ctypes
+import importlib.util
 import os
 import socket
 import struct
@@ -25,8 +26,16 @@ import time
 
 import pytest
 
-pymavlink = pytest.importorskip("pymavlink")
-from pymavlink.dialects.v20 import common as mav_common  # noqa: E402
+# Skip the whole module at collection time when pymavlink is unavailable, but
+# still *collect* the tests so pytest exits 0. pytest.importorskip() at import
+# time collects 0 tests, which makes pytest exit with code 5 ("no tests
+# collected") and ament's run_test.py then reports the test as failed.
+_HAVE_PYMAVLINK = importlib.util.find_spec("pymavlink") is not None
+pytestmark = pytest.mark.skipif(
+    not _HAVE_PYMAVLINK, reason="pymavlink is not installed (pip-only test dep)")
+
+if _HAVE_PYMAVLINK:
+    from pymavlink.dialects.v20 import common as mav_common
 
 
 # --------------------------------------------------------------------------

--- a/libmavconn/test/e2e/test_libmavconn_e2e.py
+++ b/libmavconn/test/e2e/test_libmavconn_e2e.py
@@ -21,6 +21,7 @@ import ctypes
 import os
 import socket
 import struct
+import time
 
 import pytest
 
@@ -146,6 +147,10 @@ def link(shim):
     handle = shim.mavconn_udp_create(
         42, 200, bind_port, b"127.0.0.1", remote_port)
     try:
+        # Let the link's io thread post its async receive before any test sends
+        # a datagram. UDP delivers unreceived datagrams to no one, so without
+        # this the first packet can be lost on a loaded/slow CI runner.
+        time.sleep(0.2)
         yield shim, handle, bind_port, remote_sock, remote_port
     finally:
         shim.mavconn_destroy(handle)

--- a/libmavconn/test/e2e/test_libmavconn_e2e.py
+++ b/libmavconn/test/e2e/test_libmavconn_e2e.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# libmavconn
+# Copyright 2026, mavros contributors. Licensed as the rest of the package.
+#
+# This file is part of the mavros package and subject to the license terms
+# in the top-level LICENSE file of the mavros repository.
+# https://github.com/mavlink/mavros/tree/master/LICENSE.md
+#
+"""
+End-to-end byte-stream tests for libmavconn, using pymavlink as reference.
+
+Drive a real MAVConnUDP link through a small ctypes shim and check that the
+bytes libmavconn emits match pymavlink's reference encoding, and that frames
+crafted by pymavlink are decoded by libmavconn into the same message fields.
+
+Skip cleanly when pymavlink (or the shim) is unavailable, so CI/buildfarm
+without pip stays green.
+"""
+
+import ctypes
+import os
+import socket
+import struct
+
+import pytest
+
+pymavlink = pytest.importorskip("pymavlink")
+from pymavlink.dialects.v20 import common as mav_common  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# ctypes shim binding
+# --------------------------------------------------------------------------
+
+_SHIM_PATH = os.environ.get("MAVCONN_E2E_SHIM", "")
+
+
+class RxMsg(ctypes.Structure):
+    _fields_ = [
+        ("msgid", ctypes.c_uint32),
+        ("sysid", ctypes.c_uint8),
+        ("compid", ctypes.c_uint8),
+        ("seq", ctypes.c_uint8),
+        ("len", ctypes.c_uint8),
+        ("framing", ctypes.c_uint8),
+        ("payload", ctypes.c_uint8 * 255),
+    ]
+
+    def payload_bytes(self):
+        return bytes(self.payload[: self.len])
+
+
+def _load_shim():
+    if not _SHIM_PATH or not os.path.exists(_SHIM_PATH):
+        pytest.skip(f"mavconn e2e shim not available (MAVCONN_E2E_SHIM={_SHIM_PATH!r})")
+    lib = ctypes.CDLL(_SHIM_PATH)
+    lib.mavconn_udp_create.restype = ctypes.c_void_p
+    lib.mavconn_udp_create.argtypes = [
+        ctypes.c_uint8, ctypes.c_uint8,
+        ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint16,
+    ]
+    lib.mavconn_poll_rx.restype = ctypes.c_int
+    lib.mavconn_poll_rx.argtypes = [ctypes.c_void_p, ctypes.POINTER(RxMsg), ctypes.c_int]
+    lib.mavconn_send_heartbeat.restype = ctypes.c_int
+    lib.mavconn_send_heartbeat.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8,
+        ctypes.c_uint32, ctypes.c_uint8,
+    ]
+    lib.mavconn_send_raw_bytes.restype = ctypes.c_int
+    lib.mavconn_send_raw_bytes.argtypes = [
+        ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint8), ctypes.c_uint32,
+    ]
+    lib.mavconn_setup_signing.restype = ctypes.c_int
+    lib.mavconn_setup_signing.argtypes = [
+        ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint8),
+        ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint64,
+    ]
+    lib.mavconn_destroy.restype = None
+    lib.mavconn_destroy.argtypes = [ctypes.c_void_p]
+    return lib
+
+
+# MAVLink framing values (mavlink_framing_t)
+FRAMING_INCOMPLETE = 0
+FRAMING_OK = 1
+FRAMING_BAD_CRC = 2
+FRAMING_BAD_SIGNATURE = 3
+
+# A deterministic test signing key.
+TEST_KEY = bytes(range(32))
+
+
+def _mav(src_system=42, src_component=200, signing=None):
+    """Create a pymavlink MAVLink codec context (no transport)."""
+    m = mav_common.MAVLink(None, srcSystem=src_system, srcComponent=src_component)
+    if signing is not None:
+        m.signing.secret_key = signing["key"]
+        m.signing.sign_outgoing = True
+        m.signing.link_id = signing.get("link_id", 0)
+        m.signing.timestamp = signing.get("timestamp", 0)
+    return m
+
+
+def _pack_heartbeat(mav, **fields):
+    # NOTE: pass fields by keyword. pymavlink's positional ctor order is the
+    # message *declaration* order, which is NOT the wire (sorted) order.
+    msg = mav_common.MAVLink_heartbeat_message(
+        custom_mode=fields.get("custom_mode", 0),
+        type=fields.get("type", 18),       # MAV_TYPE_ONBOARD_CONTROLLER
+        autopilot=fields.get("autopilot", 8),   # MAV_AUTOPILOT_INVALID
+        base_mode=fields.get("base_mode", 192),  # MAV_MODE_MANUAL_ARMED
+        system_status=fields.get("system_status", 4),  # MAV_STATE_ACTIVE
+        mavlink_version=fields.get("mavlink_version", 3),
+    )
+    msg.pack(mav)
+    return msg
+
+
+def _recv_parsed(sock, mav, timeout=3.0):
+    """Receive one UDP datagram and parse it with pymavlink."""
+    sock.settimeout(timeout)
+    data, _ = sock.recvfrom(4096)
+    msgs = mav.parse_buffer(data)
+    return data, msgs
+
+
+@pytest.fixture()
+def shim():
+    lib = _load_shim()
+    yield lib
+
+
+@pytest.fixture()
+def link(shim):
+    """Yield a MAVConnUDP link bound to an ephemeral port; torn down after test."""
+    bind_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    bind_sock.bind(("127.0.0.1", 0))
+    bind_port = bind_sock.getsockname()[1]
+    bind_sock.close()
+
+    remote_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    remote_sock.bind(("127.0.0.1", 0))
+    remote_port = remote_sock.getsockname()[1]
+
+    handle = shim.mavconn_udp_create(
+        42, 200, bind_port, b"127.0.0.1", remote_port)
+    try:
+        yield shim, handle, bind_port, remote_sock, remote_port
+    finally:
+        shim.mavconn_destroy(handle)
+        remote_sock.close()
+
+
+# --------------------------------------------------------------------------
+# TX: libmavconn -> pymavlink
+# --------------------------------------------------------------------------
+
+def test_tx_heartbeat_matches_pymavlink(link):
+    shim, handle, bind_port, remote_sock, remote_port = link
+
+    # libmavconn sends a heartbeat.
+    rc = shim.mavconn_send_heartbeat(handle, 18, 8, 192, 0, 4)
+    assert rc == 0
+
+    # pymavlink reference frame with the same ids/fields. seq starts at 0.
+    ref = _mav(src_system=42, src_component=200)
+    ref_msg = _pack_heartbeat(ref, type=18, autopilot=8, base_mode=192,
+                              custom_mode=0, system_status=4, mavlink_version=3)
+    expected = bytes(ref_msg.get_msgbuf())
+
+    data, msgs = _recv_parsed(remote_sock, _mav())
+    assert data == expected, f"wire mismatch:\n got {data.hex()}\nwant {expected.hex()}"
+
+    assert msgs and msgs[-1].get_msgId() == 0  # HEARTBEAT
+    hb = msgs[-1]
+    assert (hb.type, hb.autopilot, hb.base_mode, hb.system_status) == (18, 8, 192, 4)
+    assert (hb.get_srcSystem(), hb.get_srcComponent()) == (42, 200)
+
+
+# --------------------------------------------------------------------------
+# RX: pymavlink -> libmavconn
+# --------------------------------------------------------------------------
+
+def test_rx_heartbeat_from_pymavlink(link):
+    shim, handle, bind_port, remote_sock, remote_port = link
+
+    # pymavlink crafts and sends a heartbeat to the libmavconn bind port.
+    sender = _mav(src_system=7, src_component=8)
+    msg = _pack_heartbeat(sender, type=2, autopilot=3, base_mode=64,
+                          custom_mode=12345, system_status=4)
+    wire = bytes(msg.get_msgbuf())
+
+    out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    out.sendto(wire, ("127.0.0.1", bind_port))
+    out.close()
+
+    got = RxMsg()
+    rc = shim.mavconn_poll_rx(handle, ctypes.byref(got), 3000)
+    assert rc == 1, "libmavconn did not receive the pymavlink frame"
+    assert got.framing == FRAMING_OK
+    assert got.msgid == 0  # HEARTBEAT
+    assert (got.sysid, got.compid, got.seq) == (7, 8, 0)
+    # payload layout: custom_mode(u32) type(u8) autopilot(u8) base_mode(u8)
+    # system_status(u8) mavlink_version(u8)
+    assert got.payload_bytes() == struct.pack("<IBBBBB", 12345, 2, 3, 64, 4, 3)
+
+
+def test_rx_sys_status_from_pymavlink(link):
+    """A non-trivial message with extension fields round-trips."""
+    shim, handle, bind_port, remote_sock, remote_port = link
+
+    sender = _mav(src_system=5, src_component=6)
+    ss = mav_common.MAVLink_sys_status_message(
+        onboard_control_sensors_present=0xA5A5A5A5,
+        onboard_control_sensors_enabled=0x0F0F0F0F,
+        onboard_control_sensors_health=0x12345678,
+        load=500,
+        voltage_battery=16800,
+        current_battery=-1,
+        battery_remaining=50,
+        drop_rate_comm=0,
+        errors_comm=0,
+        errors_count1=10,
+        errors_count2=11,
+        errors_count3=12,
+        errors_count4=13,
+    )
+    ss.pack(sender)
+    wire = bytes(ss.get_msgbuf())
+
+    out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    out.sendto(wire, ("127.0.0.1", bind_port))
+    out.close()
+
+    got = RxMsg()
+    rc = shim.mavconn_poll_rx(handle, ctypes.byref(got), 3000)
+    assert rc == 1
+    assert got.framing == FRAMING_OK
+    assert got.msgid == 1  # SYS_STATUS
+    assert (got.sysid, got.compid) == (5, 6)
+    # The payload must equal pymavlink's own payload bytes exactly.
+    assert got.payload_bytes() == bytes(ss.get_payload())
+
+
+# --------------------------------------------------------------------------
+# Signing
+# --------------------------------------------------------------------------
+
+def test_tx_signed_heartbeat_verified_by_pymavlink(link):
+    shim, handle, bind_port, remote_sock, remote_port = link
+
+    key = (ctypes.c_uint8 * 32)(*TEST_KEY)
+    rc = shim.mavconn_setup_signing(handle, key, 1, 7, 1000)  # link_id=7, ts=1000
+    assert rc == 0
+
+    rc = shim.mavconn_send_heartbeat(handle, 18, 8, 192, 0, 4)
+    assert rc == 0
+
+    # pymavlink verifier with the same key; its own clock only needs the
+    # timestamp window to accept a new stream.
+    verifier = _mav()
+    verifier.signing.secret_key = TEST_KEY
+    verifier.signing.sign_outgoing = False
+    verifier.signing.timestamp = 1000
+
+    data, msgs = _recv_parsed(remote_sock, verifier)
+    # signed v2 frame: incompat_flags has the SIGNED bit set.
+    assert data[0] == 0xFD
+    assert data[2] & 0x01, "frame not marked signed"
+    assert msgs and msgs[-1].get_msgId() == 0, f"signature rejected: {msgs}"
+    assert verifier.signing.badsig_count == 0
+
+
+def test_rx_signed_heartbeat_from_pymavlink(link):
+    shim, handle, bind_port, remote_sock, remote_port = link
+
+    key = (ctypes.c_uint8 * 32)(*TEST_KEY)
+    rc = shim.mavconn_setup_signing(handle, key, 1, 3, 1000)
+    assert rc == 0
+
+    sender = _mav(src_system=9, src_component=10,
+                  signing={"key": TEST_KEY, "link_id": 3, "timestamp": 1000})
+    msg = _pack_heartbeat(sender, type=18, autopilot=8, base_mode=192,
+                          custom_mode=0, system_status=4)
+    wire = bytes(msg.get_msgbuf())
+
+    out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    out.sendto(wire, ("127.0.0.1", bind_port))
+    out.close()
+
+    got = RxMsg()
+    rc = shim.mavconn_poll_rx(handle, ctypes.byref(got), 3000)
+    assert rc == 1
+    assert got.framing == FRAMING_OK
+    assert got.msgid == 0
+    assert (got.sysid, got.compid) == (9, 10)
+
+
+def test_rx_bad_signature_rejected(link):
+    shim, handle, bind_port, remote_sock, remote_port = link
+
+    key = (ctypes.c_uint8 * 32)(*TEST_KEY)
+    rc = shim.mavconn_setup_signing(handle, key, 1, 3, 1000)
+    assert rc == 0
+
+    # Sender signs with a *different* key.
+    bad_key = bytes(b ^ 0xFF for b in TEST_KEY)
+    sender = _mav(src_system=9, src_component=10,
+                  signing={"key": bad_key, "link_id": 3, "timestamp": 1000})
+    msg = _pack_heartbeat(sender, type=18, autopilot=8, base_mode=192,
+                          custom_mode=0, system_status=4)
+    wire = bytes(msg.get_msgbuf())
+
+    out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    out.sendto(wire, ("127.0.0.1", bind_port))
+    out.close()
+
+    got = RxMsg()
+    rc = shim.mavconn_poll_rx(handle, ctypes.byref(got), 3000)
+    assert rc == 1
+    assert got.framing == FRAMING_BAD_SIGNATURE

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -53,7 +53,6 @@ using mavconn::Framing;
 using ::mavlink::mavlink_message_t;
 using ::mavlink::msgid_t;
 
-using namespace std::placeholders;      // NOLINT
 using namespace std::chrono_literals;   // NOLINT
 
 class Router;
@@ -157,18 +156,28 @@ public:
 
     add_service = this->create_service<mavros_msgs::srv::EndpointAdd>(
       "~/add_endpoint",
-      std::bind(&Router::add_endpoint, this, _1, _2));
+      [this](
+        const mavros_msgs::srv::EndpointAdd::Request::SharedPtr request,
+        mavros_msgs::srv::EndpointAdd::Response::SharedPtr response)
+      {
+        this->add_endpoint(request, response);
+      });
     del_service = this->create_service<mavros_msgs::srv::EndpointDel>(
       "~/del_endpoint",
-      std::bind(&Router::del_endpoint, this, _1, _2));
+      [this](
+        const mavros_msgs::srv::EndpointDel::Request::SharedPtr request,
+        mavros_msgs::srv::EndpointDel::Response::SharedPtr response)
+      {
+        this->del_endpoint(request, response);
+      });
 
     // try to reconnect endpoint each 30 seconds
     reconnect_timer =
-      this->create_wall_timer(30s, std::bind(&Router::periodic_reconnect_endpoints, this));
+      this->create_wall_timer(30s, [this]() {this->periodic_reconnect_endpoints();});
 
     // collect garbage addrs each minute
     stale_addrs_timer =
-      this->create_wall_timer(60s, std::bind(&Router::periodic_clear_stale_remote_addrs, this));
+      this->create_wall_timer(60s, [this]() {this->periodic_clear_stale_remote_addrs();});
 
     diagnostic_updater.setHardwareID("none");  // NOTE: router connects several hardwares
     diagnostic_updater.add("MAVROS Router", this, &Router::diag_run);
@@ -201,7 +210,7 @@ private:
 
   static std::atomic<id_t> id_counter;
 
-  std::shared_timed_mutex mu;
+  std::shared_mutex mu;
 
   // map stores all routing endpoints
   std::unordered_map<id_t, Endpoint::SharedPtr> endpoints;
@@ -232,7 +241,10 @@ private:
   void param_init()
   {
     set_parameters_handle_ptr =
-      this->add_on_set_parameters_callback(std::bind(&Router::on_set_parameters_cb, this, _1));
+      this->add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter> & parameters) {
+        return this->on_set_parameters_cb(parameters);
+      });
 
     auto params = get_parameters({"fcu_urls", "gcs_urls", "uas_urls"});
     on_set_parameters_cb(params);
@@ -240,7 +252,7 @@ private:
 
   void param_init_once()
   {
-    std::call_once(param_init_flag, std::bind(&Router::param_init, this));
+    std::call_once(param_init_flag, &Router::param_init, this);
   }
 
   rcl_interfaces::msg::SetParametersResult on_set_parameters_cb(

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -31,6 +31,7 @@
 #include <Eigen/Eigen>      // NOLINT
 
 #include "mavconn/interface.hpp"
+#include "mavconn/io_context_runner.hpp"
 #include "mavconn/mavlink_dialect.hpp"
 #include "mavros/utils.hpp"
 #include "rclcpp/macros.hpp"
@@ -145,6 +146,7 @@ public:
     const std::string & node_name = "mavros_router")
   : rclcpp::Node(node_name,
       options /* rclcpp::NodeOptions(options).use_intra_process_comms(true) */),
+    router_io_runner(),
     endpoints{}, stat_msg_routed(0), stat_msg_sent(0), stat_msg_dropped(0),
     diagnostic_updater(this, 1.0)
   {
@@ -192,6 +194,8 @@ public:
     RCLCPP_INFO(get_logger(), "Known MAVLink dialects:%s", ss.str().c_str());
     RCLCPP_INFO(get_logger(), "MAVROS Router started");
 
+    router_io_runner.start([this]() {this->router_io_runner.io().run();});
+
     // Delay parameter callback initialization because
     // add/del endpoints calls have to use shared_from_this(),
     // which cannot be used before we leave the constructor.
@@ -202,13 +206,24 @@ public:
       });
   }
 
+  ~Router() override
+  {
+    router_io_runner.shutdown_owned();
+  }
+
   void route_message(Endpoint::SharedPtr src, const mavlink_message_t * msg, const Framing framing);
+
+  [[nodiscard]] asio::io_service * get_shared_io()
+  {
+    return &router_io_runner.io();
+  }
 
 private:
   friend class Endpoint;
   friend class TestRouter;
 
   static std::atomic<id_t> id_counter;
+  mavconn::IoContextRunner router_io_runner;
 
   std::shared_mutex mu;
 

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -54,7 +54,6 @@ using mavconn::Framing;
 using ::mavlink::mavlink_message_t;
 using ::mavlink::msgid_t;
 
-using namespace std::placeholders;      // NOLINT
 using namespace std::chrono_literals;   // NOLINT
 
 class Router;
@@ -159,18 +158,28 @@ public:
 
     add_service = this->create_service<mavros_msgs::srv::EndpointAdd>(
       "~/add_endpoint",
-      std::bind(&Router::add_endpoint, this, _1, _2));
+      [this](
+        const mavros_msgs::srv::EndpointAdd::Request::SharedPtr request,
+        mavros_msgs::srv::EndpointAdd::Response::SharedPtr response)
+      {
+        this->add_endpoint(request, response);
+      });
     del_service = this->create_service<mavros_msgs::srv::EndpointDel>(
       "~/del_endpoint",
-      std::bind(&Router::del_endpoint, this, _1, _2));
+      [this](
+        const mavros_msgs::srv::EndpointDel::Request::SharedPtr request,
+        mavros_msgs::srv::EndpointDel::Response::SharedPtr response)
+      {
+        this->del_endpoint(request, response);
+      });
 
     // try to reconnect endpoint each 30 seconds
     reconnect_timer =
-      this->create_wall_timer(30s, std::bind(&Router::periodic_reconnect_endpoints, this));
+      this->create_wall_timer(30s, [this]() {this->periodic_reconnect_endpoints();});
 
     // collect garbage addrs each minute
     stale_addrs_timer =
-      this->create_wall_timer(60s, std::bind(&Router::periodic_clear_stale_remote_addrs, this));
+      this->create_wall_timer(60s, [this]() {this->periodic_clear_stale_remote_addrs();});
 
     diagnostic_updater.setHardwareID("none");  // NOTE: router connects several hardwares
     diagnostic_updater.add("MAVROS Router", this, &Router::diag_run);
@@ -203,7 +212,7 @@ private:
 
   static std::atomic<id_t> id_counter;
 
-  std::shared_timed_mutex mu;
+  std::shared_mutex mu;
 
   // map stores all routing endpoints
   std::unordered_map<id_t, Endpoint::SharedPtr> endpoints;
@@ -234,7 +243,10 @@ private:
   void param_init()
   {
     set_parameters_handle_ptr =
-      this->add_on_set_parameters_callback(std::bind(&Router::on_set_parameters_cb, this, _1));
+      this->add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter> & parameters) {
+        return this->on_set_parameters_cb(parameters);
+      });
 
     auto params = get_parameters({"fcu_urls", "gcs_urls", "uas_urls"});
     on_set_parameters_cb(params);
@@ -242,7 +254,7 @@ private:
 
   void param_init_once()
   {
-    std::call_once(param_init_flag, std::bind(&Router::param_init, this));
+    std::call_once(param_init_flag, &Router::param_init, this);
   }
 
   rcl_interfaces::msg::SetParametersResult on_set_parameters_cb(

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -210,6 +210,7 @@ public:
 
   ~Router() override
   {
+    startup_delay_timer->cancel();
     reconnect_timer->cancel();
     stale_addrs_timer->cancel();
     router_io_runner.shutdown_owned();

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -210,6 +210,8 @@ public:
 
   ~Router() override
   {
+    reconnect_timer->cancel();
+    stale_addrs_timer->cancel();
     router_io_runner.shutdown_owned();
   }
 

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -32,6 +32,7 @@
 #include <Eigen/Eigen>      // NOLINT
 
 #include "mavconn/interface.hpp"
+#include "mavconn/io_context_runner.hpp"
 #include "mavconn/mavlink_dialect.hpp"
 #include "mavros/utils.hpp"
 #include "rclcpp/macros.hpp"
@@ -147,6 +148,7 @@ public:
     const std::string & node_name = "mavros_router")
   : rclcpp::Node(node_name,
       options /* rclcpp::NodeOptions(options).use_intra_process_comms(true) */),
+    router_io_runner(),
     endpoints{}, stat_msg_routed(0), stat_msg_sent(0), stat_msg_dropped(0),
     diagnostic_updater(this, 1.0)
   {
@@ -194,6 +196,8 @@ public:
     RCLCPP_INFO(get_logger(), "Known MAVLink dialects:%s", ss.str().c_str());
     RCLCPP_INFO(get_logger(), "MAVROS Router started");
 
+    router_io_runner.start([this]() {this->router_io_runner.io().run();});
+
     // Delay parameter callback initialization because
     // add/del endpoints calls have to use shared_from_this(),
     // which cannot be used before we leave the constructor.
@@ -204,13 +208,24 @@ public:
       });
   }
 
+  ~Router() override
+  {
+    router_io_runner.shutdown_owned();
+  }
+
   void route_message(Endpoint::SharedPtr src, const mavlink_message_t * msg, const Framing framing);
+
+  [[nodiscard]] asio::io_context * get_shared_io()
+  {
+    return &router_io_runner.io();
+  }
 
 private:
   friend class Endpoint;
   friend class TestRouter;
 
   static std::atomic<id_t> id_counter;
+  mavconn::IoContextRunner router_io_runner;
 
   std::shared_mutex mu;
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -108,7 +108,6 @@ void Router::add_endpoint(
   const mavros_msgs::srv::EndpointAdd::Request::SharedPtr request,
   mavros_msgs::srv::EndpointAdd::Response::SharedPtr response)
 {
-  unique_lock lock(mu);
   auto lg = get_logger();
 
   RCLCPP_INFO(
@@ -139,7 +138,10 @@ void Router::add_endpoint(
   ep->link_type = static_cast<Endpoint::Type>(request->type);
   ep->url = request->url;
 
-  this->endpoints[id] = ep;
+  {
+    unique_lock lock(mu);
+    this->endpoints[id] = ep;
+  }
   this->diagnostic_updater.add(ep->diag_name(), std::bind(&Endpoint::diag_run, ep, _1));
   RCLCPP_INFO(lg, "Endpoint link[%d] created", id);
 
@@ -159,17 +161,25 @@ void Router::del_endpoint(
   const mavros_msgs::srv::EndpointDel::Request::SharedPtr request,
   mavros_msgs::srv::EndpointDel::Response::SharedPtr response)
 {
-  unique_lock lock(mu);
   auto lg = get_logger();
+  Endpoint::SharedPtr endpoint_to_remove;
+  std::string endpoint_diag_name;
 
   if (request->id != 0) {
     RCLCPP_INFO(lg, "Requested to del endpoint id: %d", request->id);
-    auto it = this->endpoints.find(request->id);
-    if (it != this->endpoints.end() ) {
-      it->second->close();
-      this->diagnostic_updater.removeByName(it->second->diag_name());
-      this->endpoints.erase(it);
-      response->successful = true;
+    {
+      unique_lock lock(mu);
+      auto it = this->endpoints.find(request->id);
+      if (it != this->endpoints.end() ) {
+        endpoint_to_remove = it->second;
+        endpoint_diag_name = it->second->diag_name();
+        this->endpoints.erase(it);
+        response->successful = true;
+      }
+    }
+    if (endpoint_to_remove) {
+      endpoint_to_remove->close();
+      this->diagnostic_updater.removeByName(endpoint_diag_name);
     }
     return;
   }
@@ -177,16 +187,23 @@ void Router::del_endpoint(
   RCLCPP_INFO(
     lg, "Requested to del endpoint type: %d url: %s", request->type,
     request->url.c_str());
-  for (auto it = this->endpoints.cbegin(); it != this->endpoints.cend(); it++) {
-    if (it->second->url == request->url &&
-      it->second->link_type == static_cast<Endpoint::Type>( request->type))
-    {
-      it->second->close();
-      this->diagnostic_updater.removeByName(it->second->diag_name());
-      this->endpoints.erase(it);
-      response->successful = true;
-      return;
+  {
+    unique_lock lock(mu);
+    for (auto it = this->endpoints.cbegin(); it != this->endpoints.cend(); it++) {
+      if (it->second->url == request->url &&
+        it->second->link_type == static_cast<Endpoint::Type>(request->type))
+      {
+        endpoint_to_remove = it->second;
+        endpoint_diag_name = it->second->diag_name();
+        this->endpoints.erase(it);
+        response->successful = true;
+        break;
+      }
     }
+  }
+  if (endpoint_to_remove) {
+    endpoint_to_remove->close();
+    this->diagnostic_updater.removeByName(endpoint_diag_name);
   }
 }
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -403,6 +403,11 @@ bool MAVConnEndpoint::is_open()
 
 std::pair<bool, std::string> MAVConnEndpoint::open()
 {
+  auto nh = this->parent;
+  if (!nh) {
+    return {false, "parent not set"};
+  }
+
   try {
     auto weak_self = weak_from_this();
     this->link = mavconn::MAVConnInterface::open_url(
@@ -411,7 +416,9 @@ std::pair<bool, std::string> MAVConnEndpoint::open()
         if (auto self = weak_self.lock()) {
           self->recv_message(msg, framing);
         }
-      });
+      },
+      mavconn::MAVConnInterface::ClosedCb(),
+      nh->get_shared_io());
   } catch (mavconn::DeviceError & ex) {
     return {false, ex.what()};
   }

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -23,8 +23,8 @@
 using namespace mavros::router;  // NOLINT
 using rclcpp::QoS;
 
-using unique_lock = std::unique_lock<std::shared_timed_mutex>;
-using shared_lock = std::shared_lock<std::shared_timed_mutex>;
+using unique_lock = std::unique_lock<std::shared_mutex>;
+using shared_lock = std::shared_lock<std::shared_mutex>;
 
 std::atomic<id_t> Router::id_counter {1000};
 
@@ -142,7 +142,11 @@ void Router::add_endpoint(
     unique_lock lock(mu);
     this->endpoints[id] = ep;
   }
-  this->diagnostic_updater.add(ep->diag_name(), std::bind(&Endpoint::diag_run, ep, _1));
+  this->diagnostic_updater.add(
+    ep->diag_name(),
+    [ep](diagnostic_updater::DiagnosticStatusWrapper & stat) {
+      ep->diag_run(stat);
+    });
   RCLCPP_INFO(lg, "Endpoint link[%d] created", id);
 
   auto result = ep->open();
@@ -400,10 +404,14 @@ bool MAVConnEndpoint::is_open()
 std::pair<bool, std::string> MAVConnEndpoint::open()
 {
   try {
+    auto weak_self = weak_from_this();
     this->link = mavconn::MAVConnInterface::open_url(
-      this->url, 1, mavconn::MAV_COMP_ID_UDP_BRIDGE, std::bind(
-        &MAVConnEndpoint::recv_message,
-        shared_from_this(), _1, _2));
+      this->url, 1, mavconn::MAV_COMP_ID_UDP_BRIDGE,
+      [weak_self](const mavlink_message_t * msg, const Framing framing) {
+        if (auto self = weak_self.lock()) {
+          self->recv_message(msg, framing);
+        }
+      });
   } catch (mavconn::DeviceError & ex) {
     return {false, ex.what()};
   }
@@ -501,7 +509,9 @@ std::pair<bool, std::string> ROSEndpoint::open()
         "mavlink_source"), qos);
     this->sink = nh->create_subscription<mavros_msgs::msg::Mavlink>(
       utils::format("%s/%s", this->url.c_str(), "mavlink_sink"), qos,
-      std::bind(&ROSEndpoint::ros_recv_message, this, _1));
+      [this](const mavros_msgs::msg::Mavlink::SharedPtr rmsg) {
+        this->ros_recv_message(rmsg);
+      });
   } catch (rclcpp::exceptions::InvalidTopicNameError & ex) {
     return {false, ex.what()};
   }

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -37,7 +37,6 @@ void Router::route_message(
   Endpoint::SharedPtr src, const mavlink_message_t * msg,
   const Framing framing)
 {
-  shared_lock lock(mu);
   this->stat_msg_routed++;
 
   // find message destination target
@@ -52,35 +51,42 @@ void Router::route_message(
     }
   }
 
-  size_t sent_cnt = 0, retry_cnt = 0;
-retry:
-  for (auto & kv : this->endpoints) {
-    auto & dest = kv.second;
+  auto collect_targets = [this, &src](addr_t addr) {
+      std::vector<Endpoint::SharedPtr> targets;
+      shared_lock lock(mu);
+      targets.reserve(this->endpoints.size());
 
-    if (src->id == dest->id) {
-      continue;     // do not echo message
-    }
-    if (src->link_type == dest->link_type) {
-      continue;     // drop messages between same type FCU/GCS/UAS
-    }
+      for (const auto & kv : this->endpoints) {
+        const auto & dest = kv.second;
 
-    // NOTE(vooon): current router do not allow to speak drone-to-drone.
-    //              if it is needed perhaps better to add mavlink-router in front of mavros-router.
+        if (src->id == dest->id) {
+          continue;     // do not echo message
+        }
+        if (src->link_type == dest->link_type) {
+          continue;     // drop messages between same type FCU/GCS/UAS
+        }
 
-    bool has_target = dest->remote_addrs.find(target_addr) != dest->remote_addrs.end();
+        // NOTE(vooon): current router do not allow to speak drone-to-drone.
+        //              if it is needed perhaps better to add mavlink-router in front of mavros-router.
+        if (dest->remote_addrs.find(addr) != dest->remote_addrs.end()) {
+          targets.emplace_back(dest);
+        }
+      }
 
-    if (has_target) {
-      dest->send_message(msg, framing, src->id);
-      sent_cnt++;
-    }
-  }
+      return targets;
+    };
 
-  // if message haven't been sent retry broadcast it
-  if (sent_cnt == 0 && retry_cnt < 2) {
+  auto targets = collect_targets(target_addr);
+  if (targets.empty() && target_addr != 0) {
+    // if targeted message hasn't been sent, retry as broadcast
     target_addr = 0;
-    retry_cnt++;
-    goto retry;
+    targets = collect_targets(target_addr);
   }
+
+  for (const auto & dest : targets) {
+    dest->send_message(msg, framing, src->id);
+  }
+  const auto sent_cnt = targets.size();
 
   // update stats
   this->stat_msg_sent.fetch_add(sent_cnt);

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -67,7 +67,8 @@ void Router::route_message(
         }
 
         // NOTE(vooon): current router do not allow to speak drone-to-drone.
-        //              if it is needed perhaps better to add mavlink-router in front of mavros-router.
+        //              if needed, perhaps better to add mavlink-router in front of
+        //              mavros-router.
         if (dest->remote_addrs.find(addr) != dest->remote_addrs.end()) {
           targets.emplace_back(dest);
         }

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -76,8 +76,6 @@ void Router::route_message(
           }
         }
       }
-
-
       return targets;
     };
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -37,7 +37,6 @@ void Router::route_message(
   Endpoint::SharedPtr src, const mavlink_message_t * msg,
   const Framing framing)
 {
-  shared_lock lock(mu);
   this->stat_msg_routed++;
 
   // find message destination target
@@ -52,39 +51,47 @@ void Router::route_message(
     }
   }
 
-  size_t sent_cnt = 0, retry_cnt = 0;
-retry:
-  for (auto & kv : this->endpoints) {
-    auto & dest = kv.second;
+  auto collect_targets = [this, &src](addr_t addr) {
+      std::vector<Endpoint::SharedPtr> targets;
+      shared_lock lock(mu);
+      targets.reserve(this->endpoints.size());
 
-    if (src->id == dest->id) {
-      continue;     // do not echo message
-    }
-    if (src->link_type == dest->link_type) {
-      continue;     // drop messages between same type FCU/GCS/UAS
-    }
+      for (const auto & kv : this->endpoints) {
+        const auto & dest = kv.second;
 
-    // NOTE(vooon): current router do not allow to speak drone-to-drone.
-    //              if it is needed perhaps better to add mavlink-router in front of mavros-router.
+        if (src->id == dest->id) {
+          continue;     // do not echo message
+        }
+        if (src->link_type == dest->link_type) {
+          continue;     // drop messages between same type FCU/GCS/UAS
+        }
 
-    bool has_target;
-    {
-      std::shared_lock<std::shared_mutex> lock(dest->remote_addrs_mutex);
-      has_target = dest->remote_addrs.find(target_addr) != dest->remote_addrs.end();
-    }
+        // NOTE(vooon): current router do not allow to speak drone-to-drone.
+        //              if needed, perhaps better to add mavlink-router in front of
+        //              mavros-router.
+        {
+          std::shared_lock<std::shared_mutex> ep_lock(dest->remote_addrs_mutex);
+          if (dest->remote_addrs.find(addr) != dest->remote_addrs.end()) {
+            targets.emplace_back(dest);
+          }
+        }
+      }
 
-    if (has_target) {
-      dest->send_message(msg, framing, src->id);
-      sent_cnt++;
-    }
-  }
 
-  // if message haven't been sent retry broadcast it
-  if (sent_cnt == 0 && retry_cnt < 2) {
+      return targets;
+    };
+
+  auto targets = collect_targets(target_addr);
+  if (targets.empty() && target_addr != 0) {
+    // if targeted message hasn't been sent, retry as broadcast
     target_addr = 0;
-    retry_cnt++;
-    goto retry;
+    targets = collect_targets(target_addr);
   }
+
+  for (const auto & dest : targets) {
+    dest->send_message(msg, framing, src->id);
+  }
+  const auto sent_cnt = targets.size();
 
   // update stats
   this->stat_msg_sent.fetch_add(sent_cnt);
@@ -106,7 +113,6 @@ void Router::add_endpoint(
   const mavros_msgs::srv::EndpointAdd::Request::SharedPtr request,
   mavros_msgs::srv::EndpointAdd::Response::SharedPtr response)
 {
-  unique_lock lock(mu);
   auto lg = get_logger();
 
   RCLCPP_INFO(
@@ -137,7 +143,10 @@ void Router::add_endpoint(
   ep->link_type = static_cast<Endpoint::Type>(request->type);
   ep->url = request->url;
 
-  this->endpoints[id] = ep;
+  {
+    unique_lock lock(mu);
+    this->endpoints[id] = ep;
+  }
   this->diagnostic_updater.add(ep->diag_name(), std::bind(&Endpoint::diag_run, ep, _1));
   RCLCPP_INFO(lg, "Endpoint link[%d] created", id);
 
@@ -157,17 +166,25 @@ void Router::del_endpoint(
   const mavros_msgs::srv::EndpointDel::Request::SharedPtr request,
   mavros_msgs::srv::EndpointDel::Response::SharedPtr response)
 {
-  unique_lock lock(mu);
   auto lg = get_logger();
+  Endpoint::SharedPtr endpoint_to_remove;
+  std::string endpoint_diag_name;
 
   if (request->id != 0) {
     RCLCPP_INFO(lg, "Requested to del endpoint id: %d", request->id);
-    auto it = this->endpoints.find(request->id);
-    if (it != this->endpoints.end() ) {
-      it->second->close();
-      this->diagnostic_updater.removeByName(it->second->diag_name());
-      this->endpoints.erase(it);
-      response->successful = true;
+    {
+      unique_lock lock(mu);
+      auto it = this->endpoints.find(request->id);
+      if (it != this->endpoints.end() ) {
+        endpoint_to_remove = it->second;
+        endpoint_diag_name = it->second->diag_name();
+        this->endpoints.erase(it);
+        response->successful = true;
+      }
+    }
+    if (endpoint_to_remove) {
+      endpoint_to_remove->close();
+      this->diagnostic_updater.removeByName(endpoint_diag_name);
     }
     return;
   }
@@ -175,16 +192,23 @@ void Router::del_endpoint(
   RCLCPP_INFO(
     lg, "Requested to del endpoint type: %d url: %s", request->type,
     request->url.c_str());
-  for (auto it = this->endpoints.cbegin(); it != this->endpoints.cend(); it++) {
-    if (it->second->url == request->url &&
-      it->second->link_type == static_cast<Endpoint::Type>( request->type))
-    {
-      it->second->close();
-      this->diagnostic_updater.removeByName(it->second->diag_name());
-      this->endpoints.erase(it);
-      response->successful = true;
-      return;
+  {
+    unique_lock lock(mu);
+    for (auto it = this->endpoints.cbegin(); it != this->endpoints.cend(); it++) {
+      if (it->second->url == request->url &&
+        it->second->link_type == static_cast<Endpoint::Type>(request->type))
+      {
+        endpoint_to_remove = it->second;
+        endpoint_diag_name = it->second->diag_name();
+        this->endpoints.erase(it);
+        response->successful = true;
+        break;
+      }
     }
+  }
+  if (endpoint_to_remove) {
+    endpoint_to_remove->close();
+    this->diagnostic_updater.removeByName(endpoint_diag_name);
   }
 }
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -415,6 +415,11 @@ bool MAVConnEndpoint::is_open()
 
 std::pair<bool, std::string> MAVConnEndpoint::open()
 {
+  auto nh = this->parent;
+  if (!nh) {
+    return {false, "parent not set"};
+  }
+
   try {
     auto weak_self = weak_from_this();
     this->link = mavconn::MAVConnInterface::open_url(
@@ -423,7 +428,9 @@ std::pair<bool, std::string> MAVConnEndpoint::open()
         if (auto self = weak_self.lock()) {
           self->recv_message(msg, framing);
         }
-      });
+      },
+      mavconn::MAVConnInterface::ClosedCb(),
+      nh->get_shared_io());
   } catch (mavconn::DeviceError & ex) {
     return {false, ex.what()};
   }

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -23,8 +23,8 @@
 using namespace mavros::router;  // NOLINT
 using rclcpp::QoS;
 
-using unique_lock = std::unique_lock<std::shared_timed_mutex>;
-using shared_lock = std::shared_lock<std::shared_timed_mutex>;
+using unique_lock = std::unique_lock<std::shared_mutex>;
+using shared_lock = std::shared_lock<std::shared_mutex>;
 
 std::atomic<id_t> Router::id_counter {1000};
 
@@ -147,7 +147,11 @@ void Router::add_endpoint(
     unique_lock lock(mu);
     this->endpoints[id] = ep;
   }
-  this->diagnostic_updater.add(ep->diag_name(), std::bind(&Endpoint::diag_run, ep, _1));
+  this->diagnostic_updater.add(
+    ep->diag_name(),
+    [ep](diagnostic_updater::DiagnosticStatusWrapper & stat) {
+      ep->diag_run(stat);
+    });
   RCLCPP_INFO(lg, "Endpoint link[%d] created", id);
 
   auto result = ep->open();
@@ -412,10 +416,14 @@ bool MAVConnEndpoint::is_open()
 std::pair<bool, std::string> MAVConnEndpoint::open()
 {
   try {
+    auto weak_self = weak_from_this();
     this->link = mavconn::MAVConnInterface::open_url(
-      this->url, 1, mavconn::MAV_COMP_ID_UDP_BRIDGE, std::bind(
-        &MAVConnEndpoint::recv_message,
-        shared_from_this(), _1, _2));
+      this->url, 1, mavconn::MAV_COMP_ID_UDP_BRIDGE,
+      [weak_self](const mavlink_message_t * msg, const Framing framing) {
+        if (auto self = weak_self.lock()) {
+          self->recv_message(msg, framing);
+        }
+      });
   } catch (mavconn::DeviceError & ex) {
     return {false, ex.what()};
   }
@@ -520,7 +528,9 @@ std::pair<bool, std::string> ROSEndpoint::open()
         "mavlink_source"), qos);
     this->sink = nh->create_subscription<mavros_msgs::msg::Mavlink>(
       utils::format("%s/%s", this->url.c_str(), "mavlink_sink"), qos,
-      std::bind(&ROSEndpoint::ros_recv_message, this, _1));
+      [this](const mavros_msgs::msg::Mavlink::SharedPtr rmsg) {
+        this->ros_recv_message(rmsg);
+      });
   } catch (rclcpp::exceptions::InvalidTopicNameError & ex) {
     return {false, ex.what()};
   }

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -224,6 +224,11 @@ public:
   {
     return router->stat_msg_dropped.load();
   }
+
+  void run_clear_stale_remote_addrs(Router::SharedPtr router)
+  {
+    router->periodic_clear_stale_remote_addrs();
+  }
 };
 
 TEST_F(TestRouter, set_parameter)
@@ -529,6 +534,37 @@ TEST_F(TestRouter, endpoint_recv_message)
   ASSERT_EQ(size_t(1), get_stat_msg_routed(router));
   ASSERT_EQ(size_t(0), get_stat_msg_sent(router));
   ASSERT_EQ(size_t(1), get_stat_msg_dropped(router));
+}
+
+TEST_F(TestRouter, clear_stale_remote_addrs_keeps_active_and_reaps_stale)
+{
+  auto router = this->create_node();
+  auto uas1 = getep(router, 1002);
+
+  // baseline from fixture
+  ASSERT_NE(uas1->remote_addrs.end(), uas1->remote_addrs.find(0x0000));
+  ASSERT_NE(uas1->remote_addrs.end(), uas1->remote_addrs.find(0x0100));
+  ASSERT_NE(uas1->remote_addrs.end(), uas1->remote_addrs.find(0x01BF));
+
+  // add one stale-only remote address
+  uas1->remote_addrs.emplace(0x1234);
+
+  // pass #1 only primes stale set from current remotes
+  run_clear_stale_remote_addrs(router);
+  ASSERT_NE(uas1->remote_addrs.end(), uas1->remote_addrs.find(0x1234));
+  ASSERT_NE(uas1->stale_addrs.end(), uas1->stale_addrs.find(0x1234));
+
+  // emulate activity on one address between timer passes
+  auto hb = make_heartbeat();
+  auto hbmsg = convert_message(hb, 0x01BF);
+  uas1->Endpoint::recv_message(&hbmsg, Framing::ok);
+  ASSERT_EQ(uas1->stale_addrs.end(), uas1->stale_addrs.find(0x01BF));
+
+  // pass #2 removes untouched stale-only address but keeps active one
+  run_clear_stale_remote_addrs(router);
+
+  ASSERT_EQ(uas1->remote_addrs.end(), uas1->remote_addrs.find(0x1234));
+  ASSERT_NE(uas1->remote_addrs.end(), uas1->remote_addrs.find(0x01BF));
 }
 
 TEST_F(TestRouter, route_stress_multithreaded_broadcast)

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -14,8 +14,11 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <atomic>
+#include <cstdlib>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <set>
 #include <unordered_map>
@@ -63,6 +66,36 @@ public:
     recv_message, void(const mavlink_message_t * msg,
     const Framing framing));
   MOCK_METHOD1(diag_run, void(diagnostic_updater::DiagnosticStatusWrapper &));
+};
+
+class StressEndpoint : public Endpoint
+{
+public:
+  using SharedPtr = std::shared_ptr<StressEndpoint>;
+
+  std::atomic<size_t> send_count {0};
+
+  bool is_open() override
+  {
+    return true;
+  }
+
+  std::pair<bool, std::string> open() override
+  {
+    return {true, ""};
+  }
+
+  void close() override {}
+
+  void send_message(
+    const mavlink_message_t * msg [[maybe_unused]],
+    const Framing framing [[maybe_unused]],
+    id_t src_id [[maybe_unused]]) override
+  {
+    send_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat [[maybe_unused]]) override {}
 };
 
 namespace mavros
@@ -432,6 +465,73 @@ TEST_F(TestRouter, endpoint_recv_message)
   ASSERT_EQ(size_t(1), get_stat_msg_routed(router));
   ASSERT_EQ(size_t(0), get_stat_msg_sent(router));
   ASSERT_EQ(size_t(1), get_stat_msg_dropped(router));
+}
+
+TEST_F(TestRouter, route_stress_multithreaded_broadcast)
+{
+  if (const char * skip = std::getenv("MAVROS_SKIP_STRESS_TESTS");
+    skip && std::string(skip) == "1")
+  {
+    GTEST_SKIP() << "skipped by MAVROS_SKIP_STRESS_TESTS=1";
+  }
+
+  auto router = create_node_no_endpoints();
+
+  auto make_ep = [router](id_t id, LT type) {
+      auto ep = std::make_shared<StressEndpoint>();
+      ep->parent = router;
+      ep->id = id;
+      ep->link_type = type;
+      ep->remote_addrs = {0x0000};
+      return ep;
+    };
+
+  auto & endpoints = get_endpoints(router);
+
+  auto src = make_ep(1000, LT::fcu);
+  auto dst1 = make_ep(1001, LT::gcs);
+  auto dst2 = make_ep(1002, LT::gcs);
+  auto dst3 = make_ep(1003, LT::uas);
+  auto dst4 = make_ep(1004, LT::uas);
+  endpoints[src->id] = src;
+  endpoints[dst1->id] = dst1;
+  endpoints[dst2->id] = dst2;
+  endpoints[dst3->id] = dst3;
+  endpoints[dst4->id] = dst4;
+
+  auto hb = make_heartbeat();
+  auto hbmsg = convert_message(hb, 0x0101);
+  constexpr auto fr = Framing::ok;
+
+  constexpr size_t thread_count = 8;
+  constexpr size_t iterations_per_thread = 2000;
+  const auto expected_routed = thread_count * iterations_per_thread;
+  const auto expected_sent_per_endpoint = expected_routed;
+  const auto expected_sent_total = expected_routed * 4;
+
+  std::vector<std::thread> workers;
+  workers.reserve(thread_count);
+
+  for (size_t i = 0; i < thread_count; i++) {
+    workers.emplace_back([&]() {
+      for (size_t n = 0; n < iterations_per_thread; n++) {
+        router->route_message(src, &hbmsg, fr);
+      }
+    });
+  }
+
+  for (auto & w : workers) {
+    w.join();
+  }
+
+  EXPECT_EQ(get_stat_msg_routed(router), expected_routed);
+  EXPECT_EQ(get_stat_msg_sent(router), expected_sent_total);
+  EXPECT_EQ(get_stat_msg_dropped(router), 0U);
+
+  EXPECT_EQ(dst1->send_count.load(), expected_sent_per_endpoint);
+  EXPECT_EQ(dst2->send_count.load(), expected_sent_per_endpoint);
+  EXPECT_EQ(dst3->send_count.load(), expected_sent_per_endpoint);
+  EXPECT_EQ(dst4->send_count.load(), expected_sent_per_endpoint);
 }
 
 #if 0  // TODO(vooon):

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -430,6 +430,70 @@ TEST_F(TestRouter, route_targeted_system_component)
   VERIFY_EPS();
 }
 
+TEST_F(TestRouter, route_targeted_miss_falls_back_to_broadcast)
+{
+  using MF = mavlink::common::MAV_MODE_FLAG;
+  using utils::enum_value;
+
+  auto router = this->create_node();
+
+  auto set_mode = mavlink::common::msg::SET_MODE();
+  set_mode.target_system = 0x42;  // unknown target in test topology
+  set_mode.base_mode = enum_value(MF::SAFETY_ARMED) | enum_value(MF::TEST_ENABLED);
+  set_mode.custom_mode = 7;
+
+  auto smmsg = convert_message(set_mode, 0x0101);
+  auto fr = Framing::ok;
+
+  DEFINE_EPS();
+
+  EXPECT_CALL(*fcu1, send_message(_, fr, _)).Times(0);
+  EXPECT_CALL(*fcu2, send_message(_, fr, _)).Times(0);
+  EXPECT_CALL(*uas1, send_message(_, fr, _)).Times(1);
+  EXPECT_CALL(*uas2, send_message(_, fr, _)).Times(1);
+  EXPECT_CALL(*gcs1, send_message(_, fr, _)).Times(1);
+  EXPECT_CALL(*gcs2, send_message(_, fr, _)).Times(1);
+
+  router->route_message(fcu1, &smmsg, fr);
+
+  VERIFY_EPS();
+}
+
+TEST_F(TestRouter, route_drops_when_only_same_link_type_exists)
+{
+  auto router = this->create_node_no_endpoints();
+  auto & endpoints = get_endpoints(router);
+
+  auto make_ep = [router](id_t id, const std::string & url) {
+      auto ep = std::make_shared<MockEndpoint>();
+      ep->parent = router;
+      ep->id = id;
+      ep->link_type = LT::fcu;
+      ep->url = url;
+      ep->remote_addrs = {0x0000, 0x0100, 0x0101};
+      testing::Mock::AllowLeak(&(*ep));
+      return ep;
+    };
+
+  auto fcu1 = make_ep(1000, "mock://fcu1");
+  auto fcu2 = make_ep(1001, "mock://fcu2");
+  endpoints[fcu1->id] = fcu1;
+  endpoints[fcu2->id] = fcu2;
+
+  auto hb = make_heartbeat();
+  auto hbmsg = convert_message(hb, 0x0101);
+  auto fr = Framing::ok;
+
+  EXPECT_CALL(*fcu1, send_message(_, fr, _)).Times(0);
+  EXPECT_CALL(*fcu2, send_message(_, fr, _)).Times(0);
+
+  router->route_message(fcu1, &hbmsg, fr);
+
+  EXPECT_EQ(size_t(1), get_stat_msg_routed(router));
+  EXPECT_EQ(size_t(0), get_stat_msg_sent(router));
+  EXPECT_EQ(size_t(1), get_stat_msg_dropped(router));
+}
+
 TEST_F(TestRouter, endpoint_recv_message)
 {
   auto router = create_node_no_endpoints();

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -114,6 +114,15 @@ public:
 
   ~TestRouter()
   {
+    // Break the Endpoint <-> Router reference cycle (router->endpoints holds
+    // endpoints, and each endpoint->parent holds the router), otherwise the
+    // Router node (a DDS participant) is leaked and never destroyed. Leaked
+    // participants from concurrent test processes crash FastDDS discovery.
+    for (auto & router : routers_) {
+      router->endpoints.clear();
+    }
+    routers_.clear();
+
     // NOTE(vooon): required to remove any remaining Nodes
     // std::cout << "kill" << std::endl;
     rclcpp::shutdown();
@@ -123,6 +132,7 @@ public:
   {
     auto router = std::make_shared<Router>("test_mavros_router");
     router->startup_delay_timer->cancel();
+    routers_.push_back(router);
 
     auto make_and_add_mock_endpoint =
       [router](id_t id, const std::string & url, LT type,
@@ -157,6 +167,7 @@ public:
   {
     auto router = std::make_shared<Router>("test_mavros_router");
     router->startup_delay_timer->cancel();
+    routers_.push_back(router);
 
     // Call this manually
     router->param_init_once();
@@ -174,6 +185,10 @@ public:
   {
     return router->endpoints;
   }
+
+  // Routers created via create_node()/create_node_no_endpoints() this test, so
+  // the fixture can break their Endpoint<->Router cycles before shutdown.
+  std::vector<Router::SharedPtr> routers_;
 
   mavlink_message_t convert_message(const mavlink::Message & msg, const addr_t source = 0x0101)
   {

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -614,9 +614,9 @@ TEST_F(TestRouter, route_stress_multithreaded_broadcast)
 
   for (size_t i = 0; i < thread_count; i++) {
     workers.emplace_back([&]() {
-      for (size_t n = 0; n < iterations_per_thread; n++) {
-        router->route_message(src, &hbmsg, fr);
-      }
+        for (size_t n = 0; n < iterations_per_thread; n++) {
+          router->route_message(src, &hbmsg, fr);
+        }
     });
   }
 


### PR DESCRIPTION
## Summary

Refactors router internals for lower lock contention and better runtime efficiency, and switches MAVConn endpoints to a shared ASIO `io_service`.

## Changes

- Reduced lock hold time in router message path:
  - no send operations under router map lock
  - removed `goto`-style retry flow in routing logic
- Reduced lock hold time in endpoint management:
  - `add_endpoint()`/`del_endpoint()` avoid open/close work under router lock
- C++20 cleanup in router:
  - replaced `std::bind` callbacks with lambdas
  - switched `std::shared_timed_mutex` -> `std::shared_mutex`
- Shared IO integration:
  - router now owns a shared `mavconn::IoContextRunner`
  - all `MAVConnEndpoint` instances use router shared `io_service`
  - clean shared IO shutdown in `Router` destructor

## Validation

- Built `mavros` from `/ws`
- Ran `mavros-router-test`
- Passed