### PR TITLE
Try optimize

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
 - package-ecosystem: "uv"
   directory: "/tools"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
 - package-ecosystem: "pip"
   directory: "/docs"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,6 +69,7 @@ jobs:
           sudo apt-get install -y gcovr ccache
 
       - uses: actions/cache@v6  # nosemgrep
+        continue-on-error: true
         with:
           path: ${{ env.CCACHE_DIR }}
           key: "ccache-cov-${{ runner.os }}-${{ matrix.ros_distro }}-${{ matrix.component.name }}-${{ hashFiles('**/package.xml', '**/CMakeLists.txt') }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,15 @@ jobs:
       # rosdep to pip-install it on PEP 668 distros (jazzy+)
       TEST_ENABLE_E2E: "1"
       PIP_BREAK_SYSTEM_PACKAGES: "1"
+      # Run the mavros router Google Benchmark (~10 s per distro) in CI;
+      # AMENT_RUN_PERFORMANCE_TESTS is a CMake configure-time option, so it
+      # must be passed via CMAKE_ARGS (industrial_ci forwards it to colcon).
+      CMAKE_ARGS: "-DAMENT_RUN_PERFORMANCE_TESTS=ON"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7  # nosemgrep
       - uses: actions/cache@v6  # nosemgrep
+        continue-on-error: true
         with:
           path: "${{ env.CCACHE_DIR }}"
           key: "ccache-${{ runner.os }}-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}-${{ hashFiles('**/package.xml', '**/CMakeLists.txt') }}"

--- a/mavros/CMakeLists.txt
+++ b/mavros/CMakeLists.txt
@@ -287,6 +287,22 @@ if(BUILD_TESTING)
     ${mavros_msgs_TARGETS}
   )
 
+  find_package(ament_cmake_google_benchmark REQUIRED)
+  ament_add_gtest(mavros-router-e2e test/test_router_e2e.cpp)
+  target_link_libraries(mavros-router-e2e
+    mavros
+    ${mavros_msgs_TARGETS}
+  )
+
+  ament_add_google_benchmark_executable(mavros-router-benchmark test/test_router_benchmark.cpp)
+  target_link_libraries(mavros-router-benchmark
+    mavros
+    ${mavros_msgs_TARGETS}
+  )
+  ament_add_google_benchmark_test(mavros-router-benchmark
+    TIMEOUT 120
+  )
+
   ament_add_gmock(mavros-uas-test test/test_uas.cpp)
   target_link_libraries(mavros-uas-test
     mavros

--- a/mavros/README.md
+++ b/mavros/README.md
@@ -123,7 +123,7 @@ MAVROS builds its executors via a factory that honors two environment variables:
         (rclcpp >= 30.0.0). On older distros the request is ignored with a
         warning and `MultiThreadedExecutor` is used.
   - `MAVROS_UAS_EXECUTOR_THREADS` - number of threads for the UAS plugin
-    executor (default: clamped hardware concurrency, min 4 max 16; must be
+    executor (default: clamped hardware concurrency, min 2 max 4; must be
     >= 2 if set).
 
 Example, running `mavros_node` with the events executor:

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -33,6 +33,7 @@
 
 #include "mavconn/interface.hpp"
 #include "mavconn/io_context_runner.hpp"
+#include "mavconn/thread_utils.hpp"
 #include "mavconn/mavlink_dialect.hpp"
 #include "mavros/utils.hpp"
 #include "rclcpp/macros.hpp"
@@ -102,17 +103,35 @@ public:
   std::set<addr_t> remote_addrs;         // remotes that we heard there
   std::set<addr_t> stale_addrs;          // temporary storage for stale remote addrs
 
+  // "ep:<id>" string used as the Mavlink message frame_id in the hot path.
+  // Computed once via set_id() before the endpoint is published to the
+  // router, so this is a plain string read with no locking.
+  const std::string & frame_id() const
+  {
+    return frame_id_str_;
+  }
+
+  // Set the endpoint id and memoize its frame_id string.
+  void set_id(id_t id_)
+  {
+    id = id_;
+    frame_id_str_ = mavconn::utils::format("ep:%d", id_);
+  }
+
   virtual bool is_open() = 0;
   virtual std::pair<bool, std::string> open() = 0;
   virtual void close() = 0;
 
   virtual void send_message(
     const mavlink_message_t * msg, const Framing framing = Framing::ok,
-    id_t src_id = 0) = 0;
+    const std::string & from_frame_id = "") = 0;
   virtual void recv_message(const mavlink_message_t * msg, const Framing framing = Framing::ok);
 
   virtual std::string diag_name();
   virtual void diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat) = 0;
+
+private:
+  std::string frame_id_str_;
 };
 
 /**
@@ -150,7 +169,7 @@ public:
       options /* rclcpp::NodeOptions(options).use_intra_process_comms(true) */),
     router_io_runner(),
     endpoints{}, stat_msg_routed(0), stat_msg_sent(0), stat_msg_dropped(0),
-    diagnostic_updater(this, 1.0)
+    diagnostic_updater(this, 5.0)
   {
     RCLCPP_DEBUG(this->get_logger(), "Start mavros::router::Router initialization...");
 
@@ -312,7 +331,7 @@ public:
 
   void send_message(
     const mavlink_message_t * msg, const Framing framing = Framing::ok,
-    id_t src_id = 0) override;
+    const std::string & from_frame_id = "") override;
 
   void diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat) override;
 };
