### PR TITLE
mavros: fix duplicated namespace in launch files

### DIFF
--- a/mavros/launch/apm.launch
+++ b/mavros/launch/apm.launch
@@ -9,7 +9,7 @@
 	<arg name="log_output" default="screen" />
 	<arg name="fcu_protocol" default="v2.0" />
 	<arg name="respawn_mavros" default="false" />
-	<arg name="namespace" default="mavros"/>
+	<arg name="namespace" default=""/>
 
 	<include file="$(find-pkg-share mavros)/launch/node.launch">
 		<arg name="pluginlists_yaml" value="$(find-pkg-share mavros)/launch/apm_pluginlists.yaml" />

--- a/mavros/launch/apm_with_terrain.launch
+++ b/mavros/launch/apm_with_terrain.launch
@@ -9,7 +9,7 @@
 	<arg name="log_output" default="screen" />
 	<arg name="fcu_protocol" default="v2.0" />
 	<arg name="respawn_mavros" default="false" />
-	<arg name="namespace" default="mavros"/>
+	<arg name="namespace" default=""/>
 
 	<!-- Terrain server parameters -->
 	<arg name="terrain_data_path" default="" />

--- a/mavros/launch/node.launch
+++ b/mavros/launch/node.launch
@@ -11,7 +11,7 @@
 	<arg name="log_output" default="screen" />
 	<arg name="fcu_protocol" default="v2.0" />
 	<arg name="respawn_mavros" default="false" />
-	<arg name="namespace" default="mavros"/>
+	<arg name="namespace" default=""/>
 
 	<node pkg="mavros" exec="mavros_node" namespace="$(var namespace)" output="screen">
 		<param name="fcu_url" value="$(var fcu_url)" />

--- a/mavros/launch/px4.launch
+++ b/mavros/launch/px4.launch
@@ -6,7 +6,7 @@
 	<arg name="log_output" default="screen" />
 	<arg name="fcu_protocol" default="v2.0" />
 	<arg name="respawn_mavros" default="false" />
-	<arg name="namespace" default="mavros"/>
+	<arg name="namespace" default=""/>
 
 	<include file="$(find-pkg-share mavros)/launch/node.launch">
 		<arg name="pluginlists_yaml" value="$(find-pkg-share mavros)/launch/px4_pluginlists.yaml" />


### PR DESCRIPTION
Fix #2262 by defaulting the launch namespace to empty, since plugin subnodes now properly inherit the UAS namespace.