### PR TITLE
Add missing test_depend on ament_cmake_google_benchmark to libmavconn

### DIFF
--- a/libmavconn/package.xml
+++ b/libmavconn/package.xml
@@ -30,6 +30,7 @@
   <depend>libconsole-bridge-dev</depend>
   <build_depend>python3-empy</build_depend>
 
+  <test_depend>ament_cmake_google_benchmark</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
It's used in tests since #2256, but it wasn't declared as a (test) dependency, resulting in build failures on the ROS 2 buildfarm: https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__libmavconn__ubuntu_jammy_amd64__binary/160/console

```
23:58:37 CMake Error at CMakeLists.txt:117 (find_package):
23:58:37   By not providing "Findament_cmake_google_benchmark.cmake" in
23:58:37   CMAKE_MODULE_PATH this project has asked CMake to find a package
23:58:37   configuration file provided by "ament_cmake_google_benchmark", but CMake
23:58:37   did not find one.
23:58:37
23:58:37   Could not find a package configuration file provided by
23:58:37   "ament_cmake_google_benchmark" with any of the following names:
23:58:37
23:58:37     ament_cmake_google_benchmarkConfig.cmake
23:58:37     ament_cmake_google_benchmark-config.cmake
```