### PR TITLE
Replace REQUEST_AUTOPILOT_CAPACITIES (deprecated) by REQUEST_MESSAGE

### DIFF
--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1321,9 +1321,11 @@ private:
 
       auto cmdrq = std::make_shared<mavros_msgs::srv::CommandLong::Request>();
       cmdrq->broadcast = do_broadcast;
-      cmdrq->command = enum_value(MAV_CMD::REQUEST_AUTOPILOT_CAPABILITIES);
+      cmdrq->command = enum_value(MAV_CMD::REQUEST_MESSAGE);
       cmdrq->confirmation = false;
-      cmdrq->param1 = 1.0;
+      // Request a single AUTOPILOT_VERSION message from the target system.
+      cmdrq->param1 = mavlink::common::msg::AUTOPILOT_VERSION::MSG_ID;
+      cmdrq->param7 = 1.0;
 
       RCLCPP_DEBUG(
         lg, "VER: Sending %s request.",

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1324,7 +1324,7 @@ private:
       cmdrq->command = enum_value(MAV_CMD::REQUEST_MESSAGE);
       cmdrq->confirmation = false;
       // Request a single AUTOPILOT_VERSION message from the target system.
-      cmdrq->param1 = mavlink::common::msg::AUTOPILOT_VERSION::MSG_ID;
+      cmdrq->param1 = mavlink::standard::msg::AUTOPILOT_VERSION::MSG_ID;
       cmdrq->param7 = 1.0;
 
       RCLCPP_DEBUG(


### PR DESCRIPTION
From the mavlink documentation, the [MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES) is deprecated since 2019. This PR changes the message to the new [MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE)