### PR TITLE
fix: use dedicated callback group for blocking services

### DIFF
--- a/mavros/include/mavros/mission_protocol_base.hpp
+++ b/mavros/include/mavros/mission_protocol_base.hpp
@@ -297,6 +297,7 @@ public:
     WP_TIMEOUT(1s),
     RESCHEDULE_TIME(5s)
   {
+    srv_cg = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     timeout_timer = node->create_wall_timer(WP_TIMEOUT, std::bind(&MissionBase::timeout_cb, this));
     timeout_timer->cancel();
   }
@@ -361,6 +362,7 @@ protected:
   std::condition_variable list_receiving;
   std::condition_variable list_sending;
 
+  rclcpp::CallbackGroup::SharedPtr srv_cg;
   rclcpp::TimerBase::SharedPtr timeout_timer;
   rclcpp::TimerBase::SharedPtr schedule_timer;
 

--- a/mavros/src/plugins/geofence.cpp
+++ b/mavros/src/plugins/geofence.cpp
@@ -51,18 +51,27 @@ public:
 
     gf_list_pub = node->create_publisher<mavros_msgs::msg::WaypointList>("~/fences", gf_qos);
 
+#ifdef USE_OLD_RMW_QOS
+    auto services_qos = rmw_qos_profile_services_default;
+#else
+    auto services_qos = rclcpp::ServicesQoS();
+#endif
+
     pull_srv =
       node->create_service<mavros_msgs::srv::WaypointPull>(
       "~/pull",
-      std::bind(&GeofencePlugin::pull_cb, this, _1, _2));
+      std::bind(&GeofencePlugin::pull_cb, this, _1, _2),
+      services_qos, srv_cg);
     push_srv =
       node->create_service<mavros_msgs::srv::WaypointPush>(
       "~/push",
-      std::bind(&GeofencePlugin::push_cb, this, _1, _2));
+      std::bind(&GeofencePlugin::push_cb, this, _1, _2),
+      services_qos, srv_cg);
     clear_srv =
       node->create_service<mavros_msgs::srv::WaypointClear>(
       "~/clear",
-      std::bind(&GeofencePlugin::clear_cb, this, _1, _2));
+      std::bind(&GeofencePlugin::clear_cb, this, _1, _2),
+      services_qos, srv_cg);
 
     enable_connection_cb();
     enable_capabilities_cb();

--- a/mavros/src/plugins/param.cpp
+++ b/mavros/src/plugins/param.cpp
@@ -443,36 +443,38 @@ public:
       PSN::events,
       event_qos);
 
+    srv_cg = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
     // Custom parameter services
     pull_srv =
       node->create_service<mavros_msgs::srv::ParamPull>(
       "~/pull",
-      std::bind(&ParamPlugin::pull_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::pull_cb, this, _1, _2), qos, srv_cg);
     set_srv =
       node->create_service<mavros_msgs::srv::ParamSetV2>(
       "~/set",
-      std::bind(&ParamPlugin::set_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::set_cb, this, _1, _2), qos, srv_cg);
 
     // Standard parameter services
     get_parameters_srv = node->create_service<rcl_interfaces::srv::GetParameters>(
       PSN::get_parameters,
-      std::bind(&ParamPlugin::get_parameters_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::get_parameters_cb, this, _1, _2), qos, srv_cg);
     get_parameter_types_srv = node->create_service<rcl_interfaces::srv::GetParameterTypes>(
       PSN::get_parameter_types,
-      std::bind(&ParamPlugin::get_parameter_types_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::get_parameter_types_cb, this, _1, _2), qos, srv_cg);
     set_parameters_srv = node->create_service<rcl_interfaces::srv::SetParameters>(
       PSN::set_parameters,
-      std::bind(&ParamPlugin::set_parameters_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::set_parameters_cb, this, _1, _2), qos, srv_cg);
     set_parameters_atomically_srv =
       node->create_service<rcl_interfaces::srv::SetParametersAtomically>(
       PSN::set_parameters_atomically,
-      std::bind(&ParamPlugin::set_parameters_atomically_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::set_parameters_atomically_cb, this, _1, _2), qos, srv_cg);
     describe_parameters_srv = node->create_service<rcl_interfaces::srv::DescribeParameters>(
       PSN::describe_parameters,
-      std::bind(&ParamPlugin::describe_parameters_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::describe_parameters_cb, this, _1, _2), qos, srv_cg);
     list_parameters_srv = node->create_service<rcl_interfaces::srv::ListParameters>(
       PSN::list_parameters,
-      std::bind(&ParamPlugin::list_parameters_cb, this, _1, _2), qos);
+      std::bind(&ParamPlugin::list_parameters_cb, this, _1, _2), qos, srv_cg);
 
     schedule_timer =
       node->create_wall_timer(BOOTUP_TIME, std::bind(&ParamPlugin::schedule_cb, this));
