### PR TITLE
Fix mavros_router segfault with mutex on remote_addrs

### DIFF
--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -95,12 +95,12 @@ public:
 
   std::shared_ptr<Router> parent;
 
-  uint32_t id;                         // id of the endpoint
-  Type link_type;                      // class of the endpoint
-  std::string url;                     // url to open that endpoint
-  std::mutex remote_addrs_mutex;       // guards remote_addrs and stale_addrs
-  std::set<addr_t> remote_addrs;       // remotes that we heard there
-  std::set<addr_t> stale_addrs;        // temporary storage for stale remote addrs
+  uint32_t id;                           // id of the endpoint
+  Type link_type;                        // class of the endpoint
+  std::string url;                       // url to open that endpoint
+  std::shared_mutex remote_addrs_mutex;  // guards remote_addrs and stale_addrs
+  std::set<addr_t> remote_addrs;         // remotes that we heard there
+  std::set<addr_t> stale_addrs;          // temporary storage for stale remote addrs
 
   virtual bool is_open() = 0;
   virtual std::pair<bool, std::string> open() = 0;

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <shared_mutex>     // NOLINT
@@ -97,6 +98,7 @@ public:
   uint32_t id;                         // id of the endpoint
   Type link_type;                      // class of the endpoint
   std::string url;                     // url to open that endpoint
+  std::mutex remote_addrs_mutex;       // guards remote_addrs and stale_addrs
   std::set<addr_t> remote_addrs;       // remotes that we heard there
   std::set<addr_t> stale_addrs;        // temporary storage for stale remote addrs
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -67,7 +67,11 @@ retry:
     // NOTE(vooon): current router do not allow to speak drone-to-drone.
     //              if it is needed perhaps better to add mavlink-router in front of mavros-router.
 
