### PR TITLE
plugins: fix cmd/command service deadlocks and const shared_ptr deprecation warnings

### DIFF
--- a/docs/plugins/extras/gimbal_control.md
+++ b/docs/plugins/extras/gimbal_control.md
@@ -30,7 +30,7 @@ Also publishes gimbal pose to TF when parameter tf_send==true
 - `~/manager/camera_track` [type: [mavros_msgs::srv::GimbalManagerCameraTrack](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/GimbalManagerCameraTrack.html)] - --Not successfully validated-- Control gimbal camera tracking (MAV_CMD_CAMERA_TRACK_*).
 
 ## Clients
-- `cmd/command` [type: [mavros_msgs::srv::CommandLong](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/CommandLong.html), qos: ] - Client to send MAVLink commands (mavros/cmd/command).
+- `cmd/command` [type: [mavros_msgs::srv::CommandLong](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/CommandLong.html), qos: [ServicesQoS](../qos.md#servicesqos "ServicesQoS QoS profile")] - Client to send MAVLink commands (mavros/cmd/command).
 
 
 ## Parameters

--- a/docs/plugins/extras/index.json
+++ b/docs/plugins/extras/index.json
@@ -1866,15 +1866,20 @@
       {
         "name": "~/configure",
         "type_name": "mavros_msgs::srv::MountConfigure",
-        "line": 254,
-        "description": "Configure the mount (MAV_CMD_DO_MOUNT_CONFIGURE)."
+        "line": 262,
+        "description": "Configure the mount (MAV_CMD_DO_MOUNT_CONFIGURE).",
+        "qos": {
+          "kind": "named",
+          "name": "ServicesQoS",
+          "var": "services_qos"
+        }
       }
     ],
     "clients": [
       {
         "name": "cmd/command",
         "type_name": "mavros_msgs::srv::CommandLong",
-        "line": 379
+        "line": 389
       }
     ],
     "parameters": [
@@ -1928,7 +1933,7 @@
         "message_name": "MOUNT_ORIENTATION",
         "msg_id_expr": "mavlink::common::msg::MOUNT_ORIENTATION::MSG_ID",
         "dialect": "common",
-        "line": 289,
+        "line": 299,
         "msg_id": 265
       },
       {
@@ -1937,7 +1942,7 @@
         "message_name": "MOUNT_STATUS",
         "msg_id_expr": "mavlink::ardupilotmega::msg::MOUNT_STATUS::MSG_ID",
         "dialect": "ardupilotmega",
-        "line": 322,
+        "line": 332,
         "msg_id": 158
       }
     ],
@@ -1948,7 +1953,7 @@
         "message_name": "COMMAND_LONG",
         "msg_id_expr": "mavlink::common::msg::COMMAND_LONG::MSG_ID",
         "dialect": "common",
-        "line": 367,
+        "line": 377,
         "msg_id": 76
       }
     ]

