### PR TITLE
mavros_extras: Fix dangling pointers and uninitialized memory with Eigen

### DIFF
--- a/mavros_extras/src/plugins/hil.cpp
+++ b/mavros_extras/src/plugins/hil.cpp
@@ -172,10 +172,10 @@ private:
     state_quat.ind_airspeed = req->ind_airspeed * 1E2;
     state_quat.true_airspeed = req->true_airspeed * 1E2;
     // WRT world frame
-    auto ang_vel = ftf::transform_frame_enu_ned(
+    Eigen::Vector3d ang_vel = ftf::transform_frame_enu_ned(
       ftf::transform_frame_baselink_aircraft(
         ftf::to_eigen(req->angular_velocity)));
-    auto lin_vel = ftf::transform_frame_enu_ned<Eigen::Vector3d>(
+    Eigen::Vector3d lin_vel = ftf::transform_frame_enu_ned<Eigen::Vector3d>(
       ftf::to_eigen(req->linear_velocity)) * 1E2;
     // linear acceleration - WRT world frame
     auto lin_acc = ftf::transform_frame_baselink_aircraft(

--- a/mavros_extras/src/plugins/landing_target.cpp
+++ b/mavros_extras/src/plugins/landing_target.cpp
@@ -313,7 +313,7 @@ private:
     auto q = ftf::transform_orientation_enu_ned(
       ftf::transform_orientation_baselink_aircraft(Eigen::Quaterniond(tr.rotation())));
 
-    Eigen::Vector2f angle;
+    Eigen::Vector2f angle = Eigen::Vector2f::Zero();
     Eigen::Vector2f size_rad;
     Eigen::Vector2f fov(fov_x, fov_y);
 

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -316,7 +316,8 @@ private:
     publish_msg.header.stamp = node->now();
     publish_msg.header.frame_id = std::to_string(ms.target_component);
 
-    auto vec = Eigen::Vector3d(ms.pointing_b, ms.pointing_a, ms.pointing_c) * M_PI / 18000.0;
+    Eigen::Vector3d vec = Eigen::Vector3d(ms.pointing_b, ms.pointing_a,
+          ms.pointing_c) * M_PI / 18000.0;
     tf2::toMsg(vec, publish_msg.vector);
 
     mount_status_pub->publish(publish_msg);


### PR DESCRIPTION
While testing builds with GCC 15.2 (while adopting Nix which has new versions of underlying libraries and compilers), I noticed several `-Wdangling-pointer` and `-Wmaybe-uninitialized` warnings that were causing undefined behavior and silent memory corruption.

The issue stems from using `auto` to store the result of Eigen math formulas (e.g., `auto vec = Vector3d(...) * M_PI`). Under the hood, this evaluates to an expression template rather than an actual vector. Since the original temporary vector gets destroyed immediately, the expression template ends up holding a dangling pointer.

To fix this, I swapped the `auto` declarations for explicit `Eigen::Vector3d` types in `hil.cpp` and `mount_control.cpp` to force immediate evaluation. I also zero-initialized a vector in `landing_target.cpp` to clear out an uninitialized memory warning.

Tested locally and everything compiles cleanly now:
**Summary: 415 tests, 0 errors, 0 failures, 100 skipped**