@@ -498,6 +500,7 @@ private:
 
   std::recursive_mutex mutex;
 
+  rclcpp::CallbackGroup::SharedPtr srv_cg;
   rclcpp::Service<mavros_msgs::srv::ParamPull>::SharedPtr pull_srv;
   // rclcpp::Service<mavros_msgs::srv::ParamPush>::SharedPtr push_srv;
   rclcpp::Service<mavros_msgs::srv::ParamSetV2>::SharedPtr set_srv;

--- a/mavros/src/plugins/rallypoint.cpp
+++ b/mavros/src/plugins/rallypoint.cpp
@@ -50,18 +50,27 @@ public:
 
     rp_list_pub = node->create_publisher<mavros_msgs::msg::WaypointList>("~/rallypoints", rp_qos);
 
+#ifdef USE_OLD_RMW_QOS
+    auto services_qos = rmw_qos_profile_services_default;
+#else
+    auto services_qos = rclcpp::ServicesQoS();
+#endif
+
     pull_srv =
       node->create_service<mavros_msgs::srv::WaypointPull>(
       "~/pull",
-      std::bind(&RallypointPlugin::pull_cb, this, _1, _2));
+      std::bind(&RallypointPlugin::pull_cb, this, _1, _2),
+      services_qos, srv_cg);
     push_srv =
       node->create_service<mavros_msgs::srv::WaypointPush>(
       "~/push",
-      std::bind(&RallypointPlugin::push_cb, this, _1, _2));
+      std::bind(&RallypointPlugin::push_cb, this, _1, _2),
+      services_qos, srv_cg);
     clear_srv =
       node->create_service<mavros_msgs::srv::WaypointClear>(
       "~/clear",
-      std::bind(&RallypointPlugin::clear_cb, this, _1, _2));
+      std::bind(&RallypointPlugin::clear_cb, this, _1, _2),
+      services_qos, srv_cg);
 
     enable_connection_cb();
     enable_capabilities_cb();

--- a/mavros/src/plugins/waypoint.cpp
+++ b/mavros/src/plugins/waypoint.cpp
@@ -80,21 +80,31 @@ public:
     wp_list_pub = node->create_publisher<mavros_msgs::msg::WaypointList>("~/waypoints", wp_qos);
     wp_reached_pub = node->create_publisher<mavros_msgs::msg::WaypointReached>("~/reached", wp_qos);
 
+#ifdef USE_OLD_RMW_QOS
+    auto services_qos = rmw_qos_profile_services_default;
+#else
+    auto services_qos = rclcpp::ServicesQoS();
+#endif
+
     pull_srv =
       node->create_service<mavros_msgs::srv::WaypointPull>(
       "~/pull",
-      std::bind(&WaypointPlugin::pull_cb, this, _1, _2));
+      std::bind(&WaypointPlugin::pull_cb, this, _1, _2),
+      services_qos, srv_cg);
     push_srv =
       node->create_service<mavros_msgs::srv::WaypointPush>(
       "~/push",
-      std::bind(&WaypointPlugin::push_cb, this, _1, _2));
+      std::bind(&WaypointPlugin::push_cb, this, _1, _2),
+      services_qos, srv_cg);
     clear_srv =
       node->create_service<mavros_msgs::srv::WaypointClear>(
       "~/clear",
-      std::bind(&WaypointPlugin::clear_cb, this, _1, _2));
+      std::bind(&WaypointPlugin::clear_cb, this, _1, _2),
+      services_qos, srv_cg);
     set_cur_srv = node->create_service<mavros_msgs::srv::WaypointSetCurrent>(
       "~/set_current", std::bind(
-        &WaypointPlugin::set_cur_cb, this, _1, _2));
+        &WaypointPlugin::set_cur_cb, this, _1, _2),
+      services_qos, srv_cg);
 
     enable_connection_cb();
     enable_capabilities_cb();


### PR DESCRIPTION
Fixes a bug where blocking services would prevent timeout callbacks from executing as they were all part of the same `MutuallyExclusiveCallbackGroup`. This change moves all services to a dedicated `srv_cg` callback group as was already done in `command` plugin.