--- a/docs/plugins/extras/mount_control.md
+++ b/docs/plugins/extras/mount_control.md
@@ -17,7 +17,7 @@ superseded [MAVLink Gimbal Protocol v1](https://mavlink.io/en/services/gimbal.ht
 - `~/command` [type: [mavros_msgs::msg::MountControl](https://docs.ros.org/en/rolling/p/mavros_msgs/msg/MountControl.html), qos: [QoS(10)](../qos.md#qos_10_)] - Subscribe to MountControl to send as MAV_CMD_DO_MOUNT_CONTROL to the FCU.
 
 ## Services
-- `~/configure` [type: [mavros_msgs::srv::MountConfigure](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/MountConfigure.html)] - Configure the mount (MAV_CMD_DO_MOUNT_CONFIGURE).
+- `~/configure` [type: [mavros_msgs::srv::MountConfigure](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/MountConfigure.html), qos: [ServicesQoS](../qos.md#servicesqos "ServicesQoS QoS profile")] - Configure the mount (MAV_CMD_DO_MOUNT_CONFIGURE).
 
 ## Clients
 - `cmd/command` [type: [mavros_msgs::srv::CommandLong](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/CommandLong.html)]

--- a/docs/plugins/qos.md
+++ b/docs/plugins/qos.md
@@ -71,7 +71,7 @@ See [rclcpp::ServicesQoS](https://docs.ros.org/en/rolling/p/rclcpp/classrclcpp_1
 |---|---|---|---|---|---|---|
 | Keep last | 10 | Reliable | Volatile | Default | Default | System default |
 
-Used by: *std*: [`command`](std/command.md), [`geofence`](std/geofence.md), [`rallypoint`](std/rallypoint.md), [`sys_status`](std/sys_status.md), [`waypoint`](std/waypoint.md)
+Used by: *std*: [`command`](std/command.md), [`geofence`](std/geofence.md), [`home_position`](std/home_position.md), [`rallypoint`](std/rallypoint.md), [`sys_status`](std/sys_status.md), [`waypoint`](std/waypoint.md); *extras*: [`mount_control`](extras/mount_control.md)
 
 
 ### StateQoS {#stateqos}

--- a/docs/plugins/std/home_position.md
+++ b/docs/plugins/std/home_position.md
@@ -15,7 +15,7 @@ Publishes home position.
 - `~/set` [type: [mavros_msgs::msg::HomePosition](https://docs.ros.org/en/rolling/p/mavros_msgs/msg/HomePosition.html), qos: [QoS(10)](../qos.md#qos_10_)] - Set home position (SET_HOME_POSITION).
 
 ## Services
-- `~/req_update` [type: [std_srvs::srv::Trigger](https://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html)] - Request home position update (MAV_CMD_GET_HOME_POSITION).
+- `~/req_update` [type: [std_srvs::srv::Trigger](https://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html), qos: [ServicesQoS](../qos.md#servicesqos "ServicesQoS QoS profile")] - Request home position update (MAV_CMD_GET_HOME_POSITION).
 
 ## Clients
 - `cmd/command` [type: [mavros_msgs::srv::CommandLong](https://docs.ros.org/en/rolling/p/mavros_msgs/srv/CommandLong.html)] - Client to request home position via command (MAV_CMD_GET_HOME_POSITION).

--- a/docs/plugins/std/index.json
+++ b/docs/plugins/std/index.json
@@ -925,7 +925,7 @@
       {
         "name": "~/home",
         "type_name": "mavros_msgs::msg::HomePosition",
-        "line": 54,
+        "line": 62,
         "description": "Publish home position (HOME_POSITION).",
         "qos": {
           "kind": "named",
@@ -938,7 +938,7 @@
       {
         "name": "~/set",
         "type_name": "mavros_msgs::msg::HomePosition",
-        "line": 58,
+        "line": 66,
         "description": "Set home position (SET_HOME_POSITION).",
         "qos": {
           "kind": "inline",
@@ -950,15 +950,20 @@
       {
         "name": "~/req_update",
         "type_name": "std_srvs::srv::Trigger",
-        "line": 63,
-        "description": "Request home position update (MAV_CMD_GET_HOME_POSITION)."
+        "line": 72,
+        "description": "Request home position update (MAV_CMD_GET_HOME_POSITION).",
+        "qos": {
+          "kind": "named",
+          "name": "ServicesQoS",
+          "var": "services_qos"
+        }
       }
     ],
     "clients": [
       {
         "name": "cmd/command",
         "type_name": "mavros_msgs::srv::CommandLong",
-        "line": 99,
+        "line": 112,
         "description": "Client to request home position via command (MAV_CMD_GET_HOME_POSITION)."
       }
     ],
@@ -970,7 +975,7 @@
         "message_name": "HOME_POSITION",
         "msg_id_expr": "mavlink::common::msg::HOME_POSITION::MSG_ID",
         "dialect": "common",
-        "line": 114,
+        "line": 127,
         "msg_id": 242
       }
     ],
@@ -981,7 +986,7 @@
         "message_name": "SET_HOME_POSITION",
         "msg_id_expr": "mavlink::common::msg::SET_HOME_POSITION::MSG_ID",
         "dialect": "common",
-        "line": 189,
+        "line": 202,
         "msg_id": 243
       }
     ]

--- a/libmavconn/test/test_mavconn.cpp
+++ b/libmavconn/test/test_mavconn.cpp
@@ -548,7 +548,8 @@ TEST(URL, open_url_serial_baudrate)
   {
     // Valid baudrate above uint16 max must pass parsing (reach device open).
     try {
-      MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:921600");
+      [[maybe_unused]] auto p =
+        MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:921600");
       ADD_FAILURE() << "expected DeviceError from device open";
     } catch (const DeviceError & e) {
       const std::string msg = e.what();
@@ -560,6 +561,7 @@ TEST(URL, open_url_serial_baudrate)
   // Zero baudrate must be rejected by the parser.
   EXPECT_THROW(
   {
+    [[maybe_unused]] auto p =
     MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:0");
   },
     DeviceError);
@@ -567,6 +569,7 @@ TEST(URL, open_url_serial_baudrate)
   // Non-numeric baudrate must be rejected by the parser.
   EXPECT_THROW(
   {
+    [[maybe_unused]] auto p =
     MAVConnInterface::open_url_no_connect("serial:///non-existent-mavros-test:abc");
   },
     DeviceError);

--- a/mavros/src/plugins/home_position.cpp
+++ b/mavros/src/plugins/home_position.cpp
@@ -50,6 +50,14 @@ public:
   {
     auto state_qos = mavros::StateQoS();
 
+#ifdef USE_OLD_RMW_QOS
+    auto services_qos = rmw_qos_profile_services_default;
+#else
+    auto services_qos = rclcpp::ServicesQoS();
+#endif
+
+    srv_cg = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
     //! Publish home position (HOME_POSITION).
     hp_pub = node->create_publisher<mavros_msgs::msg::HomePosition>(
       "~/home", state_qos, mavros::NonIntraProcessPublisherOptions());
@@ -58,15 +66,18 @@ public:
       node->create_subscription<mavros_msgs::msg::HomePosition>(
       "~/set", 10,
       std::bind(&HomePositionPlugin::home_position_cb, this, _1));
+
     //! Request home position update (MAV_CMD_GET_HOME_POSITION).
     update_srv =
       node->create_service<std_srvs::srv::Trigger>(
       "~/req_update",
-      std::bind(&HomePositionPlugin::req_update_cb, this, _1, _2));
-
+      std::bind(&HomePositionPlugin::req_update_cb, this, _1, _2),
+      services_qos, srv_cg);
 
     poll_timer =
-      node->create_wall_timer(REQUEST_POLL_TIME, std::bind(&HomePositionPlugin::timeout_cb, this));
+      node->create_wall_timer(
+      REQUEST_POLL_TIME, std::bind(&HomePositionPlugin::timeout_cb, this),
+      srv_cg);
     poll_timer->cancel();
 
     enable_connection_cb();
@@ -83,6 +94,8 @@ private:
   rclcpp::Publisher<mavros_msgs::msg::HomePosition>::SharedPtr hp_pub;
   rclcpp::Subscription<mavros_msgs::msg::HomePosition>::SharedPtr hp_sub;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr update_srv;
+
+  rclcpp::CallbackGroup::SharedPtr srv_cg;
 
   rclcpp::TimerBase::SharedPtr poll_timer;
 

--- a/mavros_extras/include/mavros_extras/servo_state_publisher.hpp
+++ b/mavros_extras/include/mavros_extras/servo_state_publisher.hpp
@@ -139,8 +139,8 @@ private:
   std::shared_mutex mutex;
   std::list<ServoDescription> servos;
 
-  void robot_description_cb(const std_msgs::msg::String::SharedPtr msg);
-  void rc_out_cb(const mavros_msgs::msg::RCOut::SharedPtr msg);
+  void robot_description_cb(const std_msgs::msg::String::ConstSharedPtr msg);
+  void rc_out_cb(const mavros_msgs::msg::RCOut::ConstSharedPtr msg);
 };
 
 }   // namespace extras

--- a/mavros_extras/src/lib/servo_state_publisher.cpp
+++ b/mavros_extras/src/lib/servo_state_publisher.cpp
@@ -78,7 +78,7 @@ ServoStatePublisher::ServoStatePublisher(
     this->create_publisher<sensor_msgs::msg::JointState>("joint_states", sensor_qos);
 }
 
-void ServoStatePublisher::robot_description_cb(const std_msgs::msg::String::SharedPtr msg)
+void ServoStatePublisher::robot_description_cb(const std_msgs::msg::String::ConstSharedPtr msg)
 {
   std::unique_lock lock(mutex);
 
@@ -118,7 +118,7 @@ void ServoStatePublisher::robot_description_cb(const std_msgs::msg::String::Shar
   }
 }
 
-void ServoStatePublisher::rc_out_cb(const mavros_msgs::msg::RCOut::SharedPtr msg)
+void ServoStatePublisher::rc_out_cb(const mavros_msgs::msg::RCOut::ConstSharedPtr msg)
 {
   std::shared_lock lock(mutex);
 

--- a/mavros_extras/src/plugins/gimbal_control.cpp
+++ b/mavros_extras/src/plugins/gimbal_control.cpp
@@ -500,7 +500,7 @@ private:
    * @param req	- received GimbalControl msg
    */
   void manager_set_manual_control_cb(
-    const mavros_msgs::msg::GimbalManagerSetPitchyaw::SharedPtr req)
+    const mavros_msgs::msg::GimbalManagerSetPitchyaw::ConstSharedPtr req)
   {
     mavlink::common::msg::GIMBAL_MANAGER_SET_PITCHYAW msg {};
     uas->msg_set_target(msg);

--- a/mavros_extras/src/plugins/mount_control.cpp
+++ b/mavros_extras/src/plugins/mount_control.cpp
@@ -250,11 +250,19 @@ public:
     //! Publish mount status from MAVLink MOUNT_STATUS.
     mount_status_pub = node->create_publisher<geometry_msgs::msg::Vector3Stamped>("~/status", 10);
 
+#ifdef USE_OLD_RMW_QOS
+    auto services_qos = rmw_qos_profile_services_default;
+#else
+    auto services_qos = rclcpp::ServicesQoS();
+#endif
+
+    srv_cg = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
     //! Configure the mount (MAV_CMD_DO_MOUNT_CONFIGURE).
     configure_srv = node->create_service<mavros_msgs::srv::MountConfigure>(
       "~/configure", std::bind(
         &MountControlPlugin::mount_configure_cb,
-        this, _1, _2));
+        this, _1, _2), services_qos, srv_cg);
   }
 
 
@@ -273,6 +281,8 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr mount_status_pub;
 
   rclcpp::Service<mavros_msgs::srv::MountConfigure>::SharedPtr configure_srv;
+
+  rclcpp::CallbackGroup::SharedPtr srv_cg;
 
   MountStatusDiag mount_diag;
   bool negate_measured_roll;

--- a/mavros_extras/src/plugins/play_tune.cpp
+++ b/mavros_extras/src/plugins/play_tune.cpp
@@ -54,7 +54,7 @@ public:
 private:
   rclcpp::Subscription<mavros_msgs::msg::PlayTuneV2>::SharedPtr sub;
 
-  void callback(const mavros_msgs::msg::PlayTuneV2::SharedPtr tune)
+  void callback(const mavros_msgs::msg::PlayTuneV2::ConstSharedPtr tune)
   {
     auto msg = mavlink::common::msg::PLAY_TUNE_V2{};
 

--- a/mavros_extras/src/plugins/tunnel.cpp
+++ b/mavros_extras/src/plugins/tunnel.cpp
@@ -63,7 +63,7 @@ private:
   rclcpp::Subscription<mavros_msgs::msg::Tunnel>::SharedPtr sub_;
   rclcpp::Publisher<mavros_msgs::msg::Tunnel>::SharedPtr pub_;
 
-  void ros_callback(const mavros_msgs::msg::Tunnel::SharedPtr ros_tunnel)
+  void ros_callback(const mavros_msgs::msg::Tunnel::ConstSharedPtr ros_tunnel)
   {
     try {
       const auto mav_tunnel =


### PR DESCRIPTION
## Summary

Set of fixes accumulated on the `check-cbg` branch:

1. **Fix service deadlocks** in `home_position` (#2285) and `mount_control` (#2286) — bind each plugin's own service/timer to a dedicated `MutuallyExclusive` callback group so the sync `cmd/command` client response (in the default group) can be scheduled while the caller blocks on `future.get()`.
2. **Fix `-Wunused-result`** warnings in the libmavconn serial baudrate test by consuming the `[[nodiscard]]` return value.
3. **Fix `-Wdeprecated-declarations`** warnings from rclcpp's non-const `shared_ptr` subscription callbacks by converting to `ConstSharedPtr`.
4. Regenerate plugin docs after the callback-group/QoS changes.

## Commits

- `extras: run mount configure in a dedicated callback group (fix #2286)`
- `mavros: run home position callbacks in a dedicated group (fix #2285)`
- `libmavconn: consume nodiscard result in baudrate test`
- `extras: use const shared_ptr in gimbal manual control callback`
- `extras: use const shared_ptr in play_tune callback`
- `extras: use const shared_ptr in tunnel callback`
- `extras: use const shared_ptr in servo_state_publisher callbacks`
- `docs: regenerate plugin docs after QoS callback-group changes`

## Verification

Built and tested in a `ros2-lyrical` container:
- clean builds of `mavros`, `mavros_extras`, `libmavconn` with no new warnings
- `colcon test`: 590 tests, 0 errors, 0 failures
- `ament_uncrustify`: no style divergence

Fixes #2285, Fixes #2286.