### PR TITLE
libmavconn: refactored deprecated asio API

### DIFF
--- a/libmavconn/include/mavconn/interface.hpp
+++ b/libmavconn/include/mavconn/interface.hpp
@@ -286,7 +286,7 @@ public:
    * @param[in] url           resource locator
    * @param[in] system_id     optional system id
    * @param[in] component_id  optional component id
-   * @param[in] shared_io     optional external io_service. If provided, caller owns
+   * @param[in] shared_io     optional external io_context. If provided, caller owns
    *                          its execution/threading lifecycle.
    * @return @a Ptr to constructed interface class,
    *         or throw @a DeviceError if error occurred.
@@ -296,20 +296,20 @@ public:
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     const ReceivedCb & cb_handle_message = ReceivedCb(),
     const ClosedCb & cb_handle_closed_port = ClosedCb(),
-    asio::io_service * shared_io = nullptr
+    asio::io_context * shared_io = nullptr
   );
 
   /**
    * @brief version of open_url() which do not perform connect()
    *
-   * @param[in] shared_io optional external io_service. If provided, caller owns
+   * @param[in] shared_io optional external io_context. If provided, caller owns
    *                      its execution/threading lifecycle.
    */
   [[nodiscard]] static Ptr open_url_no_connect(
     std::string url,
     uint8_t system_id = 1,
     uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
-    asio::io_service * shared_io = nullptr);
+    asio::io_context * shared_io = nullptr);
 
   [[nodiscard]] static std::vector<std::string> get_known_dialects();
 

--- a/libmavconn/include/mavconn/io_context_runner.hpp
+++ b/libmavconn/include/mavconn/io_context_runner.hpp
@@ -22,20 +22,22 @@ namespace mavconn
 {
 
 /**
- * @brief Small utility to unify owned/shared io_service lifecycle handling.
+ * @brief Small utility to unify owned/shared io_context lifecycle handling.
  */
 class IoContextRunner
 {
 public:
-  explicit IoContextRunner(asio::io_service * shared_io = nullptr)
-  : io_owner_(shared_io ? nullptr : std::make_shared<asio::io_service>()),
+  explicit IoContextRunner(asio::io_context * shared_io = nullptr)
+  : io_owner_(shared_io ? nullptr : std::make_shared<asio::io_context>()),
     io_(shared_io ? *shared_io : *io_owner_),
-    io_work_(shared_io ? nullptr : std::make_unique<asio::io_service::work>(io_)),
+    io_work_(shared_io ? nullptr :
+      std::make_unique<asio::executor_work_guard<asio::io_context::executor_type>>(
+      asio::make_work_guard(io_))),
     owns_thread_(shared_io == nullptr),
     is_running_(false)
   {}
 
-  [[nodiscard]] asio::io_service & io()
+  [[nodiscard]] asio::io_context & io()
   {
     return io_;
   }
@@ -101,7 +103,7 @@ public:
       return;
     }
 
-    io_.reset();
+    io_.restart();
   }
 
   void shutdown_owned()
@@ -112,9 +114,9 @@ public:
   }
 
 private:
-  std::shared_ptr<asio::io_service> io_owner_;
-  asio::io_service & io_;
-  std::unique_ptr<asio::io_service::work> io_work_;
+  std::shared_ptr<asio::io_context> io_owner_;
+  asio::io_context & io_;
+  std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>> io_work_;
   bool owns_thread_;
   std::atomic<bool> is_running_;
   std::jthread io_thread_;

--- a/libmavconn/include/mavconn/serial.hpp
+++ b/libmavconn/include/mavconn/serial.hpp
@@ -47,13 +47,13 @@ public:
    *
    * @param[in] device    TTY device path
    * @param[in] baudrate  serial baudrate
