### PR TITLE
fix: Out-of-Bounds Write and Divide-by-Zero Bugs Found in...

### DIFF
--- a/mavros_extras/src/plugins/mag_calibration_status.cpp
+++ b/mavros_extras/src/plugins/mag_calibration_status.cpp
@@ -74,7 +74,7 @@ private:
     // How many compasses are we calibrating?
     std::bitset<8> compass_calibrating = mp.cal_mask;
 
-    if (compass_calibrating[mp.compass_id]) {
+    if (mp.compass_id < calibration_show.size() && compass_calibrating[mp.compass_id]) {
       // Each compass gets a portion of the overall progress
       if (mp.completion_pct < 95) {
         calibration_show[mp.compass_id] = true;
@@ -90,7 +90,7 @@ private:
       }
     }
 
-    mcs.data = total_percentage / compass_calibrating.count();
+    mcs.data = compass_calibrating.any() ? total_percentage / compass_calibrating.count() : 0;
 
     mcs_pub->publish(mcs);
   }


### PR DESCRIPTION
## Summary
Closes #2115
This PR fixes two bugs in the MAG_CAL_PROGRESS handler: an out-of-bounds write when accessing `calibration_show` with an unchecked `compass_id`, and a divide-by-zero when no compasses are being calibrated.

## Changes
- Added bounds check `mp.compass_id < calibration_show.size()` before accessing `calibration_show[mp.compass_id]` to prevent out-of-bounds write
- Added ternary check `compass_calibrating.any()` to prevent division by zero when `compass_calibrating.count()` is 0user
Write a concise, professional GitHub PR description for this fix.

Issue #2115: [REPORT] Out-of-Bounds Write and Divide-by-Zero Bugs Found in mavros_extras/src/plugins/mag_calibration_status.cpp (MAG_CAL_PROGRESS Handler)

Patch:
```diff
diff --git a/mavros_extras/src/plugins/mag_calibration_status.cpp b/mavros_extras/src/plugins/mag_calibration_status.cpp
index 8f12fda..ebedd72 100644
--- a/mavros_extras/src/plugins/mag_calibration_status.cpp
+++ b/mavros_extras/src/plugins/mag_calibration_status.cpp
@@ -74,7 +74,7 @@ private:
     // How many compasses are we calibrating?
     std::bitset<8> compass_calibrating = mp.cal_mask;
 
-    if (compass_calibrating[mp.compass_id]) {
+    if (mp.compass_id < calibration_show.size() && compass_calibrating[mp.compass_id]) {
       // Each compass gets a portion of the overall progress
       if (mp.completion_pct < 95) {
         calibration_show[mp.compass_id] = true;
@@ -90,7 +90,7 @@ private:
-    mcs.data = total_percentage / compass_calibrating.count();
+    mcs.data = compass_calibrating.any() ? total_percentage / compass_calibrating.count() : 0;
 
     mcs_pub->publish(mcs);
   }

```

Format:
## Summary
Closes #2115
[1-2 sentence explanation of what was wrong and what this fixes]

## Changes
[bullet list of specific changes]

Keep it short, factual, no fluff. Do NOT include "Testing" section unless the patch modifies tests.