### PR TITLE
Bugfix: Update fake_gps.cpp to use libraries in tf2_eigen

### DIFF
--- a/mavros_extras/src/plugins/fake_gps.cpp
+++ b/mavros_extras/src/plugins/fake_gps.cpp
@@ -403,7 +403,7 @@ private:
   /* -*- callbacks -*- */
   void mocap_tf_cb(const geometry_msgs::msg::TransformStamped::SharedPtr trans)
   {
-    Eigen::Affine3d pos_enu; tf2::fromMsg(trans->transform, pos_enu);
+    Eigen::Affine3d pos_enu = tf2::transformToEigen(trans->transform);
 
     send_fake_gps(
       trans->header.stamp,
@@ -441,7 +441,7 @@ private:
 
   void transform_cb(const geometry_msgs::msg::TransformStamped & trans)
   {
-    Eigen::Affine3d pos_enu; tf2::fromMsg(trans.transform, pos_enu);
+    Eigen::Affine3d pos_enu = tf2::transformToEigen(trans.transform);
 
     send_fake_gps(
       trans.header.stamp,


### PR DESCRIPTION
Without this plugins will fail to load with an undefined symbol: Something like:
```
load exception: Failed to load library /tmp/mavros/install/mavros_extras/lib/libmavros_extras_plugins.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library dlopen error: /tmp/mavros/install/mavros_extras/lib/libmavros_extras_plugins.so: undefined symbol: _ZN3tf27fromMsgIN13geometry_msgs3msg10Transform_ISaIvEEEN5Eigen9TransformIdLi3ELi2ELi0EEEEEvRKT_RT0_
```

I am using ROS2 Jazzy on Ubuntu 24.04