-   * @param[in] shared_io optional external io_service. If provided, caller owns
+   * @param[in] shared_io optional external io_context. If provided, caller owns
    *                      its execution/threading lifecycle.
    */
   MAVConnSerial(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     std::string device = DEFAULT_DEVICE, unsigned baudrate = DEFAULT_BAUDRATE,
-    bool hwflow = false, asio::io_service * shared_io = nullptr);
+    bool hwflow = false, asio::io_context * shared_io = nullptr);
   virtual ~MAVConnSerial();
 
   void connect(
@@ -72,7 +72,7 @@ public:
 
 private:
   IoContextRunner io_runner;
-  asio::io_service & io_service;
+  asio::io_context & io_context;
   asio::serial_port serial_dev;
 
   std::atomic<bool> tx_in_progress;

--- a/libmavconn/include/mavconn/tcp.hpp
+++ b/libmavconn/include/mavconn/tcp.hpp
@@ -50,21 +50,21 @@ public:
    * Create generic TCP client (connect to the server)
    * @param[id] server_addr    remote host
    * @param[id] server_port    remote port
-   * @param[id] shared_io      optional external io_service. If provided, caller owns
+   * @param[id] shared_io      optional external io_context. If provided, caller owns
    *                           its execution/threading lifecycle.
    */
   MAVConnTCPClient(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     std::string server_host = DEFAULT_SERVER_HOST,
     uint16_t server_port = DEFAULT_SERVER_PORT,
-    asio::io_service * shared_io = nullptr);
+    asio::io_context * shared_io = nullptr);
 
   /**
    * Special client variation for use in MAVConnTCPServer
    */
   explicit MAVConnTCPClient(
     uint8_t system_id, uint8_t component_id,
-    asio::io_service & server_io);
+    asio::io_context & server_io);
 
   virtual ~MAVConnTCPClient();
 
@@ -85,7 +85,7 @@ public:
 private:
   friend class MAVConnTCPServer;
   IoContextRunner io_runner;
-  asio::io_service & io_service;
+  asio::io_context & io_context;
 
   asio::ip::tcp::socket socket;
   asio::ip::tcp::endpoint server_ep;
@@ -106,7 +106,7 @@ private:
   void do_send(bool check_tx_state);
 
   /**
-   * Stop io_service.
+   * Stop io_context.
    */
   void stop();
 };
@@ -126,13 +126,13 @@ public:
   /**
    * @param[id] server_addr    bind host
    * @param[id] server_port    bind port
-   * @param[id] shared_io      optional external io_service. If provided, caller owns
+   * @param[id] shared_io      optional external io_context. If provided, caller owns
    *                           its execution/threading lifecycle.
    */
   MAVConnTCPServer(
     uint8_t system_id = 1, uint8_t component_id = MAV_COMP_ID_UDP_BRIDGE,
     std::string bind_host = DEFAULT_BIND_HOST, uint16_t bind_port = DEFAULT_BIND_PORT,
-    asio::io_service * shared_io = nullptr);
+    asio::io_context * shared_io = nullptr);
   virtual ~MAVConnTCPServer();
 
   void connect(
@@ -153,7 +153,7 @@ public:
 
 private:
   IoContextRunner io_runner;
-  asio::io_service & io_service;
+  asio::io_context & io_context;
 
   asio::ip::tcp::acceptor acceptor;
   asio::ip::tcp::endpoint bind_ep;

--- a/libmavconn/include/mavconn/udp.hpp
+++ b/libmavconn/include/mavconn/udp.hpp
@@ -54,7 +54,7 @@ public:
    * @param[id] bind_port    bind port
    * @param[id] remote_host  remote host (optional)
    * @param[id] remote_port  remote port (optional)
-   * @param[id] shared_io    optional external io_service. If provided, caller owns
+   * @param[id] shared_io    optional external io_context. If provided, caller owns
    *                         its execution/threading lifecycle.
    */
   MAVConnUDP(
@@ -62,7 +62,7 @@ public:
     std::string bind_host = DEFAULT_BIND_HOST, uint16_t bind_port = DEFAULT_BIND_PORT,
     std::string remote_host = DEFAULT_REMOTE_HOST,
     uint16_t remote_port = DEFAULT_REMOTE_PORT,
-    asio::io_service * shared_io = nullptr);
+    asio::io_context * shared_io = nullptr);
 
   virtual ~MAVConnUDP();
 
