### PR TITLE
imu: fix missing hPa to Pa conversion in HIGHRES_IMU handler

### DIFF
--- a/mavros/src/plugins/imu.cpp
+++ b/mavros/src/plugins/imu.cpp
@@ -464,7 +464,7 @@ private:
       auto static_pressure_msg = sensor_msgs::msg::FluidPressure();
 
       static_pressure_msg.header = header;
-      static_pressure_msg.fluid_pressure = imu_hr.abs_pressure;
+      static_pressure_msg.fluid_pressure = imu_hr.abs_pressure * MILLIBAR_TO_PASCAL;
 
       static_press_pub->publish(static_pressure_msg);
     }
@@ -478,7 +478,7 @@ private:
       auto differential_pressure_msg = sensor_msgs::msg::FluidPressure();
 
       differential_pressure_msg.header = header;
-      differential_pressure_msg.fluid_pressure = imu_hr.diff_pressure;
+      differential_pressure_msg.fluid_pressure = imu_hr.diff_pressure * MILLIBAR_TO_PASCAL;
 
       diff_press_pub->publish(differential_pressure_msg);
     }
@@ -621,12 +621,12 @@ private:
 
     auto static_pressure_msg = sensor_msgs::msg::FluidPressure();
     static_pressure_msg.header = header;
-    static_pressure_msg.fluid_pressure = press.press_abs * 100.0;
+    static_pressure_msg.fluid_pressure = press.press_abs * MILLIBAR_TO_PASCAL;
     static_press_pub->publish(static_pressure_msg);
 
     auto differential_pressure_msg = sensor_msgs::msg::FluidPressure();
     differential_pressure_msg.header = header;
-    differential_pressure_msg.fluid_pressure = press.press_diff * 100.0;
+    differential_pressure_msg.fluid_pressure = press.press_diff * MILLIBAR_TO_PASCAL;
     diff_press_pub->publish(differential_pressure_msg);
   }
 


### PR DESCRIPTION
abs_pressure and diff_pressure in HIGHRES_IMU messages are in hPa, but sensor_msgs/FluidPressure.fluid_pressure is in Pascals. MILLIBAR_TO_PASCAL  was already defined but not applied, resulting in pressure values 100 times too small.

Also adjusted the handle_scaled_pressure to use MILLIBAR_TO_PASCAL for consistency instead of 100 magic number.