@@ -346,7 +365,7 @@ public:
 
   void send_message(
     const mavlink_message_t * msg, const Framing framing = Framing::ok,
-    id_t src_id = 0) override;
+    const std::string & from_frame_id = "") override;
 
   void diag_run(diagnostic_updater::DiagnosticStatusWrapper & stat) override;
 

--- a/mavros/include/mavros/mavros_router.hpp
+++ b/mavros/include/mavros/mavros_router.hpp
@@ -245,6 +245,8 @@ public:
 private:
   friend class Endpoint;
   friend class TestRouter;
+  friend class E2ERouter;
+  friend class BenchmarkRouter;
 
   static std::atomic<id_t> id_counter;
   mavconn::IoContextRunner router_io_runner;

--- a/mavros/package.xml
+++ b/mavros/package.xml
@@ -70,6 +70,7 @@
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_google_benchmark</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/mavros/src/lib/mavros_router.cpp
+++ b/mavros/src/lib/mavros_router.cpp
@@ -87,7 +87,7 @@ void Router::route_message(
   }
 
   for (const auto & dest : targets) {
-    dest->send_message(msg, framing, src->id);
+    dest->send_message(msg, framing, src->frame_id());
   }
   const auto sent_cnt = targets.size();
 
@@ -137,7 +137,7 @@ void Router::add_endpoint(
   auto shared_this = shared_from_this();
 
   ep->parent = std::static_pointer_cast<Router>(shared_this);
-  ep->id = id;
+  ep->set_id(id);
   ep->link_type = static_cast<Endpoint::Type>(request->type);
   ep->url = request->url;
 
@@ -454,7 +454,7 @@ void MAVConnEndpoint::close()
 
 void MAVConnEndpoint::send_message(
   const mavlink_message_t * msg, const Framing framing,
-  id_t src_id [[maybe_unused]])
+  const std::string & from_frame_id [[maybe_unused]])
 {
   (void)framing;
 
@@ -549,23 +549,27 @@ void ROSEndpoint::close()
   this->sink.reset();
 }
 
-void ROSEndpoint::send_message(const mavlink_message_t * msg, const Framing framing, id_t src_id)
+void ROSEndpoint::send_message(
+  const mavlink_message_t * msg, const Framing framing,
+  const std::string & from_frame_id)
 {
   rcpputils::assert_true(msg, "msg not null");
 
-  auto rmsg = mavros_msgs::msg::Mavlink();
-  auto ok = mavros_msgs::mavlink::convert(*msg, rmsg, utils::enum_value(framing));
+  // NOTE(vooon): unique_ptr publish so intra-process subscribers (the UAS)
+  // get the buffer without a copy.
+  auto rmsg = std::make_unique<mavros_msgs::msg::Mavlink>();
+  auto ok = mavros_msgs::mavlink::convert(*msg, *rmsg, utils::enum_value(framing));
 
   // don't fail if endpoint closed
   if (!this->source) {
     return;
   }
 
-  rmsg.header.stamp = this->parent->now();
-  rmsg.header.frame_id = utils::format("ep:%d", src_id);
+  rmsg->header.stamp = this->parent->now();
+  rmsg->header.frame_id = from_frame_id;
 
   if (ok) {
-    this->source->publish(rmsg);
+    this->source->publish(std::move(rmsg));
   } else if (auto & nh = this->parent) {
     RCLCPP_ERROR(nh->get_logger(), "message conversion error");
   }

--- a/mavros/src/lib/mavros_uas.cpp
+++ b/mavros/src/lib/mavros_uas.cpp
@@ -429,14 +429,16 @@ void UAS::send_message(const mavlink::Message & obj, const uint8_t src_compid)
     &msg, source_system, src_compid, &mavlink_status, mi.min_length, mi.length,
     mi.crc_extra);
 
-  mavros_msgs::msg::Mavlink rmsg{};
-  auto ok = mavros_msgs::mavlink::convert(msg, rmsg);
+  // NOTE(vooon): unique_ptr publish so intra-process subscribers (the router)
+  // get the buffer without a copy.
+  auto rmsg = std::make_unique<mavros_msgs::msg::Mavlink>();
+  auto ok = mavros_msgs::mavlink::convert(msg, *rmsg);
 
-  rmsg.header.stamp = this->now();
-  rmsg.header.frame_id = this->get_name();
+  rmsg->header.stamp = this->now();
+  rmsg->header.frame_id = this->get_name();
 
   if (this->sink && ok) {
-    this->sink->publish(rmsg);
+    this->sink->publish(std::move(rmsg));
   }
 }
 

--- a/mavros/src/lib/uas_executor.cpp
+++ b/mavros/src/lib/uas_executor.cpp
@@ -72,7 +72,7 @@ size_t UASExecutor::select_number_of_threads()
         "Invalid MAVROS_UAS_EXECUTOR_THREADS value '%s': %s. Using default.", env, e.what());
     }
   }
-  return std::clamp<size_t>(std::thread::hardware_concurrency(), 4, 16);
+  return std::clamp<size_t>(std::thread::hardware_concurrency(), 2, 4);
 }
 
 std::unique_ptr<rclcpp::Executor> mavros::uas::make_executor(

--- a/mavros/test/test_router.cpp
+++ b/mavros/test/test_router.cpp
@@ -61,7 +61,7 @@ public:
 
   MOCK_METHOD3(
     send_message, void(const mavlink_message_t * msg,
-    const Framing framing, id_t src_id));
+    const Framing framing, const std::string & from_frame_id));
   MOCK_METHOD2(
     recv_message, void(const mavlink_message_t * msg,
     const Framing framing));
