### PR TITLE
frame_tf: fix quaternion_to_rpy yaw folding past 180° (eulerAngles clamping)

### DIFF
--- a/mavros/src/lib/ftf_quaternion_utils.cpp
+++ b/mavros/src/lib/ftf_quaternion_utils.cpp
@@ -39,15 +39,31 @@ Eigen::Quaterniond quaternion_from_rpy(const Eigen::Vector3d & rpy)
 
 Eigen::Vector3d quaternion_to_rpy(const Eigen::Quaterniond & q)
 {
-  // ZYX — atan2-based decomposition avoids Eigen::eulerAngles(2,1,0) clamping
-  // yaw to [0, pi]. All three angles now cover their full atan2/asin range:
-  //   roll  [-pi, pi], pitch [-pi/2, pi/2], yaw [-pi, pi]
+  // ZYX decomposition via rotation matrix. Avoids Eigen::eulerAngles(2,1,0)
+  // clamping yaw to [0, pi].
+  //
+  // Normal case (|pitch| < pi/2): roll, pitch, yaw all recovered via atan2/asin.
+  // Gimbal lock (pitch = ±pi/2): roll and yaw are not independently observable;
+  // we set roll = 0 and place the combined degree of freedom in yaw.
   auto m = q.toRotationMatrix();
-  return Eigen::Vector3d(
-    std::atan2(m(2, 1), m(2, 2)),   // roll
-    std::asin(-m(2, 0)),             // pitch
-    std::atan2(m(1, 0), m(0, 0))    // yaw
-  );
+
+  double sin_pitch = std::clamp(-m(2, 0), -1.0, 1.0);
+  double cos_pitch = std::sqrt(m(2, 1) * m(2, 1) + m(2, 2) * m(2, 2));
+
+  if (cos_pitch > 1e-9) {
+    return Eigen::Vector3d(
+      std::atan2(m(2, 1), m(2, 2)),    // roll  ∈ (-π, π]
+      std::atan2(sin_pitch, cos_pitch), // pitch ∈ (-π/2, π/2)
+      std::atan2(m(1, 0), m(0, 0)));   // yaw   ∈ (-π, π]
+  }
+
+  // Gimbal lock
+  if (sin_pitch > 0) {
+    // pitch = +π/2: only (yaw − roll) is observable
+    return Eigen::Vector3d(0.0, M_PI / 2.0, std::atan2(m(1, 2), m(1, 1)));
+  }
+  // pitch = -π/2: only (yaw + roll) is observable
+  return Eigen::Vector3d(0.0, -M_PI / 2.0, std::atan2(-m(1, 2), m(1, 1)));
 }
 
 double quaternion_get_yaw(const Eigen::Quaterniond & q)

--- a/mavros/src/lib/ftf_quaternion_utils.cpp
+++ b/mavros/src/lib/ftf_quaternion_utils.cpp
@@ -39,8 +39,15 @@ Eigen::Quaterniond quaternion_from_rpy(const Eigen::Vector3d & rpy)
 
 Eigen::Vector3d quaternion_to_rpy(const Eigen::Quaterniond & q)
 {
-  // YPR - ZYX
-  return q.toRotationMatrix().eulerAngles(2, 1, 0).reverse();
+  // ZYX — atan2-based decomposition avoids Eigen::eulerAngles(2,1,0) clamping
+  // yaw to [0, pi]. All three angles now cover their full atan2/asin range:
+  //   roll  [-pi, pi], pitch [-pi/2, pi/2], yaw [-pi, pi]
+  auto m = q.toRotationMatrix();
+  return Eigen::Vector3d(
+    std::atan2(m(2, 1), m(2, 2)),   // roll
+    std::asin(-m(2, 0)),             // pitch
+    std::atan2(m(1, 0), m(0, 0))    // yaw
+  );
 }
 
 double quaternion_get_yaw(const Eigen::Quaterniond & q)

--- a/mavros/test/test_quaternion_utils.cpp
+++ b/mavros/test/test_quaternion_utils.cpp
@@ -67,11 +67,13 @@ TEST(FRAME_TF, quaternion_from_rpy__paranoic_check)
 
 TEST(FRAME_TF, quaternion_to_rpy__123)
 {
-  auto q = ftf::quaternion_from_rpy(1.0, 2.0, 3.0);
+  // Angles kept within the ZYX unique domain (|pitch| < pi/2) so that the
+  // round-trip rpy->q->rpy recovers the original values exactly.
+  auto q = ftf::quaternion_from_rpy(1.0, 0.5, 3.0);
   auto rpy = ftf::quaternion_to_rpy(q);
 
   EXPECT_NEAR(1.0, rpy.x(), epsilon);
-  EXPECT_NEAR(2.0, rpy.y(), epsilon);
+  EXPECT_NEAR(0.5, rpy.y(), epsilon);
   EXPECT_NEAR(3.0, rpy.z(), epsilon);
 }
 
@@ -94,9 +96,9 @@ TEST(FRAME_TF, quaternion_to_rpy__yaw_full_circle)
     // Canonical yaw recovered by atan2 lives in (-pi, pi].
     // Allow for floating-point round-trip; the exact recovered value must
     // equal the input since both sit in (-pi, pi].
-    EXPECT_NEAR(roll,  rpy.x(), epsilon);
+    EXPECT_NEAR(roll, rpy.x(), epsilon);
     EXPECT_NEAR(pitch, rpy.y(), epsilon);
-    EXPECT_NEAR(yaw,   rpy.z(), epsilon);
+    EXPECT_NEAR(yaw, rpy.z(), epsilon);
   }
 }
 

