### PR TITLE
libmavconn: fix serial baudrate parsing above uint16

### DIFF
--- a/libmavconn/src/interface.cpp
+++ b/libmavconn/src/interface.cpp
@@ -294,12 +294,14 @@ void MAVConnInterface::set_accept_unsigned_callback(mavlink::mavlink_accept_unsi
 static void url_parse_host(
   const std::string & host,
   std::string & host_out, int & port_out,
-  const std::string & def_host, const int def_port)
+  const std::string & def_host, const int def_port,
+  const char * value_name = "port", const int max_value =
+  std::numeric_limits<uint16_t>::max())
 {
-  auto parse_int_in_range = [](const std::string & value, int min, int max, const char * field) {
+  auto parse_int_in_range = [value_name](const std::string & value, int min, int max) {
       size_t pos = 0;
       int parsed = 0;
-      const std::string err = std::string("invalid ") + field + " value: '" + value + "'";
+      const std::string err = std::string("invalid ") + value_name + " value: '" + value + "'";
       try {
         parsed = std::stoi(value, &pos);
       } catch (const std::exception &) {
@@ -337,7 +339,7 @@ static void url_parse_host(
   }
 
   port.assign(sep_it + 1, host.end());
-  port_out = parse_int_in_range(port, 1, std::numeric_limits<uint16_t>::max(), "port");
+  port_out = parse_int_in_range(port, 1, max_value);
 }
 
 /**
@@ -403,7 +405,7 @@ static MAVConnInterface::Ptr url_parse_serial(
   // /dev/ttyACM0:57600
   url_parse_host(
     path, file_path, baudrate, MAVConnSerial::DEFAULT_DEVICE,
-    MAVConnSerial::DEFAULT_BAUDRATE);
+    MAVConnSerial::DEFAULT_BAUDRATE, "baudrate", std::numeric_limits<int>::max());
   url_parse_query(query, system_id, component_id);
 
   return std::make_shared<MAVConnSerial>(

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -540,6 +540,38 @@ TEST(URL, open_url_serial)
 }
 #endif
 
+TEST(URL, open_url_serial_baudrate)
+{
+  // regression test for #2265: baudrate must not be limited to uint16.
+  // A parse error is reported as "DeviceError:url:..." while a device open
+  // failure (device path missing) is reported as "DeviceError:serial:...".
+  {
+    // Valid baudrate above uint16 max must pass parsing (reach device open).
+    try {
+      MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:921600");
+      ADD_FAILURE() << "expected DeviceError from device open";
+    } catch (const DeviceError & e) {
+      const std::string msg = e.what();
+      EXPECT_NE(msg.find("DeviceError:serial:"), std::string::npos)
+        << "valid high baudrate rejected during parsing: " << msg;
+    }
+  }
+
+  // Zero baudrate must be rejected by the parser.
+  EXPECT_THROW(
+  {
+    MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:0");
+  },
+    DeviceError);
+
+  // Non-numeric baudrate must be rejected by the parser.
+  EXPECT_THROW(
+  {
+    MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:abc");
+  },
+    DeviceError);
+}
+
 TEST(URL, open_url_udp)
 {
   MAVConnInterface::Ptr udp;
@@ -639,6 +671,12 @@ TEST(URL, open_url_tcp)
   EXPECT_THROW(
   {
     tcp_client = MAVConnInterface::open_url("tcp://localhost:abc");
+  },
+    DeviceError);
+
+  EXPECT_THROW(
+  {
+    tcp_client = MAVConnInterface::open_url("tcp://localhost:65536");
   },
     DeviceError);
 }


### PR DESCRIPTION
url_parse_host hardcoded a uint16 port limit and error label, which rejected serial baudrates above 65535 (e.g. 921600) with a misleading 'invalid port value' error. Make the value range and field name configurable and allow baudrate to use the full int range.

Adds a regression test covering a high valid baudrate and invalid zero/non-numeric baudrates.

Fix #2265