@@ -90,7 +90,7 @@ public:
   void send_message(
     const mavlink_message_t * msg [[maybe_unused]],
     const Framing framing [[maybe_unused]],
-    id_t src_id [[maybe_unused]]) override
+    const std::string & from_frame_id [[maybe_unused]]) override
   {
     send_count.fetch_add(1, std::memory_order_relaxed);
   }

--- a/mavros/test/test_router_benchmark.cpp
+++ b/mavros/test/test_router_benchmark.cpp
@@ -1,0 +1,236 @@
+// mavros
+// Copyright 2026 Vladimir Ermakov, All rights reserved.
+//
+// This file is part of the mavros package and subject to the license terms
+// in the top-level LICENSE file of the mavros repository.
+// https://github.com/mavlink/mavros/tree/master/LICENSE.md
+//
+
+/**
+ * Google Benchmark for the mavros router with real UDP endpoints.
+ *
+ * Measures sustained routing throughput: several FCU UDP streams feed the
+ * router and the benchmark reports how many messages each UAS endpoint
+ * receives per second. Run duration is controlled by Google Benchmark's
+ * --benchmark_min_time (CI uses 10s).
+ *
+ * Skipped when MAVROS_SKIP_STRESS_TESTS=1.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <asio.hpp>
+
+#include "rclcpp/executors.hpp"
+#include "mavconn/thread_utils.hpp"
+#include "mavros/mavros_router.hpp"
+#include "mavros_msgs/msg/mavlink.hpp"
+
+using namespace std::chrono_literals;  // NOLINT
+using mavconn::utils::format;
+
+namespace mavros
+{
+namespace router
+{
+
+static int udp_base()
+{
+  if (const char * env = std::getenv("MAVROS_TEST_UDP_BASE")) {
+    return std::atoi(env);
+  }
+  return 15500;
+}
+
+static int fcu_bind(int f) {return udp_base() + f;}
+static int fcu_remote(int f) {return udp_base() + 100 + f;}
+
+template<typename M>
+static size_t build_frame(const M & msg, uint8_t sysid, uint8_t compid, uint8_t * wire)
+{
+  mavlink::mavlink_message_t mmsg{};
+  mavlink::MsgMap mmap(mmsg);
+  mmsg.sysid = sysid;
+  mmsg.compid = compid;
+  msg.serialize(mmap);
+  const auto & mi = msg.get_message_info();
+  mavlink::mavlink_status_t status{};
+  mavlink::mavlink_finalize_message_buffer(
+    &mmsg, sysid, compid, &status, mi.min_length, mi.length, mi.crc_extra);
+  return mavlink::mavlink_msg_to_send_buffer(wire, &mmsg);
+}
+
+class BenchmarkRouter : public benchmark::Fixture
+{
+public:
+  void SetUp(const benchmark::State &) override
+  {
+    rclcpp::init(0, nullptr);
+    exec_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+
+    rclcpp::NodeOptions opts;
+    opts.use_intra_process_comms(true);
+    router_ = std::make_shared<Router>(opts, "bench_router");
+
+    fcu_count_ = 3;
+    uas_count_ = 4;
+
+    std::vector<std::string> fcu_urls, uas_urls;
+    for (int f = 0; f < fcu_count_; f++) {
+      fcu_urls.push_back(
+        format("udp://127.0.0.1:%d@127.0.0.1:%d", fcu_bind(f), fcu_remote(f)));
+    }
+    for (int u = 0; u < uas_count_; u++) {
+      uas_urls.push_back(format("/bench_uas%d", u + 1));
+    }
+    router_->set_parameters({
+          rclcpp::Parameter("fcu_urls", fcu_urls),
+          rclcpp::Parameter("gcs_urls", std::vector<std::string>{}),
+          rclcpp::Parameter("uas_urls", uas_urls),
+    });
+
+    exec_->add_node(router_);
+    exit_promise_ = std::make_shared<std::promise<void>>();
+    exit_future_ = exit_promise_->get_future().share();
+    spin_thread_ = std::thread([this]() {exec_->spin_until_future_complete(exit_future_);});
+    std::this_thread::sleep_for(1s);
+
+    // Subscribe to each UAS endpoint and teach the router their addresses.
+    for (int u = 0; u < uas_count_; u++) {
+      uas_recv_.push_back(std::make_shared<std::atomic<size_t>>(0));
+      subs_.push_back(
+        router_->create_subscription<mavros_msgs::msg::Mavlink>(
+          format("/bench_uas%d/mavlink_source", u + 1), rclcpp::QoS(1000).best_effort(),
+          [u, this](const mavros_msgs::msg::Mavlink::SharedPtr) {(*uas_recv_[u])++;}));
+      pubs_.push_back(
+        router_->create_publisher<mavros_msgs::msg::Mavlink>(
+          format("/bench_uas%d/mavlink_sink", u + 1), rclcpp::QoS(1000).best_effort()));
+      mavros_msgs::msg::Mavlink rmsg{};
+      rmsg.header.stamp.sec = 1;
+      rmsg.sysid = static_cast<uint8_t>((u + 1) * 10);
+      rmsg.compid = 1;
+      rmsg.msgid = 0;  // HEARTBEAT
+      pubs_.back()->publish(rmsg);
+    }
+
+    // FCU UDP senders bound to the router's remote ports.
+    for (int f = 0; f < fcu_count_; f++) {
+      asio::ip::udp::socket s(io_);
+      s.open(asio::ip::udp::v4());
+      s.set_option(asio::ip::udp::socket::reuse_address(true));
+      s.bind(
+        asio::ip::udp::endpoint(
+          asio::ip::make_address("127.0.0.1"), fcu_remote(f)));
+      s.connect(
+        asio::ip::udp::endpoint(
+          asio::ip::make_address("127.0.0.1"), fcu_bind(f)));
+      fcu_socks_.push_back(std::move(s));
+    }
+
+    mavlink::minimal::msg::HEARTBEAT hb{};
+    hb.type = 2;
+    hb.autopilot = 3;
+    hb.base_mode = 80;
+    hb.system_status = 2;
+    hb_len_ = build_frame(hb, 1, 1, hb_wire_);
+
+    // warm up so endpoints learn remotes
+    for (int f = 0; f < fcu_count_; f++) {
+      fcu_socks_[f].send(asio::buffer(hb_wire_, hb_len_));
+    }
+    std::this_thread::sleep_for(500ms);
+    for (auto & c : uas_recv_) {c->store(0);}
+  }
+
+  void TearDown(const benchmark::State &) override
+  {
+    exit_promise_->set_value();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    router_->endpoints.clear();
+    // Destroy the ROS entities (DDS participants) before shutdown so the
+    // middleware does not outlive the global context.
+    subs_.clear();
+    pubs_.clear();
+    fcu_socks_.clear();
+    router_.reset();
+    rclcpp::shutdown();
+  }
+
+  size_t delivered()
+  {
+    size_t total = 0;
+    for (auto & c : uas_recv_) {total += c->load();}
+    return total;
+  }
+
+protected:
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> exec_;
+  std::thread spin_thread_;
+  std::shared_ptr<std::promise<void>> exit_promise_;
+  std::shared_future<void> exit_future_;
+  asio::io_context io_;
+  Router::SharedPtr router_;
+  std::vector<rclcpp::Subscription<mavros_msgs::msg::Mavlink>::SharedPtr> subs_;
+  std::vector<rclcpp::Publisher<mavros_msgs::msg::Mavlink>::SharedPtr> pubs_;
+  std::vector<std::shared_ptr<std::atomic<size_t>>> uas_recv_;
+  std::vector<asio::ip::udp::socket> fcu_socks_;
+  uint8_t hb_wire_[512];
+  size_t hb_len_{0};
+  int fcu_count_{0};
+  int uas_count_{0};
+};
+
+// Sustained broadcast throughput: each iteration sends a batch of heartbeats
+// from every FCU and waits for delivery; reports messages delivered per
+// second across all UAS endpoints.
+BENCHMARK_DEFINE_F(BenchmarkRouter, sustained)(benchmark::State & state)
+{
+  const int batch = static_cast<int>(state.range(0));
+  size_t total_delivered = 0;
+
+  for (auto _ : state) {
+    const size_t before = delivered();
+    for (int f = 0; f < fcu_count_; f++) {
+      for (int i = 0; i < batch; i++) {
+        fcu_socks_[f].send(asio::buffer(hb_wire_, hb_len_));
+      }
+    }
+    // wait for the router to deliver the batch to every UAS
+    const size_t expected = static_cast<size_t>(batch) * fcu_count_ * uas_count_;
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (delivered() < before + expected && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::yield();
+    }
+    total_delivered += delivered() - before;
+  }
+
+  state.counters["delivered"] = benchmark::Counter(
+    static_cast<double>(total_delivered));
+  state.counters["delivery_pct"] = benchmark::Counter(
+    100.0 * static_cast<double>(total_delivered) /
+    (static_cast<double>(state.iterations()) * batch * fcu_count_ * uas_count_));
+  state.SetItemsProcessed(static_cast<int64_t>(total_delivered));
+}
+
+BENCHMARK_REGISTER_F(BenchmarkRouter, sustained)
+->Arg(20)      // batch per FCU per iteration
+->Unit(benchmark::kMillisecond)
+->MinTime(5);  // ~5 s timed portion per run
+
+}  // namespace router
+}  // namespace mavros
+
+BENCHMARK_MAIN();

--- a/mavros/test/test_router_e2e.cpp
+++ b/mavros/test/test_router_e2e.cpp
@@ -1,0 +1,516 @@
+// mavros
+// Copyright 2026 Vladimir Ermakov, All rights reserved.
+//
+// This file is part of the mavros package and subject to the license terms
+// in the top-level LICENSE file of the mavros repository.
+// https://github.com/mavlink/mavros/tree/master/LICENSE.md
+//
+
+/**
+ * End-to-end router test with real UDP endpoints.
+ *
+ * The routing rules are unit-tested with mocks in test_router.cpp; this test
+ * exercises them over the real MAVConn UDP send/receive path, conversion to
+ * mavros_msgs::msg::Mavlink and intra-process delivery to ROS (UAS) endpoints:
+ *   - gcs_broadcast_reaches_all_fcus: one GCS talks to all FCUs;
+ *   - fcu_broadcast_reaches_gcs: every FCU talks to the GCS;
+ *   - uas_targeted_routing: a PING targeted at a UAS is delivered only to
+ *     that UAS, plus the broadcast, like a real UAS expects;
+ *   - uas_broadcast_reaches_gcs_and_fcus: UAS traffic is routed back to the
+ *     GCS and every FCU.
+ *
+ * Sustained throughput is measured separately by the Google Benchmark
+ * mavros-router-benchmark (see test_router_benchmark.cpp).
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <future>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <asio.hpp>
+
+#include "rclcpp/executors.hpp"
+#include "mavconn/thread_utils.hpp"
+#include "mavros/mavros_router.hpp"
+#include "mavros_msgs/msg/mavlink.hpp"
+
+using namespace std::chrono_literals;  // NOLINT
+using mavconn::utils::format;
+
+namespace mavros
+{
+namespace router
+{
+
+// Base UDP port; override with MAVROS_TEST_UDP_BASE if it collides.
+static int udp_base()
+{
+  if (const char * env = std::getenv("MAVROS_TEST_UDP_BASE")) {
+    return std::atoi(env);
+  }
+  return 15500;
+}
+
+// Port layout: FCU bind/remote, GCS bind/remote
+static int fcu_bind(int f) {return udp_base() + f;}
+static int fcu_remote(int f) {return udp_base() + 100 + f;}
+static int gcs_bind() {return udp_base() + 200;}
+static int gcs_remote() {return udp_base() + 300;}
+
+template<typename M>
+static size_t build_frame(const M & msg, uint8_t sysid, uint8_t compid, uint8_t * wire)
+{
+  mavlink::mavlink_message_t mmsg{};
+  mavlink::MsgMap mmap(mmsg);
+  mmsg.sysid = sysid;
+  mmsg.compid = compid;
+  msg.serialize(mmap);
+  const auto & mi = msg.get_message_info();
+  mavlink::mavlink_status_t status{};
+  mavlink::mavlink_finalize_message_buffer(
+    &mmsg, sysid, compid, &status, mi.min_length, mi.length, mi.crc_extra);
+  return mavlink::mavlink_msg_to_send_buffer(wire, &mmsg);
+}
+
+// Extract the source system id from a MAVLink frame (v1 or v2).
+static uint8_t frame_sysid(const uint8_t * wire)
+{
+  if (wire[0] == 0xFD) {  // MAVLink v2
+    return wire[5];
+  }
+  if (wire[0] == 0xFE) {  // MAVLink v1
+    return wire[3];
+  }
+  return 0;
+}
+
+class E2ERouter : public ::testing::Test
+{
+public:
+  E2ERouter()
+  {
+    exec_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  }
+
+  ~E2ERouter()
+  {
+    // Stop the executor first so nothing can run during teardown.
+    stop_spinner();
+    // Break the Endpoint <-> Router reference cycle, then destroy the
+    // routers (and their DDS participants) before the process exits.
+    for (auto & router : routers_) {
+      router->endpoints.clear();
+    }
+    routers_.clear();
+  }
+
+  // Creates a Router with fcu_count UDP FCU endpoints, gcs_count GCS endpoints
+  // and uas_count UAS (ROSEndpoint) endpoints, configured via parameters.
+  Router::SharedPtr make_router(int fcu_count, int gcs_count, int uas_count)
+  {
+    rclcpp::NodeOptions opts;
+    opts.use_intra_process_comms(true);
+    auto router = std::make_shared<Router>(opts, "e2e_router");
+
+    std::vector<std::string> fcu_urls, gcs_urls, uas_urls;
+    for (int f = 0; f < fcu_count; f++) {
+      fcu_urls.push_back(
+        format("udp://127.0.0.1:%d@127.0.0.1:%d", fcu_bind(f), fcu_remote(f)));
+    }
+    for (int g = 0; g < gcs_count; g++) {
+      (void)g;  // single shared GCS port
+      gcs_urls.push_back(format("udp://127.0.0.1:%d@127.0.0.1:%d", gcs_bind(), gcs_remote()));
+    }
+    for (int u = 0; u < uas_count; u++) {
+      uas_urls.push_back(format("/bench_uas%d", u + 1));
+    }
+
+    router->set_parameters({
+          rclcpp::Parameter("fcu_urls", fcu_urls),
+          rclcpp::Parameter("gcs_urls", gcs_urls),
+          rclcpp::Parameter("uas_urls", uas_urls),
+    });
+
+    exec_->add_node(router);
+    routers_.push_back(router);
+    return router;
+  }
+
+  void start_spinner(const Router::SharedPtr & router, size_t expected_endpoints)
+  {
+    if (spinning_) {
+      return;
+    }
+    spinning_ = true;
+    exit_promise_ = std::make_shared<std::promise<void>>();
+    exit_future_ = exit_promise_->get_future().share();
+    spin_thread_ = std::thread([this]() {
+      exec_->spin_until_future_complete(exit_future_, 100ms);
+    });
+    // wait for the startup_delay_timer to create all endpoints
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (get_endpoints(router).size() < expected_endpoints &&
+      std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  void stop_spinner()
+  {
+    if (!spinning_) {
+      return;
+    }
+    exit_promise_->set_value();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    spinning_ = false;
+  }
+
+  // UDP socket bound to the router's remote port, sending to the router's bind port.
+  asio::ip::udp::socket make_sender(int local_port, int remote_port)
+  {
+    asio::ip::udp::socket s(io_);
+    s.open(asio::ip::udp::v4());
+    s.set_option(asio::ip::udp::socket::reuse_address(true));
+    s.bind(
+      asio::ip::udp::endpoint(
+        asio::ip::make_address("127.0.0.1"), local_port));
+    s.connect(
+      asio::ip::udp::endpoint(
+        asio::ip::make_address("127.0.0.1"), remote_port));
+    return s;
+  }
+
+  // Drains datagrams queued on a socket, incrementing count per message and
+  // optionally collecting the distinct source system ids seen.
+  void drain(
+    asio::ip::udp::socket & s, size_t & count,
+    std::set<uint8_t> * sysids = nullptr)
+  {
+    while (s.available() > 0) {
+      uint8_t buf[512];
+      s.receive(asio::buffer(buf));
+      count++;
+      if (sysids) {
+        sysids->insert(frame_sysid(buf));
+      }
+    }
+  }
+
+  std::shared_ptr<std::atomic<size_t>> subscribe_uas(
+    const Router::SharedPtr & router, int u,
+    std::vector<rclcpp::Subscription<mavros_msgs::msg::Mavlink>::SharedPtr> & subs)
+  {
+    auto counter = std::make_shared<std::atomic<size_t>>(0);
+    subs.push_back(
+      router->create_subscription<mavros_msgs::msg::Mavlink>(
+        format("/bench_uas%d/mavlink_source", u + 1), rclcpp::QoS(1000).best_effort(),
+        [counter](const mavros_msgs::msg::Mavlink::SharedPtr) {(*counter)++;}));
+    return counter;
+  }
+
+  // Publishes a message "from" a UAS so the router learns the UAS's address.
+  // The publisher is kept in pubs so the test can send more messages later.
+  void teach_uas_address(
+    const Router::SharedPtr & router, int u, uint8_t sysid,
+    std::vector<rclcpp::Publisher<mavros_msgs::msg::Mavlink>::SharedPtr> & pubs)
+  {
+    pubs.push_back(
+      router->create_publisher<mavros_msgs::msg::Mavlink>(
+        format("/bench_uas%d/mavlink_sink", u + 1), rclcpp::QoS(1000).best_effort()));
+
+    mavros_msgs::msg::Mavlink rmsg{};
+    rmsg.header.stamp.sec = 1;
+    rmsg.sysid = sysid;
+    rmsg.compid = 1;
+    rmsg.msgid = 0;  // HEARTBEAT
+    pubs.back()->publish(rmsg);
+  }
+
+  // Waits until every UAS endpoint has learned the taught address
+  // (sysid << 8 | compid, stored in remote_addrs on a mavlink_sink message).
+  void wait_learned(const Router::SharedPtr & router, const std::set<addr_t> & taught)
+  {
+    auto learned_state = [&]() {
+        size_t n = 0;
+        std::set<addr_t> addrs;
+        for (const auto & [id, ep] : get_endpoints(router)) {
+          if (ep->link_type != Endpoint::Type::uas) {
+            continue;
+          }
+          for (addr_t a : taught) {
+            if (ep->remote_addrs.find(a) != ep->remote_addrs.end()) {
+              addrs.insert(a);
+              n++;
+              break;
+            }
+          }
+        }
+        return std::pair<size_t, size_t>{n, addrs.size()};
+      };
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (learned_state().first < taught.size() &&
+      std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+protected:
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> exec_;
+  std::thread spin_thread_;
+  std::shared_ptr<std::promise<void>> exit_promise_;
+  std::shared_future<void> exit_future_;
+  bool spinning_{false};
+  asio::io_context io_;
+  std::vector<Router::SharedPtr> routers_;
+
+  // Helper so the gtest-derived classes can access the Router's endpoints.
+  std::unordered_map<id_t, Endpoint::SharedPtr> & get_endpoints(
+    const Router::SharedPtr & router) const
+  {
+    return router->endpoints;
+  }
+};
+
+// One GCS talks to all FCUs: a GCS broadcast must be delivered to every FCU
+// endpoint, so a single GCS can command all autopilots.
+TEST_F(E2ERouter, gcs_broadcast_reaches_all_fcus)
+{
+  constexpr int FCU_COUNT = 3;
+  constexpr int UAS_COUNT = 4;
+  constexpr int BROADCASTS = 10;
+
+  auto router = make_router(FCU_COUNT, 1, UAS_COUNT);
+  start_spinner(router, FCU_COUNT + 1 + UAS_COUNT);
+
+  std::vector<asio::ip::udp::socket> fcus;
+  for (int f = 0; f < FCU_COUNT; f++) {
+    fcus.push_back(make_sender(fcu_remote(f), fcu_bind(f)));
+  }
+  auto gcs = make_sender(gcs_remote(), gcs_bind());
+
+  mavlink::minimal::msg::HEARTBEAT hb{};
+  hb.type = 2;
+  hb.autopilot = 3;
+  hb.base_mode = 80;
+  hb.system_status = 2;
+  uint8_t wire[512];
+  auto len = build_frame(hb, 255, 190, wire);
+  for (int i = 0; i < BROADCASTS; i++) {
+    gcs.send(asio::buffer(wire, len));
+  }
+
+  std::vector<size_t> fcu_rx(FCU_COUNT, 0);
+  const auto deadline = std::chrono::steady_clock::now() + 10s;
+  size_t total = 0;
+  while (total < FCU_COUNT * BROADCASTS && std::chrono::steady_clock::now() < deadline) {
+    total = 0;
+    for (int f = 0; f < FCU_COUNT; f++) {
+      drain(fcus[f], fcu_rx[f]);
+      total += fcu_rx[f];
+    }
+    if (total < FCU_COUNT * BROADCASTS) {
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  for (int f = 0; f < FCU_COUNT; f++) {
+    EXPECT_EQ(fcu_rx[f], BROADCASTS) << "FCU" << f + 1;
+  }
+  stop_spinner();
+}
+
+// Every FCU talks to the GCS: broadcasts from each FCU must all be delivered
+// to the single GCS, so a ground station sees all autopilots.
+TEST_F(E2ERouter, fcu_broadcast_reaches_gcs)
+{
+  constexpr int FCU_COUNT = 3;
+  constexpr int UAS_COUNT = 4;
+  constexpr int PER_FCU = 10;
+
+  auto router = make_router(FCU_COUNT, 1, UAS_COUNT);
+  start_spinner(router, FCU_COUNT + 1 + UAS_COUNT);
+
+  std::vector<asio::ip::udp::socket> fcus;
+  for (int f = 0; f < FCU_COUNT; f++) {
+    fcus.push_back(make_sender(fcu_remote(f), fcu_bind(f)));
+  }
+  auto gcs = make_sender(gcs_remote(), gcs_bind());
+
+  mavlink::minimal::msg::HEARTBEAT hb{};
+  hb.type = 2;
+  hb.autopilot = 3;
+  hb.base_mode = 80;
+  hb.system_status = 2;
+  for (int f = 0; f < FCU_COUNT; f++) {
+    uint8_t wire[512];
+    auto len = build_frame(hb, f + 1, 1, wire);  // distinct sysid per FCU
+    for (int i = 0; i < PER_FCU; i++) {
+      fcus[f].send(asio::buffer(wire, len));
+    }
+  }
+
+  size_t gcs_rx = 0;
+  std::set<uint8_t> sysids;
+  const auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (gcs_rx < FCU_COUNT * PER_FCU && std::chrono::steady_clock::now() < deadline) {
+    drain(gcs, gcs_rx, &sysids);
+    if (gcs_rx < FCU_COUNT * PER_FCU) {
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  EXPECT_EQ(gcs_rx, FCU_COUNT * PER_FCU);
+  EXPECT_EQ(sysids, (std::set<uint8_t>{1, 2, 3})) << "GCS should hear every FCU";
+  stop_spinner();
+}
+
+// Targeted routing: each UAS learns its address, then an FCU sends a targeted
+// PING to each UAS plus one broadcast. Each UAS must receive exactly its own
+// PING and the broadcast, and none of the others'.
+TEST_F(E2ERouter, uas_targeted_routing)
+{
+  constexpr int UAS_COUNT = 4;
+  auto router = make_router(1, 0, UAS_COUNT);
+  start_spinner(router, 1 + UAS_COUNT);
+
+  std::vector<rclcpp::Subscription<mavros_msgs::msg::Mavlink>::SharedPtr> subs;
+  std::vector<std::shared_ptr<std::atomic<size_t>>> counters;
+  for (int u = 0; u < UAS_COUNT; u++) {
+    counters.push_back(subscribe_uas(router, u, subs));
+  }
+
+  std::vector<rclcpp::Publisher<mavros_msgs::msg::Mavlink>::SharedPtr> pubs;
+  std::set<addr_t> taught;
+  for (int u = 0; u < UAS_COUNT; u++) {
+    teach_uas_address(router, u, (u + 1) * 10, pubs);
+    taught.insert((static_cast<addr_t>((u + 1) * 10) << 8) | 1);
+  }
+
+  wait_learned(router, taught);
+
+  for (int u = 0; u < UAS_COUNT; u++) {
+    counters[u]->store(0);
+  }
+
+  auto fcu = make_sender(fcu_remote(0), fcu_bind(0));
+  for (int u = 0; u < UAS_COUNT; u++) {
+    mavlink::common::msg::PING ping{};
+    ping.time_usec = 1000 + u;
+    ping.seq = static_cast<uint32_t>(u);
+    ping.target_system = static_cast<uint8_t>((u + 1) * 10);
+    ping.target_component = 1;
+    uint8_t wire[512];
+    auto len = build_frame(ping, 1, 1, wire);
+    fcu.send(asio::buffer(wire, len));
+  }
+  mavlink::common::msg::PING bping{};
+  bping.time_usec = 9999;
+  bping.seq = 99;
+  bping.target_system = 0;
+  bping.target_component = 0;
+  uint8_t bwire[512];
+  auto blen = build_frame(bping, 1, 1, bwire);
+  fcu.send(asio::buffer(bwire, blen));
+
+  // Wait until each UAS received its targeted PING + the broadcast.
+  const auto rcvd_deadline = std::chrono::steady_clock::now() + 10s;
+  bool all_two = false;
+  while (!all_two && std::chrono::steady_clock::now() < rcvd_deadline) {
+    all_two = true;
+    for (int u = 0; u < UAS_COUNT; u++) {
+      if (counters[u]->load() < 2U) {
+        all_two = false;
+        break;
+      }
+    }
+    if (!all_two) {
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+  for (int u = 0; u < UAS_COUNT; u++) {
+    EXPECT_EQ(counters[u]->load(), 2U) << "UAS" << u + 1;
+  }
+
+  stop_spinner();
+}
+
+// UAS traffic is routed back to the wire: a broadcast from each UAS must reach
+// the GCS and every FCU endpoint.
+TEST_F(E2ERouter, uas_broadcast_reaches_gcs_and_fcus)
+{
+  constexpr int FCU_COUNT = 3;
+  constexpr int UAS_COUNT = 4;
+
+  auto router = make_router(FCU_COUNT, 1, UAS_COUNT);
+  start_spinner(router, FCU_COUNT + 1 + UAS_COUNT);
+
+  std::vector<asio::ip::udp::socket> fcus;
+  for (int f = 0; f < FCU_COUNT; f++) {
+    fcus.push_back(make_sender(fcu_remote(f), fcu_bind(f)));
+  }
+  auto gcs = make_sender(gcs_remote(), gcs_bind());
+
+  std::vector<rclcpp::Subscription<mavros_msgs::msg::Mavlink>::SharedPtr> subs;
+  std::vector<std::shared_ptr<std::atomic<size_t>>> counters;
+  std::vector<rclcpp::Publisher<mavros_msgs::msg::Mavlink>::SharedPtr> pubs;
+  for (int u = 0; u < UAS_COUNT; u++) {
+    counters.push_back(subscribe_uas(router, u, subs));
+    pubs.push_back(
+      router->create_publisher<mavros_msgs::msg::Mavlink>(
+        format("/bench_uas%d/mavlink_sink", u + 1), rclcpp::QoS(1000).best_effort()));
+    mavros_msgs::msg::Mavlink rmsg{};
+    rmsg.header.stamp.sec = 2;
+    rmsg.sysid = static_cast<uint8_t>((u + 1) * 10);
+    rmsg.compid = 1;
+    rmsg.msgid = 0;  // HEARTBEAT
+    pubs.back()->publish(rmsg);
+  }
+
+  size_t gcs_rx = 0;
+  std::vector<size_t> fcu_rx(FCU_COUNT, 0);
+  const auto deadline = std::chrono::steady_clock::now() + 10s;
+  size_t total = 0;
+  while (total < UAS_COUNT * (FCU_COUNT + 1) && std::chrono::steady_clock::now() < deadline) {
+    drain(gcs, gcs_rx);
+    total = gcs_rx;
+    for (int f = 0; f < FCU_COUNT; f++) {
+      drain(fcus[f], fcu_rx[f]);
+      total += fcu_rx[f];
+    }
+    if (total < UAS_COUNT * (FCU_COUNT + 1)) {
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  EXPECT_EQ(gcs_rx, UAS_COUNT) << "GCS should hear every UAS";
+  for (int f = 0; f < FCU_COUNT; f++) {
+    EXPECT_EQ(fcu_rx[f], UAS_COUNT) << "FCU" << f + 1;
+  }
+  stop_spinner();
+}
+
+}  // namespace router
+}  // namespace mavros
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int rc = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return rc;
+}

--- a/mavros/test/test_router_e2e.cpp
+++ b/mavros/test/test_router_e2e.cpp
@@ -155,7 +155,7 @@ public:
     exit_promise_ = std::make_shared<std::promise<void>>();
     exit_future_ = exit_promise_->get_future().share();
     spin_thread_ = std::thread([this]() {
-      exec_->spin_until_future_complete(exit_future_, 100ms);
+          exec_->spin_until_future_complete(exit_future_, 100ms);
     });
     // wait for the startup_delay_timer to create all endpoints
     const auto deadline = std::chrono::steady_clock::now() + 10s;


### PR DESCRIPTION
Reduce copy overhead in the mavros router hot path and add real-UDP
e2e + throughput coverage.

This series:

1. `mavros: zero-copy publish, memoize endpoint frame_id`
   - `ROSEndpoint::send_message()` and `UAS::send_message()` publish via
     `unique_ptr`, so intra-process subscribers get the buffer without a copy.
   - The router memoizes `"ep:<id>"` once in `Endpoint::set_id()` and threads
     the frame_id string through `send_message()` instead of formatting it per
     message. `Endpoint::send_message()` signature changes accordingly
     (`test_router.cpp` mock updated).

2. `uas: default UAS executor threads to clamp(2, 4)`
   - The plugin executor only runs a handful of subscription callbacks per UAS;
     one thread per core (up to 16) is wasteful with several UAS nodes.
     `MAVROS_UAS_EXECUTOR_THREADS` still overrides the default.

3. `tests: add router e2e and benchmark suites`
   - Real-UDP e2e test (`test_router_e2e.cpp`) over the mock-covered rules:
     one GCS talks to all FCUs, every FCU reaches the GCS, targeted UAS
     routing, and UAS broadcast back to GCS + FCUs.
   - Google Benchmark (`test_router_benchmark.cpp`) measures sustained
     throughput, gated by the CMake option `AMENT_RUN_PERFORMANCE_TESTS`.
     Uses plain asio (matching libmavconn) instead of Boost.Asio, which
     collide on humble; `ament_cmake_google_benchmark` is now REQUIRED.

4. `ci: run router benchmark, make ccache best-effort`
   - `AMENT_RUN_PERFORMANCE_TESTS` is a CMake configure-time option, so the
     env var was a no-op; pass it via `CMAKE_ARGS` so the ~10 s benchmark runs
     per distro. `actions/cache` steps are now continue-on-error.

5. `ci: add dependabot cooldown`

Results (local, lyrical):
- `mavros-router-benchmark` sustained: ~67k msg/s, delivery_pct=100
- `mavros-router-test`, `mavros-router-e2e`, `mavros-router-benchmark` pass;
  full package suite green (290 tests, 0 failures)