--- a/mavros/test/test_quaternion_utils.cpp
+++ b/mavros/test/test_quaternion_utils.cpp
@@ -67,13 +67,37 @@ TEST(FRAME_TF, quaternion_from_rpy__paranoic_check)
 
 TEST(FRAME_TF, quaternion_to_rpy__123)
 {
-  // this test only works on positive rpy: 0..pi
   auto q = ftf::quaternion_from_rpy(1.0, 2.0, 3.0);
   auto rpy = ftf::quaternion_to_rpy(q);
 
   EXPECT_NEAR(1.0, rpy.x(), epsilon);
   EXPECT_NEAR(2.0, rpy.y(), epsilon);
   EXPECT_NEAR(3.0, rpy.z(), epsilon);
+}
+
+// Regression test: quaternion_to_rpy must return the canonical yaw in (-pi, pi]
+// for all headings, not clamp to [0, pi] as Eigen::eulerAngles(2,1,0) does.
+TEST(FRAME_TF, quaternion_to_rpy__yaw_full_circle)
+{
+  const double roll = 0.1, pitch = 0.2;
+
+  for (int yaw_deg = -179; yaw_deg <= 180; ++yaw_deg) {
+    const double yaw = yaw_deg * deg_to_rad;
+
+    std::stringstream ss;
+    ss << "yaw=" << yaw_deg << "deg";
+    SCOPED_TRACE(ss.str());
+
+    auto q = ftf::quaternion_from_rpy(roll, pitch, yaw);
+    auto rpy = ftf::quaternion_to_rpy(q);
+
+    // Canonical yaw recovered by atan2 lives in (-pi, pi].
+    // Allow for floating-point round-trip; the exact recovered value must
+    // equal the input since both sit in (-pi, pi].
+    EXPECT_NEAR(roll,  rpy.x(), epsilon);
+    EXPECT_NEAR(pitch, rpy.y(), epsilon);
+    EXPECT_NEAR(yaw,   rpy.z(), epsilon);
+  }
 }
 
 TEST(FRAME_TF, quaternion_to_rpy__pm_pi)
@@ -106,13 +130,13 @@ TEST(FRAME_TF, quaternion_to_rpy__pm_pi)
         auto rpy = ftf::quaternion_to_rpy(q1);
         auto q2 = ftf::quaternion_from_rpy(rpy);
 
-        // direct assumption is failed at ranges outside 0..pi
+        // Direct angle comparison is still undefined near gimbal-lock (pitch ≈ ±90°)
+        // because ZYX atan2/asin decomposition is not unique there.
+        // The yaw-clamping bug (eulerAngles clamping to [0,pi]) is covered
+        // separately by quaternion_to_rpy__yaw_full_circle above.
         // EXPECT_NEAR(expected.x(), rpy.x(), epsilon);
         // EXPECT_NEAR(expected.y(), rpy.y(), epsilon);
         // EXPECT_NEAR(expected.z(), rpy.z(), epsilon);
-
-        // at -pi..0 we got complimentary q2 to q
-        // EXPECT_QUATERNION(q1, q2, epsilon);
 
         // instead of direct comparison we rotate other quaternion and then compare results
         auto tq1 = q1 * test_orientation * q1.inverse();


### PR DESCRIPTION
`Eigen::eulerAngles(2,1,0)` clamps the primary extraction axis to `[0, π]`.
  In ZYX the primary axis is Z (yaw), so any heading past 180° is folded back
  rather than continuing to negative values. A full 360° rotation produces
  yaw 0 → π → 0 → π instead of the correct 0 → π → −π → 0.

  This flows through `vision_pose_estimate` into `VISION_POSITION_ESTIMATE`,
  which carries only Euler floats. The EKF receives the folded yaw as truth and
  sees the heading suddenly reverse direction mid-flight.

  Reported in #358 (2015), #444 (2015), and #1472 (2020). No fix was ever
  merged; the ros2 port in 2021 carried the bug forward.

  ## Changes

  Replace with the standard ZYX rotation-matrix decomposition:

  ```cpp
  double sin_pitch = std::clamp(-m(2, 0), -1.0, 1.0);
  double cos_pitch = std::sqrt(m(2, 1) * m(2, 1) + m(2, 2) * m(2, 2));

  if (cos_pitch > 1e-9) {
    return Eigen::Vector3d(
      std::atan2(m(2, 1), m(2, 2)),    // roll  ∈ (-π, π]
      std::atan2(sin_pitch, cos_pitch), // pitch ∈ (-π/2, π/2)
      std::atan2(m(1, 0), m(0, 0)));   // yaw   ∈ (-π, π]
  }
  // Gimbal lock (pitch = ±π/2): only one degree of freedom is observable.
  // Set roll = 0 and place yaw−roll (or yaw+roll) entirely in yaw.
  if (sin_pitch > 0) {
    return Eigen::Vector3d(0.0, M_PI / 2.0,  std::atan2( m(1, 2), m(1, 1)));
  }
  return Eigen::Vector3d(0.0, -M_PI / 2.0, std::atan2(-m(1, 2), m(1, 1)));
``` 

  atan2 returns (−π, π] so yaw is now correct for every heading.
  The gimbal-lock branch handles pitch = ±π/2 consistently with the
  existing quaternion_to_rpy__pm_pi round-trip test.

Also updates quaternion_to_rpy__123 to use pitch=0.5 rad (within the
  ZYX unique domain) and adds quaternion_to_rpy__yaw_full_circle which
  sweeps yaw through all integer degrees in [−179°, 180°] and asserts exact
  round-trip recovery — this test fails on the old code for any yaw in (−π, 0).

  Testing

  - All 8 libmavros-quaternion-utils-test cases pass.
  - Tested on hardware: ZED 2i → ArduCopter 4.5 EKF3 via MAVROS, ROS Humble / Ubuntu 22.04.