-    bool has_target = dest->remote_addrs.find(target_addr) != dest->remote_addrs.end();
+    bool has_target;
+    {
+      std::lock_guard<std::mutex> lock(dest->remote_addrs_mutex);
+      has_target = dest->remote_addrs.find(target_addr) != dest->remote_addrs.end();
+    }
 
     if (has_target) {
       dest->send_message(msg, framing, src->id);
@@ -274,6 +278,8 @@ void Router::periodic_reconnect_endpoints()
   for (auto & kv : this->endpoints) {
     auto & p = kv.second;
 
+    std::lock_guard<std::mutex> endpoint_lock(p->remote_addrs_mutex);
+
     if (p->is_open()) {
       continue;
     }
@@ -342,16 +348,22 @@ void Endpoint::recv_message(const mavlink_message_t * msg, const Framing framing
   const addr_t sysid_addr = msg->sysid << 8;
   const addr_t sysid_compid_addr = (msg->sysid << 8) | msg->compid;
 
-  // save source addr to remote_addrs
-  auto sp = this->remote_addrs.emplace(sysid_addr);
-  auto scp = this->remote_addrs.emplace(sysid_compid_addr);
+  bool new_sysid_addr;
+  bool new_sysid_compid_addr;
+  {
+    std::lock_guard<std::mutex> lock(this->remote_addrs_mutex);
 
-  // and delete it from stale_addrs
-  this->stale_addrs.erase(sysid_addr);
-  this->stale_addrs.erase(sysid_compid_addr);
+    // save source addr to remote_addrs
+    new_sysid_addr = this->remote_addrs.emplace(sysid_addr).second;
+    new_sysid_compid_addr = this->remote_addrs.emplace(sysid_compid_addr).second;
+
+    // and delete it from stale_addrs
+    this->stale_addrs.erase(sysid_addr);
+    this->stale_addrs.erase(sysid_compid_addr);
+  }
 
   auto & nh = this->parent;
-  if (sp.second || scp.second) {
+  if (new_sysid_addr || new_sysid_compid_addr) {
     RCLCPP_INFO(
       nh->get_logger(), "link[%d] detected remote address %d.%d", this->id, msg->sysid,
       msg->compid);
@@ -439,9 +451,16 @@ void MAVConnEndpoint::diag_run(diagnostic_updater::DiagnosticStatusWrapper & sta
   stat.addf("Rx speed", "%f", iostat.rx_speed);
   stat.addf("Tx speed", "%f", iostat.tx_speed);
 
-  stat.addf("Remotes count", "%zu", this->remote_addrs.size());
+  std::set<addr_t> remote_addrs_copy;
+  {
+    std::lock_guard<std::mutex> lock(this->remote_addrs_mutex);
+    remote_addrs_copy = this->remote_addrs;
+  }
+
+  stat.addf("Remotes count", "%zu", remote_addrs_copy.size());
+
   size_t idx = 0;
-  for (auto addr : this->remote_addrs) {
+  for (auto addr : remote_addrs_copy) {
     stat.addf(utils::format("Remote [%d]", idx++), "%d.%d", addr >> 8, addr & 0xff);
   }
 
@@ -534,9 +553,16 @@ void ROSEndpoint::diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   // TODO(vooon): make some diagnostics
 
-  stat.addf("Remotes count", "%zu", this->remote_addrs.size());
+  std::set<addr_t> remote_addrs_copy;
+  {
+    std::lock_guard<std::mutex> lock(this->remote_addrs_mutex);
+    remote_addrs_copy = this->remote_addrs;
+  }
+
+  stat.addf("Remotes count", "%zu", remote_addrs_copy.size());
+
   size_t idx = 0;
-  for (auto addr : this->remote_addrs) {
+  for (auto addr : remote_addrs_copy) {
     stat.addf(utils::format("Remote [%d]", idx++), "%d.%d", addr >> 8, addr & 0xff);
   }
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -303,6 +303,7 @@ void Router::periodic_clear_stale_remote_addrs()
   RCLCPP_DEBUG(lg, "clear stale remotes");
   for (auto & kv : this->endpoints) {
     auto & p = kv.second;
+    std::lock_guard<std::mutex> endpoint_lock(p->remote_addrs_mutex);
 
     // Step 1: remove any stale addrs that still there
     //         (hadn't been removed by Endpoint::recv_message())

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -69,7 +69,7 @@ retry:
 
     bool has_target;
     {
-      std::lock_guard<std::mutex> lock(dest->remote_addrs_mutex);
+      std::shared_lock<std::shared_mutex> lock(dest->remote_addrs_mutex);
       has_target = dest->remote_addrs.find(target_addr) != dest->remote_addrs.end();
     }
 
@@ -278,8 +278,6 @@ void Router::periodic_reconnect_endpoints()
   for (auto & kv : this->endpoints) {
     auto & p = kv.second;
 
-    std::lock_guard<std::mutex> endpoint_lock(p->remote_addrs_mutex);
-
     if (p->is_open()) {
       continue;
     }
@@ -303,7 +301,7 @@ void Router::periodic_clear_stale_remote_addrs()
   RCLCPP_DEBUG(lg, "clear stale remotes");
   for (auto & kv : this->endpoints) {
     auto & p = kv.second;
-    std::lock_guard<std::mutex> endpoint_lock(p->remote_addrs_mutex);
+    std::unique_lock<std::shared_mutex> endpoint_lock(p->remote_addrs_mutex);
 
     // Step 1: remove any stale addrs that still there
     //         (hadn't been removed by Endpoint::recv_message())
@@ -352,7 +350,7 @@ void Endpoint::recv_message(const mavlink_message_t * msg, const Framing framing
   bool new_sysid_addr;
   bool new_sysid_compid_addr;
   {
-    std::lock_guard<std::mutex> lock(this->remote_addrs_mutex);
+    std::unique_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
 
     // save source addr to remote_addrs
     new_sysid_addr = this->remote_addrs.emplace(sysid_addr).second;
@@ -454,7 +452,7 @@ void MAVConnEndpoint::diag_run(diagnostic_updater::DiagnosticStatusWrapper & sta
 
   std::set<addr_t> remote_addrs_copy;
   {
-    std::lock_guard<std::mutex> lock(this->remote_addrs_mutex);
+    std::unique_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
     remote_addrs_copy = this->remote_addrs;
   }
 
@@ -556,7 +554,7 @@ void ROSEndpoint::diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   std::set<addr_t> remote_addrs_copy;
   {
-    std::lock_guard<std::mutex> lock(this->remote_addrs_mutex);
+    std::unique_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
     remote_addrs_copy = this->remote_addrs;
   }
 

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -452,7 +452,7 @@ void MAVConnEndpoint::diag_run(diagnostic_updater::DiagnosticStatusWrapper & sta
 
   std::set<addr_t> remote_addrs_copy;
   {
-    std::unique_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
+    std::shared_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
     remote_addrs_copy = this->remote_addrs;
   }
 
@@ -554,7 +554,7 @@ void ROSEndpoint::diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
   std::set<addr_t> remote_addrs_copy;
   {
-    std::unique_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
+    std::shared_lock<std::shared_mutex> lock(this->remote_addrs_mutex);
     remote_addrs_copy = this->remote_addrs;
   }
 


### PR DESCRIPTION
In the mavros_router, I've encountered a segmentation fault because `this->remote_addrs` is accessed by two threads concurrently without lock mechanism. 

**Solution**: protect concurrent calls with a mutex: `remote_addrs_mutex`. 

To reproduce the segfault: change the frequency of the timer below from 60s to 1ms 

`      this->create_wall_timer(60s, std::bind(&Router::periodic_clear_stale_remote_addrs, this));
`