### PR TITLE
fix: std::future_error in command.cpp when the set_value() promise called twice

### DIFF
--- a/mavros/src/plugins/command.cpp
+++ b/mavros/src/plugins/command.cpp
@@ -193,7 +193,13 @@ private:
 
     for (auto & tr : ack_waiting_list) {
       if (tr.expected_command == ack.command) {
-        tr.promise.set_value(ack.result);
+        try {
+          tr.promise.set_value(ack.result);
+        } catch (const std::future_error & e) {
+          if (e.code() == std::future_errc::promise_already_satisfied) {
+            RCLCPP_ERROR(get_logger(), "CMD: ACK for command %u already processed", ack.command);
+          }
+        }
         return;
       }
     }


### PR DESCRIPTION
A small fix and workaround when the promise.set_value() in handle_command_ack is called twice. The proposed method is already tested on my system and with colcon test.  MAVROS can continue the execution of the plugin. 