### PR TITLE
Protect against access to empty param list

### DIFF
--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -637,7 +637,10 @@ private:
 
       // trying to avoid endless rerequest loop
       // Issue #276
-      bool it_is_first_requested = parameters_missing_idx.front() == pmsg.param_index;
+      bool it_is_first_requested = false;
+      if (!parameters_missing_idx.empty()) {
+          it_is_first_requested = (parameters_missing_idx.front() == pmsg.param_index);
+      }
 
       // remove idx for that message
       parameters_missing_idx.remove(pmsg.param_index);


### PR DESCRIPTION
Issue: the `std::list<uint16_t> parameters_missing_idx;` can be cleared `parameters_missing_idx.clear();` and once cleared we can call `parameters_missing_idx.front()` without  `param_count != UINT16_MAX` protection. 

**`std::list::front`**
- _Calling this function on an [empty](https://cplusplus.com/list::empty) container causes undefined behavior._ https://cplusplus.com/reference/list/list/front/

Solution: add a check on list empty before .front() call: `if (!parameters_missing_idx.empty()) {`