@@ -84,7 +84,7 @@ public:
 
 private:
   IoContextRunner io_runner;
-  asio::io_service & io_service;
+  asio::io_context & io_context;
   bool permanent_broadcast;
 
   std::atomic<bool> remote_exists;
@@ -103,7 +103,7 @@ private:
   void do_sendto(bool check_tx_state);
 
   /**
-   * Stop io_service.
+   * Stop io_context.
    */
   void stop();
 };

--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -395,7 +395,7 @@ static void url_parse_query(const std::string & query, uint8_t & sysid, uint8_t 
 
 static MAVConnInterface::Ptr url_parse_serial(
   const std::string & path, const std::string & query,
-  uint8_t system_id, uint8_t component_id, bool hwflow, asio::io_service * shared_io)
+  uint8_t system_id, uint8_t component_id, bool hwflow, asio::io_context * shared_io)
 {
   std::string file_path;
   int baudrate;
@@ -414,7 +414,7 @@ static MAVConnInterface::Ptr url_parse_serial(
 static MAVConnInterface::Ptr url_parse_udp(
   const std::string & hosts, const std::string & query,
   uint8_t system_id, uint8_t component_id, bool is_udpb, bool permanent_broadcast,
-  asio::io_service * shared_io)
+  asio::io_context * shared_io)
 {
   std::string bind_pair, remote_pair;
   std::string bind_host, remote_host;
@@ -450,7 +450,7 @@ static MAVConnInterface::Ptr url_parse_udp(
 
 static MAVConnInterface::Ptr url_parse_tcp_client(
   const std::string & host, const std::string & query,
-  uint8_t system_id, uint8_t component_id, asio::io_service * shared_io)
+  uint8_t system_id, uint8_t component_id, asio::io_context * shared_io)
 {
   std::string server_host;
   int server_port;
@@ -466,7 +466,7 @@ static MAVConnInterface::Ptr url_parse_tcp_client(
 
 static MAVConnInterface::Ptr url_parse_tcp_server(
   const std::string & host, const std::string & query,
-  uint8_t system_id, uint8_t component_id, asio::io_service * shared_io)
+  uint8_t system_id, uint8_t component_id, asio::io_context * shared_io)
 {
   std::string bind_host;
   int bind_port;
@@ -484,7 +484,7 @@ MAVConnInterface::Ptr MAVConnInterface::open_url_no_connect(
   std::string url,
   uint8_t system_id,
   uint8_t component_id,
-  asio::io_service * shared_io)
+  asio::io_context * shared_io)
 {
   /* Based on code found here:
    * http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
@@ -562,7 +562,7 @@ MAVConnInterface::Ptr MAVConnInterface::open_url(
   uint8_t component_id,
   const ReceivedCb & cb_handle_message,
   const ClosedCb & cb_handle_closed_port,
-  asio::io_service * shared_io)
+  asio::io_context * shared_io)
 {
   auto interface_ptr = open_url_no_connect(url, system_id, component_id, shared_io);
   if (interface_ptr) {

--- a/libmavconn/src/serial.cpp
+++ b/libmavconn/src/serial.cpp
@@ -30,7 +30,7 @@ namespace mavconn
 {
 
 using asio::buffer;
-using asio::io_service;
+using asio::io_context;
 using mavlink::mavlink_message_t;
 using std::error_code;
 
@@ -39,11 +39,11 @@ using std::error_code;
 
 MAVConnSerial::MAVConnSerial(
   uint8_t system_id, uint8_t component_id,
-  std::string device, unsigned baudrate, bool hwflow, asio::io_service * shared_io)
+  std::string device, unsigned baudrate, bool hwflow, asio::io_context * shared_io)
 : MAVConnInterface(system_id, component_id),
   io_runner(shared_io),
-  io_service(io_runner.io()),
-  serial_dev(io_service),
+  io_context(io_runner.io()),
+  serial_dev(io_context),
   tx_in_progress(false),
   tx_q{},
   rx_buf{}
@@ -123,15 +123,15 @@ void MAVConnSerial::connect(
   message_received_cb = cb_handle_message;
   port_closed_cb = cb_handle_closed_port;
 
-  // give some work to io_service before start
-  io_service.post([this]() {this->do_read();});
+  // give some work to io_context before start
+  asio::post(io_context, [this]() {this->do_read();});
 
   if (io_runner.owns_thread()) {
-    // run io_service for async io
+    // run io_context for async io
     io_runner.start(
       [this]() {
         utils::set_this_thread_name("mserial%zu", conn_id);
-        io_service.run();
+        io_context.run();
       });
   }
 }
@@ -173,7 +173,7 @@ void MAVConnSerial::send_bytes(const uint8_t * bytes, size_t length)
     tx_q.emplace_back(bytes, length);
   }
   auto sthis = shared_from_this();
-  io_service.post([sthis]() {sthis->do_write(true);});
+  asio::post(io_context, [sthis]() {sthis->do_write(true);});
 }
 
 void MAVConnSerial::send_message(const mavlink_message_t * message)
@@ -197,7 +197,7 @@ void MAVConnSerial::send_message(const mavlink_message_t * message)
     tx_q.emplace_back(message);
   }
   auto sthis = shared_from_this();
-  io_service.post([sthis]() {sthis->do_write(true);});
+  asio::post(io_context, [sthis]() {sthis->do_write(true);});
 }
 
 void MAVConnSerial::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -219,7 +219,7 @@ void MAVConnSerial::send_message(const mavlink::Message & message, const uint8_t
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
   auto sthis = shared_from_this();
-  io_service.post([sthis]() {sthis->do_write(true);});
+  asio::post(io_context, [sthis]() {sthis->do_write(true);});
 }
 
 void MAVConnSerial::do_read(void)
@@ -287,7 +287,7 @@ void MAVConnSerial::do_write(bool check_tx_state)
       }
 
       if (continue_send) {
-        sthis->io_service.post([sthis]() {sthis->do_write(false);});
+        asio::post(sthis->io_context, [sthis]() {sthis->do_write(false);});
       }
     });
 }

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -30,7 +30,7 @@ namespace mavconn
 
 using asio::buffer;
 using asio::error_code;
-using asio::io_service;
+using asio::io_context;
 using asio::ip::tcp;
 using mavlink::mavlink_message_t;
 using mavlink::mavlink_status_t;
@@ -39,24 +39,23 @@ using utils::to_string_ss;
 #define PFX "mavconn: tcp"
 #define PFXd PFX "%zu: "
 
-static asio::io_service & get_socket_io_service(tcp::socket & sock)
+static asio::io_context & get_socket_io_context(tcp::socket & sock)
 {
 #if ASIO_VERSION >= 101400
   return static_cast<asio::io_context &>(sock.get_executor().context());
 #else
-  return sock.get_io_service();
+  return sock.get_io_context();
 #endif
 }
 
 static bool resolve_address_tcp(
-  io_service & io, size_t chan, std::string host, uint16_t port,
+  io_context & io, size_t chan, std::string host, uint16_t port,
   tcp::endpoint & ep)
 {
   bool result = false;
   tcp::resolver resolver(io);
   error_code ec;
 
-  tcp::resolver::query query(host, "");
 
   auto fn = [&](const tcp::endpoint & q_ep) {
       ep = q_ep;
@@ -67,11 +66,11 @@ static bool resolve_address_tcp(
     };
 
 #if ASIO_VERSION >= 101200
-  for (auto q_ep : resolver.resolve(query, ec)) {
+  for (auto q_ep : resolver.resolve(host, "", ec)) {
     fn(q_ep);
   }
 #else
-  std::for_each(resolver.resolve(query, ec), tcp::resolver::iterator(), fn);
+  std::for_each(resolver.resolve(host, "", ec), tcp::resolver::iterator(), fn);
 #endif
 
   if (ec) {
@@ -86,17 +85,17 @@ static bool resolve_address_tcp(
 
 MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
-  std::string server_host, uint16_t server_port, asio::io_service * shared_io)
+  std::string server_host, uint16_t server_port, asio::io_context * shared_io)
 : MAVConnInterface(system_id, component_id),
   io_runner(shared_io),
-  io_service(io_runner.io()),
-  socket(io_service),
+  io_context(io_runner.io()),
+  socket(io_context),
   is_destroying(false),
   tx_in_progress(false),
   tx_q{},
   rx_buf{}
 {
-  if (!resolve_address_tcp(io_service, conn_id, server_host, server_port, server_ep)) {
+  if (!resolve_address_tcp(io_context, conn_id, server_host, server_port, server_ep)) {
     throw DeviceError("tcp: resolve", "Bind address resolve failed");
   }
 
@@ -112,11 +111,11 @@ MAVConnTCPClient::MAVConnTCPClient(
 
 MAVConnTCPClient::MAVConnTCPClient(
   uint8_t system_id, uint8_t component_id,
-  asio::io_service & server_io)
+  asio::io_context & server_io)
 : MAVConnInterface(system_id, component_id),
   io_runner(&server_io),
-  io_service(io_runner.io()),
-  socket(io_service),
+  io_context(io_runner.io()),
+  socket(io_context),
   is_destroying(false),
   tx_in_progress(false),
   tx_q{},
@@ -133,7 +132,7 @@ void MAVConnTCPClient::client_connected(size_t server_channel)
 
   // start recv
   auto sthis = shared_from_this();
-  get_socket_io_service(socket).post([sthis]() {sthis->do_recv();});
+  get_socket_io_context(socket).post([sthis]() {sthis->do_recv();});
 }
 
 MAVConnTCPClient::~MAVConnTCPClient()
@@ -141,8 +140,8 @@ MAVConnTCPClient::~MAVConnTCPClient()
   is_destroying = true;
   close();
 
-  // If the client is already disconnected on error (By the io_service thread)
-  // and io_service running
+  // If the client is already disconnected on error (By the io_context thread)
+  // and io_context running
   if (io_runner.owns_thread() && io_runner.is_running()) {
     stop();
   }
@@ -155,18 +154,18 @@ void MAVConnTCPClient::connect(
   message_received_cb = cb_handle_message;
   port_closed_cb = cb_handle_closed_port;
 
-  // give some work to io_service before start
-  io_service.post([this]() {this->do_recv();});
+  // give some work to io_context before start
+  asio::post(io_context, [this]() {this->do_recv();});
 
   if (io_runner.owns_thread()) {
-    // run io_service for async io
+    // run io_context for async io
     io_runner.start(
       [this]() {
         utils::set_this_thread_name("mtcp%zu", conn_id);
         try {
-          io_service.run();
+          io_context.run();
         } catch (std::exception & ex) {
-          CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
+          CONSOLE_BRIDGE_logError(PFXd "io_context exception: %s", conn_id, ex.what());
         }
       });
   }
@@ -225,7 +224,7 @@ void MAVConnTCPClient::send_bytes(const uint8_t * bytes, size_t length)
     tx_q.emplace_back(bytes, length);
   }
   auto sthis = shared_from_this();
-  get_socket_io_service(socket).post([sthis]() {sthis->do_send(true);});
+  get_socket_io_context(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink_message_t * message)
@@ -249,7 +248,7 @@ void MAVConnTCPClient::send_message(const mavlink_message_t * message)
     tx_q.emplace_back(message);
   }
   auto sthis = shared_from_this();
-  get_socket_io_service(socket).post([sthis]() {sthis->do_send(true);});
+  get_socket_io_context(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -271,7 +270,7 @@ void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
   auto sthis = shared_from_this();
-  get_socket_io_service(socket).post([sthis]() {sthis->do_send(true);});
+  get_socket_io_context(socket).post([sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::do_recv()
@@ -342,7 +341,7 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
       }
 
       if (continue_send) {
-        get_socket_io_service(sthis->socket).post([sthis]() {sthis->do_send(false);});
+        get_socket_io_context(sthis->socket).post([sthis]() {sthis->do_send(false);});
       }
     });
 }
@@ -351,14 +350,14 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
 
 MAVConnTCPServer::MAVConnTCPServer(
   uint8_t system_id, uint8_t component_id,
-  std::string server_host, uint16_t server_port, asio::io_service * shared_io)
+  std::string server_host, uint16_t server_port, asio::io_context * shared_io)
 : MAVConnInterface(system_id, component_id),
   io_runner(shared_io),
-  io_service(io_runner.io()),
-  acceptor(io_service),
+  io_context(io_runner.io()),
+  acceptor(io_context),
   is_destroying(false)
 {
-  if (!resolve_address_tcp(io_service, conn_id, server_host, server_port, bind_ep)) {
+  if (!resolve_address_tcp(io_context, conn_id, server_host, server_port, bind_ep)) {
     throw DeviceError("tcp-l: resolve", "Bind address resolve failed");
   }
 
@@ -387,15 +386,15 @@ void MAVConnTCPServer::connect(
   message_received_cb = cb_handle_message;
   port_closed_cb = cb_handle_closed_port;
 
-  // give some work to io_service before start
-  io_service.post([this]() {this->do_accept();});
+  // give some work to io_context before start
+  asio::post(io_context, [this]() {this->do_accept();});
 
   if (io_runner.owns_thread()) {
-    // run io_service for async io
+    // run io_context for async io
     io_runner.start(
       [this]() {
         utils::set_this_thread_name("mtcps%zu", conn_id);
-        io_service.run();
+        io_context.run();
       });
   }
 }
@@ -530,7 +529,7 @@ void MAVConnTCPServer::do_accept()
     return;
   }
   auto sthis = shared_from_this();
-  auto acceptor_client = std::make_shared<MAVConnTCPClient>(sys_id, comp_id, io_service);
+  auto acceptor_client = std::make_shared<MAVConnTCPClient>(sys_id, comp_id, io_context);
   acceptor.async_accept(
     acceptor_client->socket,
     acceptor_client->server_ep,

--- a/libmavconn/src/tcp.cpp
+++ b/libmavconn/src/tcp.cpp
@@ -132,7 +132,7 @@ void MAVConnTCPClient::client_connected(size_t server_channel)
 
   // start recv
   auto sthis = shared_from_this();
-  get_socket_io_context(socket).post([sthis]() {sthis->do_recv();});
+  asio::post(get_socket_io_context(socket), [sthis]() {sthis->do_recv();});
 }
 
 MAVConnTCPClient::~MAVConnTCPClient()
@@ -224,7 +224,7 @@ void MAVConnTCPClient::send_bytes(const uint8_t * bytes, size_t length)
     tx_q.emplace_back(bytes, length);
   }
   auto sthis = shared_from_this();
-  get_socket_io_context(socket).post([sthis]() {sthis->do_send(true);});
+  asio::post(get_socket_io_context(socket), [sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink_message_t * message)
@@ -248,7 +248,7 @@ void MAVConnTCPClient::send_message(const mavlink_message_t * message)
     tx_q.emplace_back(message);
   }
   auto sthis = shared_from_this();
-  get_socket_io_context(socket).post([sthis]() {sthis->do_send(true);});
+  asio::post(get_socket_io_context(socket), [sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -270,7 +270,7 @@ void MAVConnTCPClient::send_message(const mavlink::Message & message, const uint
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
   auto sthis = shared_from_this();
-  get_socket_io_context(socket).post([sthis]() {sthis->do_send(true);});
+  asio::post(get_socket_io_context(socket), [sthis]() {sthis->do_send(true);});
 }
 
 void MAVConnTCPClient::do_recv()
@@ -341,7 +341,7 @@ void MAVConnTCPClient::do_send(bool check_tx_state)
       }
 
       if (continue_send) {
-        get_socket_io_context(sthis->socket).post([sthis]() {sthis->do_send(false);});
+        asio::post(get_socket_io_context(sthis->socket), [sthis]() {sthis->do_send(false);});
       }
     });
 }

--- a/libmavconn/src/udp.cpp
+++ b/libmavconn/src/udp.cpp
@@ -27,7 +27,7 @@ namespace mavconn
 
 using asio::buffer;
 using asio::error_code;
-using asio::io_service;
+using asio::io_context;
 using asio::ip::udp;
 using utils::to_string_ss;
 using utils::operator"" _KiB;
@@ -37,14 +37,12 @@ using mavlink::mavlink_message_t;
 #define PFXd PFX "%zu: "
 
 static bool resolve_address_udp(
-  io_service & io, size_t chan, std::string host, unsigned short port,
+  io_context & io, size_t chan, std::string host, unsigned short port,
   udp::endpoint & ep)
 {
   bool result = false;
   udp::resolver resolver(io);
   error_code ec;
-
-  udp::resolver::query query(host, "");
 
   auto fn = [&](const udp::endpoint & q_ep) {
       ep = q_ep;
@@ -55,11 +53,11 @@ static bool resolve_address_udp(
     };
 
 #if ASIO_VERSION >= 101200
-  for (auto q_ep : resolver.resolve(query, ec)) {
+  for (auto q_ep : resolver.resolve(host, "", ec)) {
     fn(q_ep);
   }
 #else
-  std::for_each(resolver.resolve(query, ec), udp::resolver::iterator(), fn);
+  std::for_each(resolver.resolve(host, "", ec), udp::resolver::iterator(), fn);
 #endif
 
   if (ec) {
@@ -73,20 +71,20 @@ static bool resolve_address_udp(
 MAVConnUDP::MAVConnUDP(
   uint8_t system_id, uint8_t component_id,
   std::string bind_host, uint16_t bind_port,
-  std::string remote_host, uint16_t remote_port, asio::io_service * shared_io)
+  std::string remote_host, uint16_t remote_port, asio::io_context * shared_io)
 : MAVConnInterface(system_id, component_id),
   io_runner(shared_io),
-  io_service(io_runner.io()),
+  io_context(io_runner.io()),
   permanent_broadcast(false),
   remote_exists(false),
-  socket(io_service),
+  socket(io_context),
   tx_in_progress(false),
   tx_q{},
   rx_buf{}
 {
   using udps = asio::ip::udp::socket;
 
-  if (!resolve_address_udp(io_service, conn_id, bind_host, bind_port, bind_ep)) {
+  if (!resolve_address_udp(io_context, conn_id, bind_host, bind_port, bind_ep)) {
     throw DeviceError("udp: resolve", "Bind address resolve failed");
   }
 
@@ -94,7 +92,7 @@ MAVConnUDP::MAVConnUDP(
 
   if (remote_host != "") {
     if (remote_host != BROADCAST_REMOTE_HOST && remote_host != PERMANENT_BROADCAST_REMOTE_HOST) {
-      remote_exists = resolve_address_udp(io_service, conn_id, remote_host, remote_port, remote_ep);
+      remote_exists = resolve_address_udp(io_context, conn_id, remote_host, remote_port, remote_ep);
     } else {
       remote_exists = true;
       remote_ep = udp::endpoint(asio::ip::address_v4::broadcast(), remote_port);
@@ -132,7 +130,7 @@ MAVConnUDP::~MAVConnUDP()
 {
   close();
 
-  // If the socket already closed and the io_service running
+  // If the socket already closed and the io_context running
   if (io_runner.owns_thread() && io_runner.is_running()) {
     stop();
   }
@@ -145,18 +143,18 @@ void MAVConnUDP::connect(
   message_received_cb = cb_handle_message;
   port_closed_cb = cb_handle_closed_port;
 
-  // give some work to io_service before start
-  io_service.post([this]() {this->do_recvfrom();});
+  // give some work to io_context before start
+  asio::post(io_context, [this]() {this->do_recvfrom();});
 
   if (io_runner.owns_thread()) {
-    // run io_service for async io
+    // run io_context for async io
     io_runner.start(
       [this]() {
         utils::set_this_thread_name("mudp%zu", conn_id);
         try {
-          io_service.run();
+          io_context.run();
         } catch (std::exception & ex) {
-          CONSOLE_BRIDGE_logError(PFXd "io_service exception: %s", conn_id, ex.what());
+          CONSOLE_BRIDGE_logError(PFXd "io_context exception: %s", conn_id, ex.what());
         }
       });
   }
@@ -215,7 +213,7 @@ void MAVConnUDP::send_bytes(const uint8_t * bytes, size_t length)
     tx_q.emplace_back(bytes, length);
   }
   auto sthis = shared_from_this();
-  io_service.post([sthis]() {sthis->do_sendto(true);});
+  asio::post(io_context, [sthis]() {sthis->do_sendto(true);});
 }
 
 void MAVConnUDP::send_message(const mavlink_message_t * message)
@@ -244,7 +242,7 @@ void MAVConnUDP::send_message(const mavlink_message_t * message)
     tx_q.emplace_back(message);
   }
   auto sthis = shared_from_this();
-  io_service.post([sthis]() {sthis->do_sendto(true);});
+  asio::post(io_context, [sthis]() {sthis->do_sendto(true);});
 }
 
 void MAVConnUDP::send_message(const mavlink::Message & message, const uint8_t source_compid)
@@ -271,7 +269,7 @@ void MAVConnUDP::send_message(const mavlink::Message & message, const uint8_t so
     tx_q.emplace_back(message, get_status_p(), sys_id, source_compid);
   }
   auto sthis = shared_from_this();
-  io_service.post([sthis]() {sthis->do_sendto(true);});
+  asio::post(io_context, [sthis]() {sthis->do_sendto(true);});
 }
 
 void MAVConnUDP::do_recvfrom()
@@ -354,7 +352,7 @@ void MAVConnUDP::do_sendto(bool check_tx_state)
       }
 
       if (continue_send) {
-        sthis->io_service.post([sthis]() {sthis->do_sendto(false);});
+        asio::post(sthis->io_context, [sthis]() {sthis->do_sendto(false);});
       }
     });
 }

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -171,10 +171,12 @@ TEST_F(UDP, send_message)
   EXPECT_EQ(message_id, msgid);
 }
 
-TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
+TEST(IO_THREAD, udp_shared_io_context_stays_running_after_close)
 {
-  asio::io_service shared_io;
-  auto io_work = std::make_unique<asio::io_service::work>(shared_io);
+  asio::io_context shared_io;
+  auto io_work =
+    std::make_unique<asio::executor_work_guard<asio::io_context::executor_type>>(
+    asio::make_work_guard(shared_io));
   std::jthread io_thread([&shared_io]() {shared_io.run();});
 
   std::mutex mutex;
@@ -209,7 +211,7 @@ TEST(IO_THREAD, udp_shared_io_service_stays_running_after_close)
 
   echo->close();
 
-  shared_io.post([&]() {
+  asio::post(shared_io, [&]() {
       std::lock_guard<std::mutex> lock(mutex);
       posted_done = true;
       cond.notify_all();


### PR DESCRIPTION
This PR refactors the usage of the asio library to resolve build failures caused by the complete removal of the legacy API (e.g., io_service) in the latest versions of standalone asio (1.30+).

The codebase has been migrated to the modern ASIO API (using io_context, asio::post, etc.). Because the asio maintainers introduced these modern equivalents in earlier versions and maintained both implementations in parallel for a long transition period, this refactor is entirely backward compatible with older environments.

Test Summary
    Total tests: 415
    Errors: 0
    Failures: 0
    Skipped: 100