### PR TITLE
UAS class, stop thread executor before plugin and subscriptions begin tearing down

### DIFF
--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -260,7 +260,7 @@ public:
     const std::string & uas_url_ = "/uas1", uint8_t target_system_ = 1,
     uint8_t target_component_ = 1);
 
-  ~UAS() = default;
+  ~UAS() override;
 
   /**
    * @brief Mavros diagnostic updater

--- a/mavros/include/mavros/mavros_uas.hpp
+++ b/mavros/include/mavros/mavros_uas.hpp
@@ -621,9 +621,9 @@ private:
 
   // XXX(vooon): we have to use own executor because Node::create_sub_node() doesn't work for us.
   using thread_ptr = std::unique_ptr<std::thread, std::function<void (std::thread *)>>;
-  thread_ptr exec_spin_thd;
   // rclcpp::executors::MultiThreadedExecutor exec;
   UASExecutor exec;
+  thread_ptr exec_spin_thd;
 
   // plugins
   pluginlib::ClassLoader<plugin::PluginFactory> plugin_factory_loader;

--- a/mavros/src/lib/mavros_uas.cpp
+++ b/mavros/src/lib/mavros_uas.cpp
@@ -181,6 +181,12 @@ UAS::UAS(
     });
 }
 
+UAS::~UAS()
+{
+  // Stop the executor before plugin nodes and subscriptions begin tearing down.
+  exec_spin_thd.reset();
+}
+
 void UAS::plugin_route(const mavlink_message_t * mmsg, const Framing framing)
 {
   auto it = plugin_subscriptions.find(mmsg->msgid);

--- a/mavros/src/lib/mavros_uas.cpp
+++ b/mavros/src/lib/mavros_uas.cpp
@@ -117,7 +117,9 @@ UAS::UAS(
           }),
         [this](std::thread * t) {
           this->exec.cancel();
-          t->join();
+          if (t->joinable()) {
+            t->join();
+          }
           delete t;
         });
 


### PR DESCRIPTION
`exec_spin_thd` deleter calls `exec.cancel() ` but `exec_spin_thd` is declared before `exec` in `mavros_uas.hpp`. Since the destructor is called in the reverse order in which they appear in the class declaration (https://learn.microsoft.com/en-us/cpp/cpp/destructors-cpp?view=msvc-170), `exec` is destroyed first, then the deleter runs, and calls `exec.cancel()`. 

Solution: call `exec_spin_thd.reset();` in the destructor of `UAS` (and change the order in the hpp) 